### PR TITLE
Make CLI compile create migrations using UTC, like Supabase CLI

### DIFF
--- a/.changeset/some-goats-itch.md
+++ b/.changeset/some-goats-itch.md
@@ -1,0 +1,5 @@
+---
+'pgflow': patch
+---
+
+Make compile generate migration timestamp using UTC

--- a/pkgs/cli/src/commands/compile/index.ts
+++ b/pkgs/cli/src/commands/compile/index.ts
@@ -115,15 +115,15 @@ export default (program: Command) => {
           log.success(`Created migrations directory: ${migrationsDir}`);
         }
 
-        // Generate timestamp for migration file in format YYYYMMDDHHMMSS
+        // Generate timestamp for migration file in format YYYYMMDDHHMMSS using UTC
         const now = new Date();
         const timestamp = [
-          now.getFullYear(),
-          String(now.getMonth() + 1).padStart(2, '0'),
-          String(now.getDate()).padStart(2, '0'),
-          String(now.getHours()).padStart(2, '0'),
-          String(now.getMinutes()).padStart(2, '0'),
-          String(now.getSeconds()).padStart(2, '0'),
+          now.getUTCFullYear(),
+          String(now.getUTCMonth() + 1).padStart(2, '0'),
+          String(now.getUTCDate()).padStart(2, '0'),
+          String(now.getUTCHours()).padStart(2, '0'),
+          String(now.getUTCMinutes()).padStart(2, '0'),
+          String(now.getUTCSeconds()).padStart(2, '0'),
         ].join('');
 
         // Run the compilation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Migration timestamps are now consistently generated in Coordinated Universal Time (UTC) instead of local time, ensuring uniformity across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->