### PR TITLE
docs(navigation): update edge worker link in astro config

### DIFF
--- a/pkgs/website/astro.config.mjs
+++ b/pkgs/website/astro.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
           {
             label: 'Edge Worker',
             icon: 'open-book',
-            link: '/edge-worker/',
+            link: '/edge-worker/how-it-works',
             items: [
               { label: 'How it works?', link: '/edge-worker/how-it-works' },
               {


### PR DESCRIPTION
Update navigation link for edge worker section to point directly to how-it-works page
