### PR TITLE
fix: add `--skip-config` flag

### DIFF
--- a/pkgs/cli/src/commands/install/index.ts
+++ b/pkgs/cli/src/commands/install/index.ts
@@ -11,6 +11,7 @@ export default (program: Command) => {
     .command('install')
     .description('Set up pgflow in your Supabase project')
     .option('--supabase-path <path>', 'Path to the Supabase folder')
+    .option('--skip-config', `Skips the 'config.toml' setup`, false)
     .option('-y, --yes', 'Automatically confirm all prompts', false)
     .action(async (options) => {
       intro('Installing pgflow in your Supabase project');
@@ -25,6 +26,7 @@ export default (program: Command) => {
           // Step 2: Update config.toml
           configUpdate: async ({ results: { supabasePath } }) => {
             if (!supabasePath) return false;
+            if (options.skipConfig) return true;
 
             return await updateConfigToml({
               supabasePath,


### PR DESCRIPTION
This PR includes a new `--skip-config` to allow users skip the `config.toml` part - Useful for self-hosted projects here this file is not present.