### PR TITLE
chore(changeset): add version bump trigger for dummy-pkg

### DIFF
--- a/.changeset/small-places-wait.md
+++ b/.changeset/small-places-wait.md
@@ -1,0 +1,5 @@
+---
+'@pgflow/dummy-pkg': minor
+---
+
+trigger another bump in dummy-pkg


### PR DESCRIPTION
Rationale:
- The diff shows the creation of a new changeset markdown file
- The file appears to be triggering a minor version bump for '@pgflow/dummy-pkg'
- This is a build/version management task, so 'chore' is the most appropriate type
- The scope is '(changeset)' to indicate it's related to version management
- The description succinctly captures the purpose of the new file
