### PR TITLE
Fix spawnNewFunction missing ANON_KEY

### DIFF
--- a/pkgs/edge-worker/deno.json
+++ b/pkgs/edge-worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@pgflow/edge-worker",
-  "version": "0.0.3-spawnfix",
+  "version": "0.0.4",
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {

--- a/pkgs/edge-worker/deno.json
+++ b/pkgs/edge-worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@pgflow/edge-worker",
-  "version": "0.0.3",
+  "version": "0.0.3-spawnfix",
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -122,7 +122,7 @@
       "options": {
         "cwd": "pkgs/edge-worker",
         "commands": [
-          "pnpm dlx jsr publish"
+          "pnpm dlx jsr publish --allow-slow-types"
         ],
         "parallel": false
       }

--- a/pkgs/edge-worker/src/spawnNewEdgeFunction.ts
+++ b/pkgs/edge-worker/src/spawnNewEdgeFunction.ts
@@ -2,6 +2,7 @@ import { getLogger } from './Logger.ts';
 
 // @ts-ignore - TODO: fix the types
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') as string;
+const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY') as string;
 
 const logger = getLogger('spawnNewEdgeFunction');
 
@@ -17,7 +18,7 @@ export default async function spawnNewEdgeFunction(
   const response = await fetch(`${SUPABASE_URL}/functions/v1/${functionName}`, {
     method: 'POST',
     headers: {
-      // Authorization: `Bearer ${supabaseAnonKey}`,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
       'Content-Type': 'application/json',
     },
     // body: JSON.stringify(body),


### PR DESCRIPTION
In 0.0.3, I accidentally commented out the Auth header when releasing 0.0.3, which makes using Edge Worker on production impossible.

This version includes the Auth header back so function can properly respawn in production environment