### PR TITLE
Add compileFlow method to DSL package

### DIFF
--- a/.changeset/soft-peaches-dig.md
+++ b/.changeset/soft-peaches-dig.md
@@ -1,0 +1,5 @@
+---
+'@pgflow/dsl': patch
+---
+
+Add compileFlow function

--- a/pkgs/dsl/__tests__/runtime/compile-flow.test.ts
+++ b/pkgs/dsl/__tests__/runtime/compile-flow.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { Flow } from '../../src/dsl.js';
+import { compileFlow } from '../../src/compile-flow.js';
+
+describe('compileFlow', () => {
+  it('should compile a simple flow with no steps', () => {
+    const flow = new Flow({ slug: 'test_flow' });
+    const statements = compileFlow(flow);
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0]).toBe("SELECT pgflow.create_flow('test_flow');");
+  });
+
+  it('should compile a flow with runtime options', () => {
+    const flow = new Flow({
+      slug: 'test_flow',
+      maxAttempts: 5,
+      baseDelay: 10,
+      timeout: 120,
+    });
+
+    const statements = compileFlow(flow);
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0]).toBe(
+      "SELECT pgflow.create_flow('test_flow', max_attempts => 5, base_delay => 10, timeout => 120);"
+    );
+  });
+
+  it('should compile a flow with steps', () => {
+    const flow = new Flow({ slug: 'test_flow' })
+      .step({ slug: 'step1' }, () => 'result1')
+      .step({ slug: 'step2', dependsOn: ['step1'] }, () => 'result2');
+
+    const statements = compileFlow(flow);
+
+    expect(statements).toHaveLength(3);
+    expect(statements[0]).toBe("SELECT pgflow.create_flow('test_flow');");
+    expect(statements[1]).toBe("SELECT pgflow.add_step('test_flow', 'step1');");
+    expect(statements[2]).toBe(
+      "SELECT pgflow.add_step('test_flow', 'step2', ARRAY['step1']);"
+    );
+  });
+
+  it('should compile a flow with steps that have runtime options', () => {
+    const flow = new Flow({ slug: 'test_flow' })
+      .step({ slug: 'step1', maxAttempts: 3, baseDelay: 5 }, () => 'result1')
+      .step(
+        { slug: 'step2', dependsOn: ['step1'], timeout: 30 },
+        () => 'result2'
+      );
+
+    const statements = compileFlow(flow);
+
+    expect(statements).toHaveLength(3);
+    expect(statements[0]).toBe("SELECT pgflow.create_flow('test_flow');");
+    expect(statements[1]).toBe(
+      "SELECT pgflow.add_step('test_flow', 'step1', max_attempts => 3, base_delay => 5);"
+    );
+    expect(statements[2]).toBe(
+      "SELECT pgflow.add_step('test_flow', 'step2', ARRAY['step1'], timeout => 30);"
+    );
+  });
+
+  it('should compile a complex flow with multiple steps and dependencies', () => {
+    const flow = new Flow({
+      slug: 'complex_flow',
+      maxAttempts: 5,
+    })
+      .step({ slug: 'step1' }, () => 'result1')
+      .step({ slug: 'step2' }, () => 'result2')
+      .step({ slug: 'step3', dependsOn: ['step1', 'step2'] }, () => 'result3')
+      .step(
+        { slug: 'step4', dependsOn: ['step3'], timeout: 60 },
+        () => 'result4'
+      );
+
+    const statements = compileFlow(flow);
+
+    expect(statements).toHaveLength(5);
+    expect(statements[0]).toBe(
+      "SELECT pgflow.create_flow('complex_flow', max_attempts => 5);"
+    );
+    expect(statements[1]).toBe(
+      "SELECT pgflow.add_step('complex_flow', 'step1');"
+    );
+    expect(statements[2]).toBe(
+      "SELECT pgflow.add_step('complex_flow', 'step2');"
+    );
+    expect(statements[3]).toBe(
+      "SELECT pgflow.add_step('complex_flow', 'step3', ARRAY['step1', 'step2']);"
+    );
+    expect(statements[4]).toBe(
+      "SELECT pgflow.add_step('complex_flow', 'step4', ARRAY['step3'], timeout => 60);"
+    );
+  });
+});

--- a/pkgs/dsl/__tests__/runtime/compile-flow.test.ts
+++ b/pkgs/dsl/__tests__/runtime/compile-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Flow } from '../../src/dsl.js';
 import { compileFlow } from '../../src/compile-flow.js';
+import { AnalyzeWebsite } from '../../src/example-flow.js';
 
 describe('compileFlow', () => {
   it('should compile a simple flow with no steps', () => {
@@ -93,5 +94,20 @@ describe('compileFlow', () => {
     expect(statements[4]).toBe(
       "SELECT pgflow.add_step('complex_flow', 'step4', ARRAY['step3'], timeout => 60);"
     );
+  });
+
+  it('should compile the example AnalyzeWebsite flow with snapshot testing', () => {
+    const statements = compileFlow(AnalyzeWebsite);
+
+    // Use snapshot testing to verify the entire array of SQL statements
+    expect(statements).toMatchInlineSnapshot(`
+      [
+        "SELECT pgflow.create_flow('analyze_website', max_attempts => 3, base_delay => 5, timeout => 10);",
+        "SELECT pgflow.add_step('analyze_website', 'website');",
+        "SELECT pgflow.add_step('analyze_website', 'sentiment', ARRAY['website'], max_attempts => 5, timeout => 30);",
+        "SELECT pgflow.add_step('analyze_website', 'summary', ARRAY['website']);",
+        "SELECT pgflow.add_step('analyze_website', 'saveToDb', ARRAY['sentiment', 'summary']);",
+      ]
+    `);
   });
 });

--- a/pkgs/dsl/src/compile-flow.ts
+++ b/pkgs/dsl/src/compile-flow.ts
@@ -1,0 +1,54 @@
+import { Flow, AnyFlow, RuntimeOptions } from './dsl.js';
+
+/**
+ * Compiles a Flow object into an array of SQL statements
+ * that can be executed to create the flow and its steps in PostgreSQL
+ * 
+ * @param flow The Flow object to compile
+ * @returns Array of SQL statements
+ */
+export function compileFlow(flow: AnyFlow): string[] {
+  const statements: string[] = [];
+  
+  // Create the flow
+  const flowOptions = formatRuntimeOptions(flow.options);
+  statements.push(`SELECT pgflow.create_flow('${flow.slug}'${flowOptions});`);
+  
+  // Add steps in the order they were defined
+  for (const stepSlug of flow.stepOrder) {
+    const step = flow.getStepDefinition(stepSlug);
+    const stepOptions = formatRuntimeOptions(step.options);
+    
+    // Format dependencies array if it exists
+    let depsClause = '';
+    if (step.dependencies.length > 0) {
+      const depsArray = step.dependencies.map(dep => `'${dep}'`).join(', ');
+      depsClause = `, ARRAY[${depsArray}]`;
+    }
+    
+    statements.push(`SELECT pgflow.add_step('${flow.slug}', '${step.slug}'${depsClause}${stepOptions});`);
+  }
+  
+  return statements;
+}
+
+/**
+ * Formats runtime options into SQL parameter string
+ */
+function formatRuntimeOptions(options: RuntimeOptions): string {
+  const parts: string[] = [];
+  
+  if (options.maxAttempts !== undefined) {
+    parts.push(`max_attempts => ${options.maxAttempts}`);
+  }
+  
+  if (options.baseDelay !== undefined) {
+    parts.push(`base_delay => ${options.baseDelay}`);
+  }
+  
+  if (options.timeout !== undefined) {
+    parts.push(`timeout => ${options.timeout}`);
+  }
+  
+  return parts.length > 0 ? `, ${parts.join(', ')}` : '';
+}

--- a/pkgs/dsl/src/compile-flow.ts
+++ b/pkgs/dsl/src/compile-flow.ts
@@ -1,34 +1,36 @@
-import { Flow, AnyFlow, RuntimeOptions } from './dsl.js';
+import { AnyFlow, RuntimeOptions } from './dsl.js';
 
 /**
  * Compiles a Flow object into an array of SQL statements
  * that can be executed to create the flow and its steps in PostgreSQL
- * 
+ *
  * @param flow The Flow object to compile
  * @returns Array of SQL statements
  */
 export function compileFlow(flow: AnyFlow): string[] {
   const statements: string[] = [];
-  
+
   // Create the flow
   const flowOptions = formatRuntimeOptions(flow.options);
   statements.push(`SELECT pgflow.create_flow('${flow.slug}'${flowOptions});`);
-  
+
   // Add steps in the order they were defined
   for (const stepSlug of flow.stepOrder) {
     const step = flow.getStepDefinition(stepSlug);
     const stepOptions = formatRuntimeOptions(step.options);
-    
+
     // Format dependencies array if it exists
     let depsClause = '';
     if (step.dependencies.length > 0) {
-      const depsArray = step.dependencies.map(dep => `'${dep}'`).join(', ');
+      const depsArray = step.dependencies.map((dep) => `'${dep}'`).join(', ');
       depsClause = `, ARRAY[${depsArray}]`;
     }
-    
-    statements.push(`SELECT pgflow.add_step('${flow.slug}', '${step.slug}'${depsClause}${stepOptions});`);
+
+    statements.push(
+      `SELECT pgflow.add_step2('${flow.slug}', '${step.slug}'${depsClause}${stepOptions});`
+    );
   }
-  
+
   return statements;
 }
 
@@ -37,18 +39,18 @@ export function compileFlow(flow: AnyFlow): string[] {
  */
 function formatRuntimeOptions(options: RuntimeOptions): string {
   const parts: string[] = [];
-  
+
   if (options.maxAttempts !== undefined) {
     parts.push(`max_attempts => ${options.maxAttempts}`);
   }
-  
+
   if (options.baseDelay !== undefined) {
     parts.push(`base_delay => ${options.baseDelay}`);
   }
-  
+
   if (options.timeout !== undefined) {
     parts.push(`timeout => ${options.timeout}`);
   }
-  
+
   return parts.length > 0 ? `, ${parts.join(', ')}` : '';
 }

--- a/pkgs/dsl/src/compile-flow.ts
+++ b/pkgs/dsl/src/compile-flow.ts
@@ -27,7 +27,7 @@ export function compileFlow(flow: AnyFlow): string[] {
     }
 
     statements.push(
-      `SELECT pgflow.add_step2('${flow.slug}', '${step.slug}'${depsClause}${stepOptions});`
+      `SELECT pgflow.add_step('${flow.slug}', '${step.slug}'${depsClause}${stepOptions});`
     );
   }
 

--- a/pkgs/dsl/src/dsl.ts
+++ b/pkgs/dsl/src/dsl.ts
@@ -161,7 +161,7 @@ export class Flow<
    * Type safety is enforced at the method level when adding or retrieving steps.
    */
   private stepDefinitions: Record<string, StepDefinition<AnyInput, AnyOutput>>;
-  private stepOrder: string[];
+  public readonly stepOrder: string[];
   public readonly slug: string;
   public readonly options: RuntimeOptions;
 

--- a/pkgs/dsl/src/index.ts
+++ b/pkgs/dsl/src/index.ts
@@ -1,1 +1,2 @@
 export * from './dsl.js';
+export * from './compile-flow.js';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to compile flow definitions into SQL statements for PostgreSQL using a new function.
- **Tests**
  - Added comprehensive tests to ensure accurate SQL generation from flow definitions.
- **Refactor**
  - Made the step order of flows publicly accessible while keeping it read-only for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->