### PR TITLE
Move Edge Worker migrations to SQL Core

### DIFF
--- a/pkgs/core/supabase/migrations/000_edge_worker_initial.sql
+++ b/pkgs/core/supabase/migrations/000_edge_worker_initial.sql
@@ -84,4 +84,3 @@ BEGIN
     END LOOP;
 END;
 $$ language plpgsql;
-

--- a/pkgs/core/supabase/migrations/000_edge_worker_initial.sql
+++ b/pkgs/core/supabase/migrations/000_edge_worker_initial.sql
@@ -6,12 +6,12 @@ create schema if not exists edge_worker;
 -- Workers Table --------------------------------------------------------------
 -------------------------------------------------------------------------------
 create table if not exists edge_worker.workers (
-    worker_id UUID not null primary key,
-    queue_name TEXT not null,
-    function_name TEXT not null,
-    started_at TIMESTAMPTZ not null default now(),
-    stopped_at TIMESTAMPTZ,
-    last_heartbeat_at TIMESTAMPTZ not null default now()
+  worker_id uuid not null primary key,
+  queue_name text not null,
+  function_name text not null,
+  started_at timestamptz not null default now(),
+  stopped_at timestamptz,
+  last_heartbeat_at timestamptz not null default now()
 );
 
 --------------------------------------------------------------------------------
@@ -26,19 +26,19 @@ create table if not exists edge_worker.workers (
 -- This will be removed once Supabase upgrades to 1.5.0 or higher.            --
 --------------------------------------------------------------------------------
 create function edge_worker.read_with_poll(
-    queue_name TEXT,
-    vt INTEGER,
-    qty INTEGER,
-    max_poll_seconds INTEGER default 5,
-    poll_interval_ms INTEGER default 100,
-    conditional JSONB default '{}'
+  queue_name text,
+  vt integer,
+  qty integer,
+  max_poll_seconds integer default 5,
+  poll_interval_ms integer default 100,
+  conditional jsonb default '{}'
 )
 returns setof pgmq.message_record as $$
 DECLARE
     r pgmq.message_record;
-    stop_at TIMESTAMP;
-    sql TEXT;
-    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+    stop_at timestamp;
+    sql text;
+    qtable text := pgmq.format_table_name(queue_name, 'q');
 BEGIN
     stop_at := clock_timestamp() + make_interval(secs => max_poll_seconds);
     LOOP
@@ -84,3 +84,4 @@ BEGIN
     END LOOP;
 END;
 $$ language plpgsql;
+

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -60,7 +60,6 @@
         "cwd": "pkgs/edge-worker",
         "commands": [
           "rm -f supabase/migrations/*.sql",
-          "cp migrations/*.sql supabase/migrations/",
           "cp ../core/supabase/migrations/*.sql supabase/migrations/",
           "cp sql/*_*.sql supabase/migrations/",
           "supabase db reset"

--- a/pkgs/edge-worker/scripts/concatenate-migrations.sh
+++ b/pkgs/edge-worker/scripts/concatenate-migrations.sh
@@ -7,14 +7,6 @@ echo "-- Combined migrations file" > "$target_file"
 echo "-- Generated on $(date)" >> "$target_file"
 echo "" >> "$target_file"
 
-# Find all .sql files, sort them alphabetically, and concatenate
-for f in $(find ./migrations -name '*.sql' | sort); do
-  echo "-- From file: $(basename $f)" >> "$target_file"
-  cat "$f" >> "$target_file"
-  echo "" >> "$target_file"
-  echo "" >> "$target_file"
-done
-
 # Also add core migrations
 for f in $(find ../core/supabase/migrations -name '*.sql' | sort); do
   echo "-- From file: $(basename $f)" >> "$target_file"
@@ -23,7 +15,7 @@ for f in $(find ../core/supabase/migrations -name '*.sql' | sort); do
   echo "" >> "$target_file"
 done
 
-# And copy the pgflow_tests 
+# And copy the pgflow_tests
 echo "-- From file: seed.sql" >> "$target_file"
 cat "../core/supabase/seed.sql" >> "$target_file"
 echo "" >> "$target_file"

--- a/pkgs/website/src/content/docs/edge-worker/getting-started/install-edge-worker.mdx
+++ b/pkgs/website/src/content/docs/edge-worker/getting-started/install-edge-worker.mdx
@@ -29,7 +29,7 @@ If you haven't installed the CLI yet or need to upgrade, see Supabase's [install
 
     ```bash frame="none"
     wget -P supabase/migrations \
-        https://raw.githubusercontent.com/pgflow-dev/pgflow/refs/heads/main/pkgs/edge-worker/migrations/000_edge_worker_initial.sql
+        https://raw.githubusercontent.com/pgflow-dev/pgflow/refs/heads/main/pkgs/core/supabase/migrations/000_edge_worker_initial.sql
     ```
 
     Then apply the migration:


### PR DESCRIPTION
This makes keeping track of all the SQL code simpler and distributing the sql migrations simpler too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined internal migration processes and improved consistency in database schema management.
  - Removed redundant commands and file handling steps to simplify maintenance.
  - Eliminated the concatenation of local migration files in the build process.

- **Documentation**
  - Updated installation instructions to reflect the new source location for migration resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->