### PR TITLE
Increase default visibilityTimeout for queue based Edge Worker

### DIFF
--- a/.changeset/khaki-papers-fix.md
+++ b/.changeset/khaki-papers-fix.md
@@ -1,0 +1,6 @@
+---
+'@pgflow/edge-worker': patch
+'@pgflow/website': patch
+---
+
+Update visibilityTimeout default value to 10s for queue-based worker

--- a/pkgs/edge-worker/src/EdgeWorker.ts
+++ b/pkgs/edge-worker/src/EdgeWorker.ts
@@ -134,7 +134,7 @@ export class EdgeWorker {
    *
    *   // how long a job is invisible after reading
    *   // if not successful, will reappear after this time
-   *   visibilityTimeout: 3,
+   *   visibilityTimeout: 10,
    * });
    * ```
    */
@@ -157,7 +157,7 @@ export class EdgeWorker {
       pollIntervalMs: config.pollIntervalMs ?? 200,
       retryDelay: config.retryDelay ?? 5,
       retryLimit: config.retryLimit ?? 5,
-      visibilityTimeout: config.visibilityTimeout ?? 3,
+      visibilityTimeout: config.visibilityTimeout ?? 10,
       connectionString:
         config.connectionString || this.platform.getConnectionString(),
     };

--- a/pkgs/edge-worker/src/queue/Queue.ts
+++ b/pkgs/edge-worker/src/queue/Queue.ts
@@ -70,7 +70,7 @@ export class Queue<TPayload extends Json> {
 
   async readWithPoll(
     batchSize = 20,
-    visibilityTimeout = 2,
+    visibilityTimeout = 10,
     maxPollSeconds = 5,
     pollIntervalMs = 200
   ) {

--- a/pkgs/edge-worker/src/queue/createQueueWorker.ts
+++ b/pkgs/edge-worker/src/queue/createQueueWorker.ts
@@ -66,7 +66,7 @@ export type QueueWorkerConfig = {
   /**
    * How long a job is invisible after reading in seconds.
    * If not successful, will reappear after this time.
-   * @default 3
+   * @default 10
    */
   visibilityTimeout?: number;
 
@@ -145,7 +145,7 @@ export function createQueueWorker<TPayload extends Json>(
       batchSize: config.batchSize || config.maxConcurrent || 10,
       maxPollSeconds: config.maxPollSeconds || 5,
       pollIntervalMs: config.pollIntervalMs || 200,
-      visibilityTimeout: config.visibilityTimeout || 3,
+      visibilityTimeout: config.visibilityTimeout || 10,
     },
     createLogger('ReadWithPollPoller')
   );

--- a/pkgs/website/src/content/docs/edge-worker/getting-started/configuration.mdx
+++ b/pkgs/website/src/content/docs/edge-worker/getting-started/configuration.mdx
@@ -55,7 +55,7 @@ EdgeWorker.start(handler, {
 
   // how long a job is invisible after reading
   // if not successful, will reappear after this time
-  visibilityTimeout: 3,
+  visibilityTimeout: 10,
 });
 ```
 
@@ -82,7 +82,7 @@ EdgeWorker.start(handler, {
 
 ### `visibilityTimeout`
 **Type:** `number`
-**Default:** `3`
+**Default:** `10`
 
 The duration (in seconds) that a message remains invisible to other consumers while being processed.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the new default visibility timeout of 10 seconds.
- **Chores**
  - Increased the default visibility timeout from 3 to 10 seconds across queue worker configurations, extending the period a job remains invisible to other consumers during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->