### PR TITLE
Stop publishing edge-worker for npm

### DIFF
--- a/.changeset/thick-actors-prove.md
+++ b/.changeset/thick-actors-prove.md
@@ -1,0 +1,10 @@
+---
+'@pgflow/edge-worker': patch
+'pgflow': patch
+'@pgflow/core': patch
+'@pgflow/dsl': patch
+'@pgflow/example-flows': patch
+'@pgflow/website': patch
+---
+
+Do not build edge-worker for npm

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "nx run-many --target=build --all",
     "version": "pnpm changeset version && ./scripts/update-jsr-json-version.sh",
-    "publish:npm": "pnpm nx run-many -t build && pnpm publish --recursive",
+    "publish:npm": "pnpm nx run-many -t build && pnpm publish --recursive --filter=!./pkgs/edge-worker",
     "publish:jsr": "cd ./pkgs/edge-worker && jsr publish --allow-slow-types",
     "changeset:tag": "pnpm changeset tag && git push --follow-tags",
     "release": "pnpm run publish:npm && pnpm run publish:jsr && pnpm run changeset:tag"

--- a/pkgs/edge-worker/eslint.config.cjs
+++ b/pkgs/edge-worker/eslint.config.cjs
@@ -1,8 +1,0 @@
-const baseConfig = require('../../eslint.config.cjs');
-
-module.exports = [
-  ...baseConfig,
-  {
-    ignores: ['**/supabase/functions/_dist/**/*'],
-  },
-];

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -18,18 +18,6 @@
         "rootDir": "pkgs/edge-worker/src"
       }
     },
-    "build:bundle": {
-      "executor": "@nx/esbuild:esbuild",
-      "options": {
-        "outputPath": "pkgs/edge-worker/supabase/functions/_dist",
-        "main": "pkgs/edge-worker/src/index.ts",
-        "tsConfig": "pkgs/edge-worker/tsconfig.lib.json",
-        "assets": ["pkgs/edge-worker/*.md"],
-        "rootDir": "pkgs/edge-worker/src",
-        "bundle": true,
-        "format": ["esm"]
-      }
-    },
     "test:nx-deno": {
       "executor": "@axhxrx/nx-deno:test",
       "outputs": ["{workspaceRoot}/coverage/pkgs/edge-worker"],
@@ -95,7 +83,7 @@
       }
     },
     "supabase:functions-serve": {
-      "dependsOn": ["supabase:start", "build:bundle"],
+      "dependsOn": ["supabase:start"],
       "executor": "nx:run-commands",
       "options": {
         "cwd": "pkgs/edge-worker",
@@ -136,7 +124,6 @@
       }
     },
     "test:e2e": {
-      "dependsOn": ["build:bundle"],
       "executor": "nx:run-commands",
       "options": {
         "cwd": "pkgs/edge-worker",

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -28,7 +28,7 @@
         "check": "local"
       }
     },
-    "lint:nx-deno": {
+    "lint": {
       "executor": "@axhxrx/nx-deno:lint",
       "options": {
         "denoConfig": "pkgs/edge-worker/deno.test.json",

--- a/pkgs/edge-worker/src/EdgeWorker.ts
+++ b/pkgs/edge-worker/src/EdgeWorker.ts
@@ -90,13 +90,11 @@ export class EdgeWorker {
     config: EdgeWorkerConfig = {}
   ): Promise<PlatformAdapter> {
     if (typeof handlerOrFlow === 'function') {
-      console.log('start() if typeof handlerOrFlow is function');
       return this.startQueueWorker(
         handlerOrFlow as MessageHandlerFn<TPayload>,
         config as QueueWorkerConfig
       );
     } else {
-      console.log('start() if typeof handlerOrFlow is FLOW');
       return this.startFlowWorker(
         handlerOrFlow as TFlow,
         config as FlowWorkerConfig
@@ -165,7 +163,6 @@ export class EdgeWorker {
     };
 
     await this.platform.startWorker((createLoggerFn) => {
-      console.log('QUEUE: platform.startWorker callback');
       return createQueueWorker(handler, workerConfig, createLoggerFn);
     });
 
@@ -212,7 +209,6 @@ export class EdgeWorker {
     };
 
     await this.platform.startWorker((createLoggerFn) => {
-      console.log('FLOW: platform.startWorker callback');
       return createFlowWorker(flow, workerConfig, createLoggerFn);
     });
 

--- a/pkgs/edge-worker/src/EdgeWorker.ts
+++ b/pkgs/edge-worker/src/EdgeWorker.ts
@@ -9,7 +9,7 @@ import {
 } from './flow/createFlowWorker.js';
 import { createAdapter } from './platform/createAdapter.js';
 import type { PlatformAdapter } from './platform/types.js';
-import { MessageHandlerFn } from './queue/types.js';
+import type { MessageHandlerFn } from './queue/types.js';
 import type { AnyFlow } from '@pgflow/dsl';
 
 /**
@@ -90,12 +90,12 @@ export class EdgeWorker {
     config: EdgeWorkerConfig = {}
   ): Promise<PlatformAdapter> {
     if (typeof handlerOrFlow === 'function') {
-      return this.startQueueWorker(
+      return await this.startQueueWorker(
         handlerOrFlow as MessageHandlerFn<TPayload>,
         config as QueueWorkerConfig
       );
     } else {
-      return this.startFlowWorker(
+      return await this.startFlowWorker(
         handlerOrFlow as TFlow,
         config as FlowWorkerConfig
       );

--- a/pkgs/edge-worker/src/platform/DenoAdapter.ts
+++ b/pkgs/edge-worker/src/platform/DenoAdapter.ts
@@ -141,7 +141,6 @@ export class DenoAdapter implements PlatformAdapter {
    * by passing a promise that never resolves.
    */
   private extendLifetimeOfEdgeFunction(): void {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const promiseThatNeverResolves = new Promise(() => {});
     EdgeRuntime.waitUntil(promiseThatNeverResolves);
   }

--- a/pkgs/edge-worker/src/platform/DenoAdapter.ts
+++ b/pkgs/edge-worker/src/platform/DenoAdapter.ts
@@ -75,11 +75,11 @@ export class DenoAdapter implements PlatformAdapter {
   /**
    * Get the environment variable value or undefined if it doesn't exist
    */
-  private getEnvVar(name: string, default?: string): string | undefined {
+  private getEnvVar(name: string, defaultValue?: string): string | undefined {
     const envVar = Deno.env.get(name);
 
-    if (envVar === undefined && default !== undefined) {
-      return default;
+    if (envVar === undefined && defaultValue !== undefined) {
+      return defaultValue;
     }
 
     return envVar;

--- a/pkgs/edge-worker/src/platform/DenoAdapter.ts
+++ b/pkgs/edge-worker/src/platform/DenoAdapter.ts
@@ -36,6 +36,8 @@ export class DenoAdapter implements PlatformAdapter {
     this.extendLifetimeOfEdgeFunction();
     this.setupShutdownHandler();
     this.setupStartupHandler(createWorkerFn);
+    // Return a resolved promise to satisfy the async requirement
+    await Promise.resolve();
   }
 
   async stopWorker(): Promise<void> {

--- a/pkgs/edge-worker/src/platform/DenoAdapter.ts
+++ b/pkgs/edge-worker/src/platform/DenoAdapter.ts
@@ -6,7 +6,7 @@ import { createLoggingFactory } from './logging.js';
  * Adapter for Deno runtime environment.
  * IMPORTANT: This class assumes it is running within a Deno environment
  * with access to the `Deno` and `EdgeRuntime` global objects.
- * 
+ *
  * NOTE: This code uses Deno specific APIs and is not meant to be executed in Node.js environments.
  * The TypeScript compilation in Node.js is only used for type checking and distribution.
  */
@@ -21,9 +21,7 @@ export class DenoAdapter implements PlatformAdapter {
   constructor() {
     // Set initial log level
     const logLevel = this.getEnvVarOrThrow('EDGE_WORKER_LOG_LEVEL') || 'info';
-    console.log(`--- DenoAdapter: Raw log level from env: ${logLevel} ---`); // Raw console log
     this.loggingFactory.setLogLevel(logLevel);
-    console.log('--- DenoAdapter: Log level set in factory ---'); // Raw console log
 
     // startWorker logger with a default module name
     this.logger = this.loggingFactory.createLogger('DenoAdapter');
@@ -61,7 +59,7 @@ export class DenoAdapter implements PlatformAdapter {
    * Get the Supabase URL for the current environment
    */
   private getEnvVarOrThrow(name: string): string {
-    const envVar = Deno.env.get(name);
+    const envVar = this.getEnvVar(name);
 
     if (!envVar) {
       const message =
@@ -69,6 +67,19 @@ export class DenoAdapter implements PlatformAdapter {
         'See docs to learn how to prepare the environment:\n' +
         'https://pgflow.pages.dev/edge-worker/prepare-environment';
       throw new Error(message);
+    }
+
+    return envVar;
+  }
+
+  /**
+   * Get the environment variable value or undefined if it doesn't exist
+   */
+  private getEnvVar(name: string, default?: string): string | undefined {
+    const envVar = Deno.env.get(name);
+
+    if (envVar === undefined && default !== undefined) {
+      return default;
     }
 
     return envVar;

--- a/pkgs/edge-worker/src/platform/createAdapter.ts
+++ b/pkgs/edge-worker/src/platform/createAdapter.ts
@@ -4,7 +4,7 @@ import { DenoAdapter } from './DenoAdapter.js';
 /**
  * Creates the appropriate platform adapter based on the runtime environment
  */
-export async function createAdapter(): Promise<PlatformAdapter> {
+export function createAdapter(): PlatformAdapter {
   if (isDenoEnvironment()) {
     const adapter = new DenoAdapter();
     return adapter;

--- a/pkgs/edge-worker/src/platform/logging.ts
+++ b/pkgs/edge-worker/src/platform/logging.ts
@@ -18,8 +18,6 @@ export function createLoggingFactory() {
    * Creates a new logger for a specific module
    */
   const createLogger = (module: string): Logger => {
-    console.log('--- createLoggingFactory CALLED ---'); // See how many times this appears
-
     // Create a logger that directly references the shared state
     const logger: Logger = {
       debug: (message, ...args) => {

--- a/pkgs/edge-worker/src/platform/types.ts
+++ b/pkgs/edge-worker/src/platform/types.ts
@@ -3,10 +3,10 @@ import type { Worker } from '../core/Worker.js';
  * Basic logger interface used throughout the application
  */
 export interface Logger {
-  debug(message: string, ...args: any[]): void;
-  info(message: string, ...args: any[]): void;
-  warn(message: string, ...args: any[]): void;
-  error(message: string, ...args: any[]): void;
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
 }
 
 /**

--- a/pkgs/edge-worker/supabase/functions/cpu_intensive/deno.json
+++ b/pkgs/edge-worker/supabase/functions/cpu_intensive/deno.json
@@ -8,6 +8,7 @@
     "@std/testing/mock": "jsr:@std/testing/mock@^0.224.0",
     "postgres": "npm:postgres@3.4.5",
     "@pgflow/core": "../../../../core/dist/index.js",
-    "@pgflow/dsl": "../../../../dsl/dist/index.js"
+    "@pgflow/dsl": "../../../../dsl/dist/index.js",
+    "@pgflow/edge-worker": "../../../src/index.ts"
   }
 }

--- a/pkgs/edge-worker/supabase/functions/cpu_intensive/index.ts
+++ b/pkgs/edge-worker/supabase/functions/cpu_intensive/index.ts
@@ -1,4 +1,4 @@
-import { EdgeWorker } from '../_dist/index.js';
+import { EdgeWorker } from '@pgflow/edge-worker';
 import { crypto } from 'jsr:@std/crypto';
 import { sql } from '../utils.ts';
 

--- a/pkgs/edge-worker/supabase/functions/max_concurrency/deno.json
+++ b/pkgs/edge-worker/supabase/functions/max_concurrency/deno.json
@@ -8,6 +8,7 @@
     "@std/testing/mock": "jsr:@std/testing/mock@^0.224.0",
     "postgres": "npm:postgres@3.4.5",
     "@pgflow/core": "../../../../core/dist/index.js",
-    "@pgflow/dsl": "../../../../dsl/dist/index.js"
+    "@pgflow/dsl": "../../../../dsl/dist/index.js",
+    "@pgflow/edge-worker": "../../../src/index.ts"
   }
 }

--- a/pkgs/edge-worker/supabase/functions/max_concurrency/index.ts
+++ b/pkgs/edge-worker/supabase/functions/max_concurrency/index.ts
@@ -1,4 +1,4 @@
-import { EdgeWorker } from '../_dist/index.js';
+import { EdgeWorker } from '@pgflow/edge-worker';
 import { sleep, sql } from '../utils.ts';
 
 async function incrementSeq() {

--- a/pkgs/edge-worker/tests/db.ts
+++ b/pkgs/edge-worker/tests/db.ts
@@ -4,7 +4,6 @@ function createSql(dbUrl: string) {
   return postgres(dbUrl, {
     prepare: false,
 
-    // eslint-disable-next-line
     onnotice(_: unknown) {
       // no-op to silence notices
     },

--- a/pkgs/edge-worker/tests/fakes.ts
+++ b/pkgs/edge-worker/tests/fakes.ts
@@ -1,6 +1,5 @@
 import type { CreateLoggerFn, Logger } from '../src/platform/types.js';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
 export const fakeLogger: Logger = {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -41,9 +41,6 @@
       ],
       "@pgflow/dsl": [
         "./pkgs/dsl/src/index.ts"
-      ],
-      "@pgflow/edge-worker": [
-        "./pkgs/edge-worker/mod.ts"
       ]
     }
   }


### PR DESCRIPTION
- **refactor: remove unnecessary console logs and improve environment variable handling in DenoAdapter**
- **chore: remove build:bundle from project.json and update dependencies in functions**
- **chore: update build and publish scripts to exclude edge-worker from npm publish**
- **refactor(logging): remove unnecessary console log statement from createLoggingFactory function**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Excluded the edge-worker package from being published to npm.
  - Updated configuration files and scripts to reflect the exclusion of the edge-worker package from the npm publish process.
  - Removed ESLint configuration file specific to the edge-worker package.
- **Refactor**
  - Improved import paths in Supabase function examples for better clarity and maintainability.
  - Simplified environment variable handling in platform adapters.
  - Converted an asynchronous adapter creation function to synchronous for streamlined usage.
  - Enhanced type safety in logging interface method signatures.
  - Removed build bundling target and adjusted related task dependencies in edge-worker project configuration.
- **Style**
  - Removed debug console logs for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->