### PR TITLE
fix: add missing build dependencies to test and execution targets

### DIFF
--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -24,6 +24,7 @@
     },
     "serve": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
         "command": "tsx src/index.ts",
         "cwd": "{projectRoot}"

--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -99,7 +99,7 @@
     },
     "test:integration": {
       "executor": "nx:run-commands",
-      "dependsOn": ["db:ensure"],
+      "dependsOn": ["db:ensure", "build"],
       "options": {
         "cwd": "{projectRoot}",
         "commands": ["vitest run __tests__/integration/"],
@@ -108,6 +108,7 @@
     },
     "test:unit": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
         "cwd": "{projectRoot}",
         "commands": ["vitest run __tests__/"],
@@ -116,7 +117,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["db:ensure"],
+      "dependsOn": ["db:ensure", "build"],
       "options": {
         "cwd": "{projectRoot}",
         "commands": ["vitest run __tests__/"],

--- a/pkgs/dsl/project.json
+++ b/pkgs/dsl/project.json
@@ -27,6 +27,7 @@
     },
     "test": {
       "executor": "@nx/vite:test",
+      "dependsOn": ["build"],
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "passWithNoTests": true,

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -126,6 +126,7 @@
     },
     "test:e2e": {
       "executor": "nx:run-commands",
+      "dependsOn": ["db:ensure", "^build"],
       "options": {
         "cwd": "pkgs/edge-worker",
         "commands": [


### PR DESCRIPTION
## Summary
- Fixed missing build dependencies across multiple packages to ensure proper build order
- Prevents "Failed to resolve entry for package" errors in CI and clean checkouts

## Changes
- **CLI Package**: Added `dependsOn: ["build"]` to `serve` target
- **Client Package**: Added `dependsOn: ["build"]` to `test`, `test:unit`, and `test:integration` targets
- **DSL Package**: Added `dependsOn: ["build"]` to `test` target
- **Edge Worker Package**: Added `dependsOn: ["db:ensure", "^build"]` to `test:e2e` target

## Test plan
- [x] All tests pass successfully
- [x] Build dependencies are correctly ordered
- [x] No regressions in existing functionality

Fixes issues documented in `branch-docs/missing-deps.md`