### PR TITLE
docs(edge-worker): add guide for handling special characters in database connection URLs

### DIFF
--- a/pkgs/website/src/content/docs/edge-worker/getting-started/install-edge-worker.mdx
+++ b/pkgs/website/src/content/docs/edge-worker/getting-started/install-edge-worker.mdx
@@ -50,6 +50,10 @@ If you haven't installed the CLI yet or need to upgrade, see Supabase's [install
     EDGE_WORKER_DB_URL="postgresql://postgres.pooler-dev:postgres@pooler:6543/postgres"
     ```
 
+    :::caution[Special Characters in Passwords]
+    If your database password contains special characters (`@`, `&`, `:`, etc.), you must URL-encode them to avoid authentication errors. See our [DB Connection URLs](/edge-worker/how-to/prepare-db-string/) guide for detailed instructions.
+    :::
+
 1. ### Setup Connection Pool
 
     Modify the `db.pooler` section in your `supabase/config.toml` file

--- a/pkgs/website/src/content/docs/edge-worker/how-to/prepare-db-string.mdx
+++ b/pkgs/website/src/content/docs/edge-worker/how-to/prepare-db-string.mdx
@@ -1,0 +1,90 @@
+---
+title: Prepare DB Connection URL
+description: How to handle special characters in passwords for Edge Worker connection strings
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+When setting up Edge Worker with a database password containing special characters, you must URL-encode these characters to avoid authentication errors like:
+
+```
+Error: SASL_SIGNATURE_MISMATCH: The server did not return the correct signature
+```
+
+## Common Characters That Need Encoding
+
+Check if your password contains any of these characters that require encoding:
+
+| Character | Encoding | Character | Encoding |
+|-----------|----------|-----------|----------|
+| `@` | `%40` | `&` | `%26` |
+| `:` | `%3A` | `/` | `%2F` |
+| `?` | `%3F` | `#` | `%23` |
+| `%` | `%25` | ` ` (space) | `%20` |
+
+[Full list at MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding)
+
+## Quick Guide
+
+### 1. Encode Your Password
+
+Special characters (`@`, `&`, `:`, etc.) in passwords must be percent-encoded to be correctly interpreted in connection strings.
+
+Use one of these methods:
+
+```javascript
+// JavaScript
+const encodedPassword = encodeURIComponent("my@complex&password!");
+// Result: "my%40complex%26password%21"
+```
+
+```python
+# Python
+import urllib.parse
+encoded_password = urllib.parse.quote("my@complex&password!")
+# Result: "my%40complex%26password%21"
+```
+
+```bash
+# Linux (requires jq)
+encoded_password=$(printf %s "my@complex&password!" | jq -sRr @uri)
+# Result: "my%40complex%26password%21"
+```
+
+### 2. Construct Your Connection String
+
+<Aside type="tip">
+  Only encode the password portion, not the entire URL.
+</Aside>
+
+```
+postgresql://username:ENCODED_PASSWORD@host:port/database
+```
+
+Example:
+```
+postgresql://postgres:my%40complex%26password%21@db.example.com:5432/postgres
+```
+
+### 3. Add to Environment
+
+Local development:
+```bash
+# supabase/functions/.env
+EDGE_WORKER_DB_URL="postgresql://postgres:my%40complex%26password%21@db.example.com:5432/postgres"
+```
+
+Deployment:
+```bash
+npx supabase secrets set EDGE_WORKER_DB_URL="postgresql://postgres:my%40complex%26password%21@db.example.com:5432/postgres"
+```
+
+## Security Considerations
+
+:::caution[Password Security]
+When working with database passwords:
+- **Never** paste your database password into untrusted websites for encoding
+- **Avoid** sharing your database password with third-party services
+- **Don't** commit your database password to Git repositories
+- Use environment variables and secrets management tools instead
+:::


### PR DESCRIPTION
Add documentation for URL-encoding database passwords in Edge Worker connection strings, including:
- New page explaining password encoding process
- Caution note in installation guide about special character handling
- Examples of encoding methods in multiple programming languages
- Security considerations for password management
