### PR TITLE
feat: add internal exports to edge-worker for experimental use

### DIFF
--- a/.changeset/thin-stars-repeat.md
+++ b/.changeset/thin-stars-repeat.md
@@ -1,0 +1,9 @@
+---
+'@pgflow/edge-worker': patch
+---
+
+Add internal exports for experimental use
+
+Expose internal components through a new `_internal` export path to enable experimentation with alternative worker architectures. These APIs are unstable and may change without notice. The internal exports are organized by namespace (core, platform, flow, queue) for better discoverability.
+
+**⚠️ WARNING: These internal APIs are subject to change without notice. Import from `_internal` at your own risk!**

--- a/pkgs/edge-worker/jsr.json
+++ b/pkgs/edge-worker/jsr.json
@@ -2,7 +2,10 @@
   "name": "@pgflow/edge-worker",
   "version": "0.3.0",
   "license": "AGPL-3.0",
-  "exports": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./_internal": "./src/_internal.ts"
+  },
   "imports": {
     "@henrygd/queue": "jsr:@henrygd/queue@^1.0.7",
     "postgres": "npm:postgres@3.4.5",

--- a/pkgs/edge-worker/package.json
+++ b/pkgs/edge-worker/package.json
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./_internal": {
+      "types": "./dist/_internal.d.ts",
+      "import": "./dist/_internal.js"
     }
   },
   "files": [

--- a/pkgs/edge-worker/src/_internal.ts
+++ b/pkgs/edge-worker/src/_internal.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal exports for experimental use only.
+ * These APIs are unstable and may change without notice.
+ * 
+ * DO NOT use these in production code unless you know what you're doing.
+ * All internal components are exported and organized by namespace.
+ */
+
+// Core namespace - all internal worker infrastructure
+export * as core from './_internal/core.js';
+
+// Platform namespace - adapters and logging
+export * as platform from './_internal/platform.js';
+
+// Flow namespace - flow-specific worker components
+export * as flow from './_internal/flow.js';
+
+// Queue namespace - queue-based worker components
+export * as queue from './_internal/queue.js';
+
+// Also export EdgeWorker from root
+export { EdgeWorker } from './EdgeWorker.js';

--- a/pkgs/edge-worker/src/_internal/core.ts
+++ b/pkgs/edge-worker/src/_internal/core.ts
@@ -1,0 +1,8 @@
+export { BatchProcessor } from '../core/BatchProcessor.js';
+export { ExecutionController } from '../core/ExecutionController.js';
+export { Heartbeat } from '../core/Heartbeat.js';
+export { Queries } from '../core/Queries.js';
+export { Worker } from '../core/Worker.js';
+export { WorkerLifecycle } from '../core/WorkerLifecycle.js';
+export { WorkerState } from '../core/WorkerState.js';
+export type * from '../core/types.js';

--- a/pkgs/edge-worker/src/_internal/flow.ts
+++ b/pkgs/edge-worker/src/_internal/flow.ts
@@ -1,0 +1,5 @@
+export { createFlowWorker } from '../flow/createFlowWorker.js';
+export { FlowWorkerLifecycle } from '../flow/FlowWorkerLifecycle.js';
+export { StepTaskExecutor } from '../flow/StepTaskExecutor.js';
+export { StepTaskPoller } from '../flow/StepTaskPoller.js';
+export type * from '../flow/types.js';

--- a/pkgs/edge-worker/src/_internal/platform.ts
+++ b/pkgs/edge-worker/src/_internal/platform.ts
@@ -1,0 +1,6 @@
+export { createAdapter } from '../platform/createAdapter.js';
+export { createLoggingFactory } from '../platform/logging.js';
+export { DenoAdapter } from '../platform/DenoAdapter.js';
+export type * from '../platform/types.js';
+// Also re-export everything from platform/index.js
+export * from '../platform/index.js';

--- a/pkgs/edge-worker/src/_internal/queue.ts
+++ b/pkgs/edge-worker/src/_internal/queue.ts
@@ -1,0 +1,5 @@
+export { createQueueWorker } from '../queue/createQueueWorker.js';
+export { MessageExecutor } from '../queue/MessageExecutor.js';
+export { Queue } from '../queue/Queue.js';
+export { ReadWithPollPoller } from '../queue/ReadWithPollPoller.js';
+export type * from '../queue/types.js';


### PR DESCRIPTION
This PR adds internal exports to the `@pgflow/edge-worker` package to enable experimentation with alternative worker architectures (like cron-based workers).

## What changed?

- Added `_internal` export path that exposes internal components
- Organized exports by namespace: `core`, `platform`, `flow`, `queue`
- Updated `package.json` and `jsr.json` to include the new export path

## Why?

This enables experimentation with alternative worker architectures without modifying the stable public API. The internal exports are clearly marked as unstable and subject to change.

## ⚠️ Important

These internal APIs are **not** part of the public API and may change or be removed in any release without notice. They are provided purely for experimentation.

## Usage

```typescript
import * as internal from "@pgflow/edge-worker/_internal";

// Access internal components via namespaces
const { BatchProcessor } = internal.core;
const { createLoggingFactory } = internal.platform;
// etc...
```