### PR TITLE
feat: add simplified snapshot release system

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The execution system handles the rest - scheduling steps when dependencies compl
 
 ## Releases
 
+- 📋 **Release Process**: See [RELEASES.md](./RELEASES.md) for how versions are managed and published
 - 📦 **Snapshot Releases**: See [SNAPSHOT_RELEASES.md](./SNAPSHOT_RELEASES.md) for testing changes before release
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -68,5 +68,9 @@ The execution system handles the rest - scheduling steps when dependencies compl
 - 🚀 **Demo**: [pgflow-demo.netlify.app](https://pgflow-demo.netlify.app)
 - 🛠️ **Getting Started**: [pgflow.dev/getting-started](https://pgflow.dev/getting-started)
 
+## Releases
+
+- 📦 **Snapshot Releases**: See [SNAPSHOT_RELEASES.md](./SNAPSHOT_RELEASES.md) for testing changes before release
+
 > [!NOTE]
 > This project and all its components are licensed under [Apache 2.0](./LICENSE) license.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,164 @@
+# Release Process
+
+> How pgflow automatically releases packages to npm and JSR via CI.
+
+## TL;DR - The Two-PR Process
+
+1. 📝 **Developer** creates changeset + merges feature PR
+2. 🤖 **CI** creates "Version Packages" PR (updates versions & changelogs)
+3. ✅ **Maintainer** merges the Version Packages PR
+4. 🚀 **CI** publishes to npm + JSR automatically
+
+All releases happen through GitHub Actions - no manual publishing.
+
+## Step-by-Step Process
+
+### 1. Making Changes
+
+When making changes to any package:
+
+```bash
+pnpm changeset  # Create changeset file
+```
+
+This will:
+- Ask which packages changed
+- Ask for version bump type (major/minor/patch)
+- Ask for changelog description
+
+Then commit the `.changeset/*.md` file with the code changes.
+
+### 2. Automatic Version PR
+
+After feature PRs with changesets are merged to main:
+
+🤖 **CI automatically creates "Version Packages" PR** containing:
+- Updated version numbers in all package.json files
+- Updated CHANGELOG.md files
+- Synced jsr.json versions (via `update-jsr-json-version.sh`)
+
+> [!NOTE]
+> All pgflow packages use "fixed" versioning - they share the same version number.
+
+### 3. Automatic Publishing
+
+When the Version Packages PR is merged:
+
+🚀 **CI runs the release workflow** (`.github/workflows/release.yml`):
+
+```bash
+# 1. Build all packages
+pnpm nx run-many -t build --exclude=playground
+
+# 2. Publish to npm (all packages except edge-worker)
+pnpm publish --recursive --filter=!./pkgs/edge-worker
+
+# 3. Publish edge-worker to JSR
+cd ./pkgs/edge-worker && jsr publish --allow-slow-types
+
+# 4. Create and push git tags
+pnpm changeset tag && git push --follow-tags
+```
+
+<details>
+<summary>📦 Why npm first, then JSR?</summary>
+
+edge-worker imports npm packages via `npm:@pgflow/core@0.5.0`. If JSR published first, it would reference non-existent npm versions.
+</details>
+
+## Configuration Details
+
+<details>
+<summary>⚙️ Fixed Versioning Setup</summary>
+
+`.changeset/config.json`:
+```json
+{
+  "fixed": [["@pgflow/*", "pgflow"]]
+}
+```
+
+All pgflow packages share the same version and release together.
+</details>
+
+<details>
+<summary>🔄 Version Syncing (npm → JSR)</summary>
+
+`update-jsr-json-version.sh` automatically:
+- Copies version from package.json → jsr.json
+- Updates import versions: `"@pgflow/core": "npm:@pgflow/core@0.5.0"`
+
+This keeps JSR packages in sync with npm versions.
+</details>
+
+## Release Types
+
+| Type | Version Example | When to Use | See |
+|------|----------------|-------------|-----|
+| **Regular** | `0.5.0` | Stable releases | This doc |
+| **Snapshot** | `0.0.0-fix-auth-...` | PR testing | [SNAPSHOT_RELEASES.md](./SNAPSHOT_RELEASES.md) |
+
+## CI Requirements
+
+> [!IMPORTANT]
+> Release workflow needs these GitHub secrets:
+> - `NPM_TOKEN` - npm publishing
+> - `GITHUB_TOKEN` - PR creation (auto-provided)
+> - OIDC permissions - JSR publishing
+
+## Quick Reference
+
+<details>
+<summary>📝 Adding a Feature</summary>
+
+```bash
+# 1. Make changes
+# 2. Create changeset
+pnpm changeset
+# 3. Commit & push
+# 4. Merge PR
+# 5. Wait for Version PR → merge it
+```
+</details>
+
+<details>
+<summary>🐛 Fixing a Bug</summary>
+
+```bash
+# 1. Fix bug
+# 2. Create changeset (usually patch)
+pnpm changeset
+# 3. Commit & push
+# 4. Merge PR
+# 5. Wait for Version PR → merge it
+```
+</details>
+
+<details>
+<summary>🧪 Testing Before Release</summary>
+
+Use snapshot releases - see [SNAPSHOT_RELEASES.md](./SNAPSHOT_RELEASES.md)
+</details>
+
+## Troubleshooting
+
+<details>
+<summary>🛑 "No changesets found"</summary>
+
+Run `pnpm changeset` before pushing. CI requires changesets for package changes.
+</details>
+
+<details>
+<summary>🛑 Version mismatch npm/JSR</summary>
+
+- Check `update-jsr-json-version.sh` ran in Version PR
+- package.json and jsr.json versions must match
+</details>
+
+<details>
+<summary>🛑 JSR publish fails</summary>
+
+- Already uses `--allow-slow-types`
+- Check JSR dashboard for specific errors
+- Ensure OIDC permissions are configured
+</details>

--- a/SNAPSHOT_RELEASES.md
+++ b/SNAPSHOT_RELEASES.md
@@ -65,6 +65,7 @@ Main script for creating snapshot releases locally or in CI.
 |------|-------------|---------|
 | `[tag]` | Custom snapshot tag | Branch name |
 | `--dry-run` | Preview without publishing | false |
+| `--allow-uncommitted-changesets` | Allow uncommitted changeset files | false |
 | `--help` | Show usage | - |
 
 **Examples:**
@@ -72,6 +73,7 @@ Main script for creating snapshot releases locally or in CI.
 ./scripts/snapshot-release.sh              # Uses branch name
 ./scripts/snapshot-release.sh my-feature   # Custom tag
 ./scripts/snapshot-release.sh --dry-run    # Preview only
+./scripts/snapshot-release.sh --allow-uncommitted-changesets  # Allow dirty changesets
 ```
 
 **Output:**
@@ -141,7 +143,11 @@ pnpm add -D @changesets/cli
 <details>
 <summary>🛑 "You have uncommitted changes"</summary>
 
-Commit changes or answer "y" to continue anyway
+For general uncommitted changes: Answer "y" to continue anyway.
+
+For uncommitted changesets specifically:
+- Commit them: `git add .changeset/*.md && git commit -m 'Add changeset'`
+- Or use: `--allow-uncommitted-changesets` flag
 </details>
 
 <details>

--- a/SNAPSHOT_RELEASES.md
+++ b/SNAPSHOT_RELEASES.md
@@ -24,44 +24,72 @@
 
 ## Installation
 
-After publishing a snapshot:
+Snapshots are published with exact versions. Always install using the full version:
 
 ### NPM Packages
 ```bash
-npm install @pgflow/core@snapshot
-npm install @pgflow/cli@snapshot
-# Or specific version:
 npm install @pgflow/core@0.0.0-my-feature-20240101120000
+npm install @pgflow/cli@0.0.0-my-feature-20240101120000
+npm install @pgflow/client@0.0.0-my-feature-20240101120000
+npm install @pgflow/dsl@0.0.0-my-feature-20240101120000
 ```
 
 ### JSR Package (Edge Worker)
 ```bash
-deno add @pgflow/edge-worker@experimental
+deno add @pgflow/edge-worker@0.0.0-my-feature-20240101120000
 # Or in import map:
-"@pgflow/edge-worker": "jsr:@pgflow/edge-worker@experimental"
+"@pgflow/edge-worker": "jsr:@pgflow/edge-worker@0.0.0-my-feature-20240101120000"
 ```
 
-## Script Options
+> [!TIP]
+> The script outputs exact install commands - just copy and paste!
 
-### Local Development
+> [!NOTE]
+> npm packages are published with dist-tag "snapshot" to protect the "latest" tag.
+> Always use exact versions - never install with `@snapshot`.
 
-| Command | Description |
-|---------|-------------|
-| `./scripts/snapshot-release.sh` | Use branch name as tag |
-| `./scripts/snapshot-release.sh my-tag` | Custom tag |
-| `./scripts/snapshot-release.sh --dry-run` | Preview only |
-| `./scripts/snapshot-release.sh --npm-tag next` | Custom npm tag |
+## Available Scripts
 
-### CI Usage
+### `snapshot-release.sh`
 
+Main script for creating snapshot releases locally or in CI.
+
+**Options:**
+| Flag | Description | Default |
+|------|-------------|---------|
+| `[tag]` | Custom snapshot tag | Branch name |
+| `--dry-run` | Preview without publishing | false |
+| `--help` | Show usage | - |
+
+**Examples:**
 ```bash
-./scripts/snapshot-release-ci.sh  # Auto-detects PR number
+./scripts/snapshot-release.sh              # Uses branch name
+./scripts/snapshot-release.sh my-feature   # Custom tag
+./scripts/snapshot-release.sh --dry-run    # Preview only
 ```
 
-Features:
-- 🔍 Auto-detects PR number/branch
-- 📝 Generates install instructions
-- 💬 Formats for PR comments
+**Output:**
+- Shows all packages being published with exact versions
+- Prints ready-to-use install commands
+- Creates JSON output at `/tmp/snapshot-release-output.json` for CI integration
+- Uses "snapshot" dist-tag to protect "latest" (but you always install by version)
+
+### `snapshot-release-ci.sh`
+
+CI-specific wrapper that auto-detects environment and generates PR comments.
+
+**Features:**
+- 🔍 Auto-detects PR number/branch from CI environment
+- 📝 Generates installation instructions
+- 💬 Outputs to GitHub Actions summary
+- 🤖 Supports GitHub Actions, GitLab CI, CircleCI
+
+**Usage:**
+```bash
+./scripts/snapshot-release-ci.sh  # No arguments needed
+```
+
+**Output:** Creates markdown file with installation instructions for PR comments.
 
 ## How It Works
 
@@ -70,8 +98,10 @@ Features:
 
 1. **Creates versions**: `changeset version --snapshot` → `0.0.0-{tag}-{timestamp}`
 2. **Syncs JSR**: Runs `update-jsr-json-version.sh`
-3. **Publishes**: npm with custom tag, then JSR
-4. **Cleans up**: Reverts all version changes (branch stays clean!)
+3. **Publishes**: npm with "snapshot" tag (protects "latest"), then JSR
+4. **Cleans up**: Automatically reverts all version changes via trap (even on errors!)
+   - Uses `git restore --source=HEAD` for reliable cleanup
+   - Branch always stays clean
 </details>
 
 ## Best Practices

--- a/SNAPSHOT_RELEASES.md
+++ b/SNAPSHOT_RELEASES.md
@@ -1,6 +1,6 @@
 # Snapshot Releases
 
-> Temporary test versions for PR testing. Version format: `0.0.0-{tag}-{timestamp}`
+> Temporary test versions for PR testing. Version format: `0.0.0-{tag}-{timestamp}-{sha}`
 
 ## Quick Start
 
@@ -34,17 +34,17 @@ Snapshots are published with exact versions. Always install using the full versi
 
 ### NPM Packages
 ```bash
-npm install @pgflow/core@0.0.0-my-feature-20240101120000
-npm install @pgflow/cli@0.0.0-my-feature-20240101120000
-npm install @pgflow/client@0.0.0-my-feature-20240101120000
-npm install @pgflow/dsl@0.0.0-my-feature-20240101120000
+npm install @pgflow/core@0.0.0-my-feature-20240101120000-abc1234
+npm install @pgflow/cli@0.0.0-my-feature-20240101120000-abc1234
+npm install @pgflow/client@0.0.0-my-feature-20240101120000-abc1234
+npm install @pgflow/dsl@0.0.0-my-feature-20240101120000-abc1234
 ```
 
 ### JSR Package (Edge Worker)
 ```bash
-deno add @pgflow/edge-worker@0.0.0-my-feature-20240101120000
+deno add @pgflow/edge-worker@0.0.0-my-feature-20240101120000-abc1234
 # Or in import map:
-"@pgflow/edge-worker": "jsr:@pgflow/edge-worker@0.0.0-my-feature-20240101120000"
+"@pgflow/edge-worker": "jsr:@pgflow/edge-worker@0.0.0-my-feature-20240101120000-abc1234"
 ```
 
 > [!TIP]
@@ -102,12 +102,13 @@ CI-specific wrapper that auto-detects environment and generates PR comments.
 <details>
 <summary>🔧 Technical Details</summary>
 
-1. **Creates versions**: `changeset version --snapshot` → `0.0.0-{tag}-{timestamp}`
+1. **Creates versions**: `changeset version --snapshot` → `0.0.0-{tag}-{timestamp}-{sha}`
 2. **Syncs JSR**: Runs `update-jsr-json-version.sh`
 3. **Publishes**: npm with "snapshot" tag (protects "latest"), then JSR
 4. **Cleans up**: Automatically reverts all version changes via trap (even on errors!)
-   - Uses `git restore --source=HEAD` for reliable cleanup
+   - Uses `git restore --source=HEAD` for reliable cleanup (falls back to `git checkout` for older git)
    - Branch always stays clean
+   - Works in CI and locally
 </details>
 
 ## Best Practices

--- a/SNAPSHOT_RELEASES.md
+++ b/SNAPSHOT_RELEASES.md
@@ -1,0 +1,121 @@
+# Snapshot Releases
+
+Snapshot releases allow you to publish temporary test versions of pgflow packages without affecting the main release process. This is perfect for testing changes before merging PRs.
+
+## Why Snapshots Over Prerelease Mode?
+
+**Snapshots are better for testing because:**
+- ✅ **No state management** - No pre.json file to track
+- ✅ **No commits required** - Versions are temporary and reverted after publishing
+- ✅ **Branch stays clean** - Safe to merge after testing
+- ✅ **Clear temporary versions** - Uses `0.0.0-*` format
+- ✅ **One command** - Simple to create and publish
+
+**Prerelease mode is more complex:**
+- ❌ Requires entering/exiting state
+- ❌ Creates commits that must be managed
+- ❌ More steps and potential for errors
+- ❌ Can accidentally publish to "latest" tag
+
+## Usage
+
+### Local Development
+
+Create a snapshot release from your current branch:
+
+```bash
+# Use branch name as snapshot tag
+./scripts/snapshot-release.sh
+
+# Use custom tag
+./scripts/snapshot-release.sh my-feature
+
+# Dry run to see what would happen
+./scripts/snapshot-release.sh fix-123 --dry-run
+
+# Use custom npm tag
+./scripts/snapshot-release.sh test --npm-tag experimental
+```
+
+### CI Environment
+
+The CI wrapper automatically detects PR numbers and generates installation instructions:
+
+```bash
+# In your CI workflow
+./scripts/snapshot-release-ci.sh
+```
+
+This will:
+- Detect PR number/branch name automatically
+- Create snapshot with appropriate tag
+- Generate installation instructions for PR comments
+- Output to GitHub Actions summary (if applicable)
+
+## How It Works
+
+1. **Creates snapshot versions** using `changeset version --snapshot`
+   - Versions become `0.0.0-{tag}-{timestamp}`
+   
+2. **Syncs JSR versions** using existing update script
+   - Updates jsr.json files to match package.json versions
+   
+3. **Publishes to registries**
+   - NPM packages with `pr-snapshot` or custom tag
+   - Edge Worker to JSR with matching tag
+   
+4. **Restores original versions**
+   - Reverts all package.json and jsr.json changes
+   - Keeps your branch clean and mergeable
+
+## Installation Instructions
+
+After publishing, install snapshot packages:
+
+### NPM Packages
+```bash
+# Using the snapshot tag
+npm install @pgflow/core@snapshot
+npm install @pgflow/cli@snapshot
+
+# Using specific version
+npm install @pgflow/core@0.0.0-my-feature-20240101120000
+```
+
+### JSR Package (Edge Worker)
+```bash
+# Using deno
+deno add @pgflow/edge-worker@experimental
+
+# In import map
+{
+  "imports": {
+    "@pgflow/edge-worker": "jsr:@pgflow/edge-worker@experimental"
+  }
+}
+```
+
+## Best Practices
+
+1. **Always test locally first** with `--dry-run`
+2. **Use descriptive tags** like `fix-auth-bug` or `feature-new-api`
+3. **Don't commit snapshot versions** - the script handles cleanup
+4. **Document in PRs** which snapshot version to test
+5. **Clean up old snapshots** periodically from npm/jsr
+
+## Troubleshooting
+
+### "Changesets CLI not found"
+Install changesets: `pnpm add -D @changesets/cli`
+
+### "You have uncommitted changes"
+Either commit your changes or answer "y" to continue anyway
+
+### JSR publish fails
+- Check you're logged in: `jsr login`
+- Ensure edge-worker has a valid jsr.json
+- Try with `--allow-slow-types` flag
+
+### Versions not updated
+- Check that update-jsr-json-version.sh is executable
+- Ensure jq is installed for JSON processing

--- a/SNAPSHOT_RELEASES.md
+++ b/SNAPSHOT_RELEASES.md
@@ -4,7 +4,13 @@
 
 ## Quick Start
 
+**Prerequisites:** You need at least one changeset for packages to publish.
+
 ```bash
+# First, create a changeset
+pnpm changeset
+
+# Then create snapshot
 ./scripts/snapshot-release.sh              # Uses branch name as tag
 ./scripts/snapshot-release.sh my-feature   # Custom tag
 ./scripts/snapshot-release.sh --dry-run    # Preview only
@@ -113,6 +119,15 @@ CI-specific wrapper that auto-detects environment and generates PR comments.
 > - Clean up old snapshots periodically
 
 ## Troubleshooting
+
+<details>
+<summary>🛑 "No unreleased changesets found"</summary>
+
+Snapshot releases require changesets to work. Create one first:
+```bash
+pnpm changeset  # Select packages and describe changes
+```
+</details>
 
 <details>
 <summary>🛑 "Changesets CLI not found"</summary>

--- a/scripts/snapshot-release-ci.sh
+++ b/scripts/snapshot-release-ci.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+set -euo pipefail
+
+# CI-specific wrapper for snapshot releases
+# Automatically detects PR number, commit SHA, and posts installation instructions
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# Colors for output (may not work in all CI environments)
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Detect CI environment and extract metadata
+CI_DETECTED=false
+SNAPSHOT_TAG=""
+PR_NUMBER=""
+COMMIT_SHA=""
+PR_COMMENT_FILE=""
+
+# GitHub Actions
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  CI_DETECTED=true
+  echo "Detected GitHub Actions environment"
+  
+  # Extract PR number if available
+  if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+    PR_NUMBER="${GITHUB_REF##*/}"
+    SNAPSHOT_TAG="pr-${PR_NUMBER}"
+  else
+    # Use branch name or commit SHA
+    BRANCH_NAME="${GITHUB_REF##*/}"
+    if [[ "$BRANCH_NAME" != "main" && "$BRANCH_NAME" != "HEAD" ]]; then
+      SNAPSHOT_TAG=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    else
+      SNAPSHOT_TAG="${GITHUB_SHA:0:7}"
+    fi
+  fi
+  
+  COMMIT_SHA="${GITHUB_SHA:0:7}"
+  PR_COMMENT_FILE="${GITHUB_STEP_SUMMARY:-/tmp/snapshot-release-summary.md}"
+fi
+
+# GitLab CI
+if [[ "${GITLAB_CI:-}" == "true" ]]; then
+  CI_DETECTED=true
+  echo "Detected GitLab CI environment"
+  
+  if [[ -n "${CI_MERGE_REQUEST_IID:-}" ]]; then
+    PR_NUMBER="${CI_MERGE_REQUEST_IID}"
+    SNAPSHOT_TAG="mr-${PR_NUMBER}"
+  else
+    BRANCH_NAME="${CI_COMMIT_REF_NAME:-}"
+    if [[ "$BRANCH_NAME" != "main" && -n "$BRANCH_NAME" ]]; then
+      SNAPSHOT_TAG=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    else
+      SNAPSHOT_TAG="${CI_COMMIT_SHORT_SHA:-unknown}"
+    fi
+  fi
+  
+  COMMIT_SHA="${CI_COMMIT_SHORT_SHA:-}"
+fi
+
+# CircleCI
+if [[ "${CIRCLECI:-}" == "true" ]]; then
+  CI_DETECTED=true
+  echo "Detected CircleCI environment"
+  
+  if [[ -n "${CIRCLE_PULL_REQUEST:-}" ]]; then
+    PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+    SNAPSHOT_TAG="pr-${PR_NUMBER}"
+  else
+    BRANCH_NAME="${CIRCLE_BRANCH:-}"
+    if [[ "$BRANCH_NAME" != "main" && -n "$BRANCH_NAME" ]]; then
+      SNAPSHOT_TAG=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    else
+      SNAPSHOT_TAG="${CIRCLE_SHA1:0:7}"
+    fi
+  fi
+  
+  COMMIT_SHA="${CIRCLE_SHA1:0:7}"
+fi
+
+# Fallback if CI not detected or tag not set
+if [[ -z "$SNAPSHOT_TAG" ]]; then
+  SNAPSHOT_TAG=$(git rev-parse --short HEAD 2>/dev/null || echo "snapshot")
+fi
+
+echo -e "${GREEN}=== CI Snapshot Release ===${NC}"
+echo -e "Environment: ${CI_DETECTED}"
+echo -e "Snapshot tag: ${YELLOW}${SNAPSHOT_TAG}${NC}"
+echo -e "Commit SHA: ${COMMIT_SHA}"
+echo -e "PR Number: ${PR_NUMBER:-N/A}"
+echo ""
+
+# Run the main snapshot release script
+"${SCRIPT_DIR}/snapshot-release.sh" "$SNAPSHOT_TAG" --npm-tag "pr-snapshot" --jsr-tag "pr-snapshot" 2>&1 | tee /tmp/snapshot-release.log
+
+# Extract published packages from the log
+PUBLISHED_PACKAGES=$(grep -E '@pgflow/[a-z-]+@0\.0\.0-' /tmp/snapshot-release.log || true)
+
+# Generate installation instructions for PR comment
+if [[ "$CI_DETECTED" == true && -n "$PR_COMMENT_FILE" ]]; then
+  cat > "$PR_COMMENT_FILE" << EOF
+## 📦 Snapshot Release Available
+
+A snapshot release has been created for this pull request.
+
+**Commit:** \`${COMMIT_SHA}\`
+**Tag:** \`${SNAPSHOT_TAG}\`
+
+### Installation
+
+#### NPM Packages
+
+\`\`\`bash
+# Install all pgflow packages from this snapshot
+npm install @pgflow/core@pr-snapshot @pgflow/cli@pr-snapshot @pgflow/client@pr-snapshot @pgflow/dsl@pr-snapshot
+
+# Or install specific versions
+EOF
+
+  # Add specific package versions if we found them
+  if [[ -n "$PUBLISHED_PACKAGES" ]]; then
+    echo '```' >> "$PR_COMMENT_FILE"
+    echo "$PUBLISHED_PACKAGES" | while read -r pkg; do
+      echo "npm install $pkg" >> "$PR_COMMENT_FILE"
+    done
+    echo '```' >> "$PR_COMMENT_FILE"
+  fi
+
+  cat >> "$PR_COMMENT_FILE" << EOF
+
+#### Edge Worker (JSR)
+
+\`\`\`bash
+# In your import map or deno.json
+"@pgflow/edge-worker": "jsr:@pgflow/edge-worker@pr-snapshot"
+
+# Or with deno add
+deno add @pgflow/edge-worker@pr-snapshot
+\`\`\`
+
+### Testing the Snapshot
+
+1. Update your project dependencies to use the snapshot versions
+2. Run your tests to ensure everything works as expected
+3. Report any issues in this PR
+
+**Note:** These snapshot versions are temporary and will not be available after this PR is merged.
+EOF
+
+  echo ""
+  echo -e "${GREEN}Installation instructions written to: ${PR_COMMENT_FILE}${NC}"
+  
+  # If in GitHub Actions, also output as a comment command
+  if [[ "${GITHUB_ACTIONS:-}" == "true" && -n "${PR_NUMBER}" ]]; then
+    echo "::notice title=Snapshot Release::Snapshot packages published with tag: pr-snapshot"
+  fi
+fi
+
+echo -e "\n${GREEN}CI snapshot release complete!${NC}"

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+set -euo pipefail
+
+# Helper script for creating and publishing snapshot releases
+# Safe to use both locally and in CI on branches
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+TAG=""
+DRY_RUN=false
+NO_GIT_TAG="--no-git-tag" # Default to no git tags for snapshots
+NPM_TAG="snapshot" # Default npm tag
+JSR_TAG="experimental" # Default JSR tag
+
+# Function to print usage
+usage() {
+  echo "Usage: $0 [snapshot-tag] [options]"
+  echo ""
+  echo "Options:"
+  echo "  --dry-run         Run without actually publishing"
+  echo "  --npm-tag TAG     NPM dist tag to use (default: snapshot)"
+  echo "  --jsr-tag TAG     JSR dist tag to use (default: experimental)"
+  echo "  --help            Show this help message"
+  echo ""
+  echo "Examples:"
+  echo "  $0                      # Create snapshot with branch name as tag"
+  echo "  $0 my-feature           # Create snapshot with 'my-feature' tag"
+  echo "  $0 fix-123 --dry-run    # Dry run for 'fix-123' snapshot"
+  echo "  $0 test --npm-tag next  # Use 'next' as npm tag"
+  exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --npm-tag)
+      NPM_TAG="$2"
+      shift 2
+      ;;
+    --jsr-tag)
+      JSR_TAG="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      ;;
+    *)
+      if [[ -z "$TAG" ]]; then
+        TAG="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Generate default tag if not provided
+if [[ -z "$TAG" ]]; then
+  # Use branch name or commit hash as default tag
+  BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [[ "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "" && "$BRANCH_NAME" != "main" ]]; then
+    # Clean branch name to be npm-compatible
+    TAG=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+  else
+    # Fallback to short commit hash
+    TAG=$(git rev-parse --short HEAD)
+  fi
+fi
+
+echo -e "${GREEN}=== pgflow Snapshot Release ===${NC}"
+echo -e "${GREEN}Snapshot tag: ${YELLOW}${TAG}${NC}"
+echo -e "${GREEN}NPM dist tag: ${YELLOW}${NPM_TAG}${NC}"
+echo -e "${GREEN}JSR dist tag: ${YELLOW}${JSR_TAG}${NC}"
+echo ""
+
+# Check if we have uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo -e "${YELLOW}Warning: You have uncommitted changes${NC}"
+  if [[ "$DRY_RUN" != true ]]; then
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      echo -e "${RED}Aborted${NC}"
+      exit 1
+    fi
+  fi
+fi
+
+# Navigate to root directory
+cd "$ROOT_DIR"
+
+# Check if changesets are installed
+if ! command -v changeset &> /dev/null && ! npx changeset --version &> /dev/null; then
+  echo -e "${RED}Error: changesets CLI not found${NC}"
+  echo "Please install changesets: pnpm add -D @changesets/cli"
+  exit 1
+fi
+
+# Store original package versions for restoration
+echo -e "${GREEN}Saving original package versions...${NC}"
+ORIGINAL_VERSIONS=$(find pkgs -name "package.json" -not -path "*/node_modules/*" -exec sh -c 'echo "{}:$(jq -r .version "{}")"' \;)
+
+# Create snapshot versions
+echo -e "\n${GREEN}Creating snapshot versions...${NC}"
+if [[ "$DRY_RUN" == true ]]; then
+  echo "(DRY RUN) Would run: pnpm changeset version --snapshot ${TAG}"
+else
+  pnpm changeset version --snapshot "${TAG}"
+  
+  # Update JSR versions to match
+  echo -e "\n${GREEN}Syncing JSR versions...${NC}"
+  ./scripts/update-jsr-json-version.sh
+fi
+
+# Show what would be published
+echo -e "\n${GREEN}Packages to be published:${NC}"
+SNAPSHOT_PACKAGES=""
+if [[ "$DRY_RUN" == true ]]; then
+  echo "(DRY RUN) Would show packages with version 0.0.0-${TAG}-*"
+else
+  # Find packages with snapshot versions
+  while IFS= read -r pkg; do
+    if grep -q "\"version\": \"0.0.0-" "$pkg" 2>/dev/null; then
+      PKG_NAME=$(jq -r .name "$pkg" 2>/dev/null || echo "unknown")
+      PKG_VERSION=$(jq -r .version "$pkg" 2>/dev/null || echo "unknown")
+      echo -e "  ${BLUE}${PKG_NAME}${NC} @ ${YELLOW}${PKG_VERSION}${NC}"
+      SNAPSHOT_PACKAGES="${SNAPSHOT_PACKAGES}${PKG_NAME}@${PKG_VERSION}\n"
+    fi
+  done < <(find pkgs -name "package.json" -not -path "*/node_modules/*")
+fi
+
+# Publish to npm
+if [[ "$DRY_RUN" == true ]]; then
+  echo -e "\n${YELLOW}DRY RUN: Skipping npm publish${NC}"
+  echo "Would run: pnpm changeset publish --tag ${NPM_TAG} ${NO_GIT_TAG}"
+else
+  echo -e "\n${GREEN}Publishing to npm...${NC}"
+  pnpm changeset publish --tag "${NPM_TAG}" ${NO_GIT_TAG}
+fi
+
+# Publish edge-worker to JSR
+if [[ "$DRY_RUN" == true ]]; then
+  echo -e "\n${YELLOW}DRY RUN: Skipping JSR publish${NC}"
+  echo "Would run: cd pkgs/edge-worker && jsr publish --allow-slow-types --tag ${JSR_TAG}"
+else
+  if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
+    echo -e "\n${GREEN}Publishing edge-worker to JSR...${NC}"
+    (cd pkgs/edge-worker && jsr publish --allow-slow-types --tag "${JSR_TAG}" || true)
+  fi
+fi
+
+# Print installation instructions
+if [[ "$DRY_RUN" != true ]]; then
+  echo -e "\n${GREEN}=== Snapshot Release Complete! ===${NC}"
+  echo -e "\n${BLUE}Install from npm:${NC}"
+  echo -e "  npm install <package>@${NPM_TAG}"
+  echo -e "  # or specific version:"
+  echo -e "  npm install <package>@0.0.0-${TAG}-TIMESTAMP"
+  
+  if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
+    echo -e "\n${BLUE}Install from JSR:${NC}"
+    echo -e "  deno add @pgflow/edge-worker@${JSR_TAG}"
+    echo -e "  # or in import map:"
+    echo -e "  \"@pgflow/edge-worker\": \"jsr:@pgflow/edge-worker@${JSR_TAG}\""
+  fi
+  
+  echo -e "\n${BLUE}Published packages:${NC}"
+  echo -e "$SNAPSHOT_PACKAGES"
+fi
+
+# Cleanup - restore original versions
+if [[ "$DRY_RUN" != true ]]; then
+  echo -e "\n${GREEN}Restoring original versions...${NC}"
+  
+  # Restore package.json files
+  git checkout -- "**/package.json" 2>/dev/null || true
+  
+  # Restore jsr.json files
+  git checkout -- "**/jsr.json" 2>/dev/null || true
+  
+  # Restore lock files
+  git checkout -- "pnpm-lock.yaml" "package-lock.json" "yarn.lock" 2>/dev/null || true
+  
+  echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
+fi

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -7,6 +7,17 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
 
+# Cleanup function to restore versions on exit
+cleanup() {
+  if [[ "${CLEANUP_NEEDED:-false}" == true && "$DRY_RUN" != true ]]; then
+    echo -e "\n${GREEN}Restoring original versions...${NC}"
+    cd "$ROOT_DIR"
+    git restore --source=HEAD -- ':/**/package.json' ':/**/jsr.json' pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null || true
+    echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
+  fi
+}
+trap cleanup EXIT
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -18,8 +29,6 @@ NC='\033[0m' # No Color
 TAG=""
 DRY_RUN=false
 NO_GIT_TAG="--no-git-tag" # Default to no git tags for snapshots
-NPM_TAG="snapshot" # Default npm tag
-JSR_TAG="experimental" # Default JSR tag
 
 # Function to print usage
 usage() {
@@ -27,15 +36,15 @@ usage() {
   echo ""
   echo "Options:"
   echo "  --dry-run         Run without actually publishing"
-  echo "  --npm-tag TAG     NPM dist tag to use (default: snapshot)"
-  echo "  --jsr-tag TAG     JSR dist tag to use (default: experimental)"
   echo "  --help            Show this help message"
   echo ""
   echo "Examples:"
   echo "  $0                      # Create snapshot with branch name as tag"
   echo "  $0 my-feature           # Create snapshot with 'my-feature' tag"
   echo "  $0 fix-123 --dry-run    # Dry run for 'fix-123' snapshot"
-  echo "  $0 test --npm-tag next  # Use 'next' as npm tag"
+  echo ""
+  echo "Note: Packages are published with exact versions (no dist-tags)"
+  echo "      Install with: npm install @pgflow/core@0.0.0-TAG-TIMESTAMP"
   exit 0
 }
 
@@ -45,14 +54,6 @@ while [[ $# -gt 0 ]]; do
     --dry-run)
       DRY_RUN=true
       shift
-      ;;
-    --npm-tag)
-      NPM_TAG="$2"
-      shift 2
-      ;;
-    --jsr-tag)
-      JSR_TAG="$2"
-      shift 2
       ;;
     --help)
       usage
@@ -71,8 +72,8 @@ if [[ -z "$TAG" ]]; then
   # Use branch name or commit hash as default tag
   BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   if [[ "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "" && "$BRANCH_NAME" != "main" ]]; then
-    # Clean branch name to be npm-compatible
-    TAG=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    # Clean branch name to be npm-compatible (lowercase, alphanumeric + hyphen)
+    TAG=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
   else
     # Fallback to short commit hash
     TAG=$(git rev-parse --short HEAD)
@@ -81,8 +82,6 @@ fi
 
 echo -e "${GREEN}=== pgflow Snapshot Release ===${NC}"
 echo -e "${GREEN}Snapshot tag: ${YELLOW}${TAG}${NC}"
-echo -e "${GREEN}NPM dist tag: ${YELLOW}${NPM_TAG}${NC}"
-echo -e "${GREEN}JSR dist tag: ${YELLOW}${JSR_TAG}${NC}"
 echo ""
 
 # Check if we have uncommitted changes
@@ -101,16 +100,18 @@ fi
 # Navigate to root directory
 cd "$ROOT_DIR"
 
-# Check if changesets are installed
+# Check if required tools are installed
 if ! command -v changeset &> /dev/null && ! npx changeset --version &> /dev/null; then
   echo -e "${RED}Error: changesets CLI not found${NC}"
   echo "Please install changesets: pnpm add -D @changesets/cli"
   exit 1
 fi
 
-# Store original package versions for restoration
-echo -e "${GREEN}Saving original package versions...${NC}"
-ORIGINAL_VERSIONS=$(find pkgs -name "package.json" -not -path "*/node_modules/*" -exec sh -c 'echo "{}:$(jq -r .version "{}")"' \;)
+if ! command -v jq &> /dev/null; then
+  echo -e "${RED}Error: jq is required for JSON processing${NC}"
+  echo "Please install jq: https://stedolan.github.io/jq/download/"
+  exit 1
+fi
 
 # Create snapshot versions
 echo -e "\n${GREEN}Creating snapshot versions...${NC}"
@@ -118,6 +119,9 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "(DRY RUN) Would run: pnpm changeset version --snapshot ${TAG}"
 else
   pnpm changeset version --snapshot "${TAG}"
+  
+  # Mark that cleanup is needed from this point
+  CLEANUP_NEEDED=true
   
   # Update JSR versions to match
   echo -e "\n${GREEN}Syncing JSR versions...${NC}"
@@ -142,56 +146,67 @@ else
 fi
 
 # Publish to npm
+# IMPORTANT: We use --tag snapshot to avoid polluting the "latest" tag
+# npm ALWAYS requires a dist-tag, so we use "snapshot" which users won't accidentally install
 if [[ "$DRY_RUN" == true ]]; then
   echo -e "\n${YELLOW}DRY RUN: Skipping npm publish${NC}"
-  echo "Would run: pnpm changeset publish --tag ${NPM_TAG} ${NO_GIT_TAG}"
+  echo "Would run: pnpm changeset publish --tag snapshot ${NO_GIT_TAG}"
 else
-  echo -e "\n${GREEN}Publishing to npm...${NC}"
-  pnpm changeset publish --tag "${NPM_TAG}" ${NO_GIT_TAG}
+  echo -e "\n${GREEN}Publishing to npm with 'snapshot' tag (to protect 'latest')...${NC}"
+  pnpm changeset publish --tag snapshot ${NO_GIT_TAG}
 fi
 
-# Publish edge-worker to JSR
+# Publish edge-worker to JSR (without dist-tags)
 if [[ "$DRY_RUN" == true ]]; then
   echo -e "\n${YELLOW}DRY RUN: Skipping JSR publish${NC}"
-  echo "Would run: cd pkgs/edge-worker && jsr publish --allow-slow-types --tag ${JSR_TAG}"
+  echo "Would run: cd pkgs/edge-worker && jsr publish --allow-slow-types"
 else
   if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
     echo -e "\n${GREEN}Publishing edge-worker to JSR...${NC}"
-    (cd pkgs/edge-worker && jsr publish --allow-slow-types --tag "${JSR_TAG}" || true)
+    (cd pkgs/edge-worker && jsr publish --allow-slow-types || true)
   fi
 fi
 
 # Print installation instructions
 if [[ "$DRY_RUN" != true ]]; then
   echo -e "\n${GREEN}=== Snapshot Release Complete! ===${NC}"
-  echo -e "\n${BLUE}Install from npm:${NC}"
-  echo -e "  npm install <package>@${NPM_TAG}"
-  echo -e "  # or specific version:"
-  echo -e "  npm install <package>@0.0.0-${TAG}-TIMESTAMP"
+  echo -e "\n${BLUE}Copy and paste to install:${NC}\n"
   
+  # Create machine-readable output for CI
+  SNAPSHOT_OUTPUT_FILE="/tmp/snapshot-release-output.json"
+  echo '{"packages":[' > "$SNAPSHOT_OUTPUT_FILE"
+  FIRST_PKG=true
+  
+  # Print npm install commands
+  echo -e "${YELLOW}# NPM packages:${NC}"
+  while IFS= read -r pkg; do
+    if grep -q "\"version\": \"0.0.0-" "$pkg" 2>/dev/null; then
+      PKG_NAME=$(jq -r .name "$pkg" 2>/dev/null || echo "unknown")
+      PKG_VERSION=$(jq -r .version "$pkg" 2>/dev/null || echo "unknown")
+      if [[ "$PKG_NAME" != "@pgflow/edge-worker" ]]; then
+        echo "npm install ${PKG_NAME}@${PKG_VERSION}"
+        # Add to JSON output
+        if [[ "$FIRST_PKG" != true ]]; then echo "," >> "$SNAPSHOT_OUTPUT_FILE"; fi
+        echo -n "{\"name\":\"${PKG_NAME}\",\"version\":\"${PKG_VERSION}\",\"registry\":\"npm\"}" >> "$SNAPSHOT_OUTPUT_FILE"
+        FIRST_PKG=false
+      fi
+    fi
+  done < <(find pkgs -name "package.json" -not -path "*/node_modules/*")
+  
+  # Print JSR install command
   if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
-    echo -e "\n${BLUE}Install from JSR:${NC}"
-    echo -e "  deno add @pgflow/edge-worker@${JSR_TAG}"
-    echo -e "  # or in import map:"
-    echo -e "  \"@pgflow/edge-worker\": \"jsr:@pgflow/edge-worker@${JSR_TAG}\""
+    EDGE_WORKER_VERSION=$(jq -r .version "pkgs/edge-worker/jsr.json" 2>/dev/null || echo "unknown")
+    echo -e "\n${YELLOW}# JSR package:${NC}"
+    echo "deno add @pgflow/edge-worker@${EDGE_WORKER_VERSION}"
+    echo -e "\n${YELLOW}# Or in import map:${NC}"
+    echo "\"@pgflow/edge-worker\": \"jsr:@pgflow/edge-worker@${EDGE_WORKER_VERSION}\""
+    # Add to JSON output
+    if [[ "$FIRST_PKG" != true ]]; then echo "," >> "$SNAPSHOT_OUTPUT_FILE"; fi
+    echo -n "{\"name\":\"@pgflow/edge-worker\",\"version\":\"${EDGE_WORKER_VERSION}\",\"registry\":\"jsr\"}" >> "$SNAPSHOT_OUTPUT_FILE"
   fi
   
-  echo -e "\n${BLUE}Published packages:${NC}"
-  echo -e "$SNAPSHOT_PACKAGES"
+  echo "]}" >> "$SNAPSHOT_OUTPUT_FILE"
+  echo -e "\n${GREEN}Machine-readable output saved to: ${SNAPSHOT_OUTPUT_FILE}${NC}"
 fi
 
-# Cleanup - restore original versions
-if [[ "$DRY_RUN" != true ]]; then
-  echo -e "\n${GREEN}Restoring original versions...${NC}"
-  
-  # Restore package.json files
-  git checkout -- "**/package.json" 2>/dev/null || true
-  
-  # Restore jsr.json files
-  git checkout -- "**/jsr.json" 2>/dev/null || true
-  
-  # Restore lock files
-  git checkout -- "pnpm-lock.yaml" "package-lock.json" "yarn.lock" 2>/dev/null || true
-  
-  echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
-fi
+# Cleanup happens automatically via trap on exit

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -259,7 +259,7 @@ else
   if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
     echo -e "\n${GREEN}Publishing edge-worker to JSR...${NC}"
     # Use --allow-dirty since we have uncommitted version changes
-    if ! (cd "pkgs/edge-worker" && jsr publish --allow-slow-types --allow-dirty); then
+    if ! (cd "pkgs/edge-worker" && pnpm jsr publish --allow-slow-types --allow-dirty); then
       echo -e "${YELLOW}Warning: JSR publish failed - continuing${NC}"
       echo -e "${YELLOW}You may need to manually publish to JSR or check your authentication${NC}"
     fi

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -12,8 +12,14 @@ cleanup() {
   if [[ "${CLEANUP_NEEDED:-false}" == true && "$DRY_RUN" != true ]]; then
     echo -e "\n${GREEN}Restoring original versions...${NC}"
     cd "$ROOT_DIR"
-    git restore --source=HEAD -- ':/**/package.json' ':/**/jsr.json' pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null || true
-    echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
+    # Try git restore first (git 2.23+), fallback to git checkout for older versions
+    if git restore --source=HEAD -- ':/**/package.json' ':/**/jsr.json' pnpm-lock.yaml package-lock.yaml yarn.lock 2>/dev/null; then
+      echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
+    elif git checkout HEAD -- '**/package.json' '**/jsr.json' pnpm-lock.yaml package-lock.yaml yarn.lock 2>/dev/null; then
+      echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
+    else
+      echo -e "${YELLOW}Warning: Could not automatically restore versions. You may need to manually reset changes.${NC}"
+    fi
   fi
 }
 trap cleanup EXIT
@@ -80,6 +86,14 @@ if [[ -z "$TAG" ]]; then
   fi
 fi
 
+# Validate tag format (npm package name rules)
+if [[ ! "$TAG" =~ ^[a-z0-9][a-z0-9-]{0,127}$ ]]; then
+  echo -e "${RED}Error: Invalid tag format '${TAG}'${NC}"
+  echo -e "${YELLOW}Tag must start with lowercase letter or number, and contain only lowercase letters, numbers, and hyphens.${NC}"
+  echo -e "${YELLOW}Maximum length: 128 characters${NC}"
+  exit 1
+fi
+
 echo -e "${GREEN}=== pgflow Snapshot Release ===${NC}"
 echo -e "${GREEN}Snapshot tag: ${YELLOW}${TAG}${NC}"
 echo ""
@@ -98,10 +112,16 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   fi
   
   if [[ "$DRY_RUN" != true ]]; then
-    read -p "Continue with other uncommitted changes? (y/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      echo -e "${RED}Aborted${NC}"
+    # In CI, abort on uncommitted changes. In interactive mode, ask.
+    if [[ -t 0 ]]; then
+      read -p "Continue with other uncommitted changes? (y/N) " -n 1 -r
+      echo
+      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${RED}Aborted${NC}"
+        exit 1
+      fi
+    else
+      echo -e "${RED}Error: Uncommitted changes detected in CI environment${NC}"
       exit 1
     fi
   fi
@@ -111,25 +131,51 @@ fi
 cd "$ROOT_DIR"
 
 # Check if required tools are installed
-if ! command -v changeset &> /dev/null && ! npx changeset --version &> /dev/null; then
-  echo -e "${RED}Error: changesets CLI not found${NC}"
-  echo "Please install changesets: pnpm add -D @changesets/cli"
+MISSING_TOOLS=()
+for tool in pnpm changeset jq jsr; do
+  if ! command -v "$tool" &> /dev/null; then
+    MISSING_TOOLS+=("$tool")
+  fi
+done
+
+# Special check for changeset via npx
+if [[ " ${MISSING_TOOLS[@]} " =~ " changeset " ]] && command -v npx &> /dev/null && npx changeset --version &> /dev/null 2>&1; then
+  # Remove changeset from missing tools if npx can run it
+  MISSING_TOOLS=("${MISSING_TOOLS[@]/changeset}")
+fi
+
+if [[ ${#MISSING_TOOLS[@]} -gt 0 ]]; then
+  echo -e "${RED}Error: Missing required tools: ${MISSING_TOOLS[*]}${NC}"
+  echo -e "\nPlease install:"
+  for tool in "${MISSING_TOOLS[@]}"; do
+    case "$tool" in
+      pnpm) echo "  - pnpm: https://pnpm.io/installation" ;;
+      changeset) echo "  - changesets: pnpm add -D @changesets/cli" ;;
+      jq) echo "  - jq: https://stedolan.github.io/jq/download/" ;;
+      jsr) echo "  - jsr: https://jsr.io/docs/cli" ;;
+    esac
+  done
   exit 1
 fi
 
-if ! command -v jq &> /dev/null; then
-  echo -e "${RED}Error: jq is required for JSON processing${NC}"
-  echo "Please install jq: https://stedolan.github.io/jq/download/"
-  exit 1
-fi
-
-# Create snapshot versions
+# Create snapshot versions with unique timestamp
 echo -e "\n${GREEN}Creating snapshot versions...${NC}"
+
+# Generate unique timestamp with milliseconds to avoid duplicates
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+SHORT_SHA=$(git rev-parse --short HEAD)
+UNIQUE_TAG="${TAG}-${TIMESTAMP}-${SHORT_SHA}"
+
 if [[ "$DRY_RUN" == true ]]; then
-  echo "(DRY RUN) Would run: pnpm changeset version --snapshot ${TAG}"
+  echo "(DRY RUN) Would run: pnpm changeset version --snapshot ${UNIQUE_TAG}"
 else
   # Capture output to check for warnings
-  VERSION_OUTPUT=$(pnpm changeset version --snapshot "${TAG}" 2>&1)
+  # In CI, ensure we don't get interactive prompts
+  if [[ -t 0 ]]; then
+    VERSION_OUTPUT=$(pnpm changeset version --snapshot "${UNIQUE_TAG}" 2>&1)
+  else
+    VERSION_OUTPUT=$(CI=true pnpm changeset version --snapshot "${UNIQUE_TAG}" 2>&1)
+  fi
   echo "$VERSION_OUTPUT"
   
   # Check if changesets warned about no unreleased changesets
@@ -148,7 +194,7 @@ else
   
   # Update JSR versions to match
   echo -e "\n${GREEN}Syncing JSR versions...${NC}"
-  ./scripts/update-jsr-json-version.sh
+  "${SCRIPT_DIR}/update-jsr-json-version.sh"
 fi
 
 # Show what would be published
@@ -199,7 +245,10 @@ if [[ "$DRY_RUN" == true ]]; then
 else
   if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
     echo -e "\n${GREEN}Publishing edge-worker to JSR...${NC}"
-    (cd pkgs/edge-worker && jsr publish --allow-slow-types || true)
+    if ! (cd "pkgs/edge-worker" && jsr publish --allow-slow-types); then
+      echo -e "${YELLOW}Warning: JSR publish failed - continuing${NC}"
+      echo -e "${YELLOW}You may need to manually publish to JSR or check your authentication${NC}"
+    fi
   fi
 fi
 
@@ -209,7 +258,8 @@ if [[ "$DRY_RUN" != true ]]; then
   echo -e "\n${BLUE}Copy and paste to install:${NC}\n"
   
   # Create machine-readable output for CI
-  SNAPSHOT_OUTPUT_FILE="/tmp/snapshot-release-output.json"
+  SNAPSHOT_OUTPUT_DIR="${TMPDIR:-/tmp}"
+  SNAPSHOT_OUTPUT_FILE="${SNAPSHOT_OUTPUT_DIR}/snapshot-release-output.json"
   echo '{"packages":[' > "$SNAPSHOT_OUTPUT_FILE"
   FIRST_PKG=true
   
@@ -242,7 +292,11 @@ if [[ "$DRY_RUN" != true ]]; then
   fi
   
   echo "]}" >> "$SNAPSHOT_OUTPUT_FILE"
-  echo -e "\n${GREEN}Machine-readable output saved to: ${SNAPSHOT_OUTPUT_FILE}${NC}"
+  if [[ -f "$SNAPSHOT_OUTPUT_FILE" ]]; then
+    echo -e "\n${GREEN}Machine-readable output saved to: ${SNAPSHOT_OUTPUT_FILE}${NC}"
+  else
+    echo -e "\n${YELLOW}Warning: Failed to create machine-readable output file${NC}"
+  fi
 fi
 
 # Cleanup happens automatically via trap on exit

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -1,299 +1,79 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+set -euo pipefail               # abort on first error, unset var or pipe-fail
 
-# Helper script for creating and publishing snapshot releases
-# Safe to use both locally and in CI on branches
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+# Quick check for required tool
+command -v jq >/dev/null || { echo "jq is required"; exit 1; }
 
-# Cleanup function to restore versions on exit
-cleanup() {
-  if [[ "${CLEANUP_NEEDED:-false}" == true && "$DRY_RUN" != true ]]; then
-    echo -e "\n${GREEN}Restoring original versions...${NC}"
-    cd "$ROOT_DIR"
-    # Try git restore first (git 2.23+), fallback to git checkout for older versions
-    if git restore --source=HEAD -- ':/**/package.json' ':/**/jsr.json' pnpm-lock.yaml package-lock.yaml yarn.lock 2>/dev/null; then
-      echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
-    elif git checkout HEAD -- '**/package.json' '**/jsr.json' pnpm-lock.yaml package-lock.yaml yarn.lock 2>/dev/null; then
-      echo -e "${GREEN}Original versions restored - branch is clean!${NC}"
-    else
-      echo -e "${YELLOW}Warning: Could not automatically restore versions. You may need to manually reset changes.${NC}"
-    fi
-  fi
-}
-trap cleanup EXIT
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Default values
-TAG=""
-DRY_RUN=false
-NO_GIT_TAG="--no-git-tag" # Default to no git tags for snapshots
-ALLOW_UNCOMMITTED_CHANGESETS=false
-
-# Function to print usage
-usage() {
-  echo "Usage: $0 [snapshot-tag] [options]"
-  echo ""
-  echo "Options:"
-  echo "  --dry-run                      Run without actually publishing"
-  echo "  --allow-uncommitted-changesets Allow uncommitted changeset files"
-  echo "  --help                         Show this help message"
-  echo ""
-  echo "Examples:"
-  echo "  $0                      # Create snapshot with branch name as tag"
-  echo "  $0 my-feature           # Create snapshot with 'my-feature' tag"
-  echo "  $0 fix-123 --dry-run    # Dry run for 'fix-123' snapshot"
-  echo "  $0 --allow-uncommitted-changesets  # Allow dirty changesets"
-  echo ""
-  echo "Note: Packages are published with exact versions (no dist-tags)"
-  echo "      Install with: npm install @pgflow/core@0.0.0-TAG-TIMESTAMP-SHA"
-  exit 0
-}
-
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    --allow-uncommitted-changesets)
-      ALLOW_UNCOMMITTED_CHANGESETS=true
-      shift
-      ;;
-    --help)
-      usage
-      ;;
-    *)
-      if [[ -z "$TAG" ]]; then
-        TAG="$1"
-      fi
-      shift
-      ;;
-  esac
-done
-
-# Generate default tag if not provided
-if [[ -z "$TAG" ]]; then
-  # Use branch name or commit hash as default tag
-  BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-  if [[ "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "" && "$BRANCH_NAME" != "main" ]]; then
-    # Clean branch name to be npm-compatible (lowercase, alphanumeric + hyphen)
-    TAG=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+# ------------------------------------------------------------------
+# 1. Resolve snapshot tag
+# ------------------------------------------------------------------
+TAG=${1:-}                      # first arg or empty
+if [[ -z $TAG ]]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [[ $BRANCH != "main" && $BRANCH != "HEAD" ]]; then
+    TAG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-')
+    # Handle edge case where tag becomes only dashes
+    [[ $TAG =~ ^-+$ ]] && TAG=$(git rev-parse --short HEAD)
   else
-    # Fallback to short commit hash
     TAG=$(git rev-parse --short HEAD)
   fi
 fi
 
-# Validate tag format (npm package name rules)
-if [[ ! "$TAG" =~ ^[a-z0-9][a-z0-9-]{0,127}$ ]]; then
-  echo -e "${RED}Error: Invalid tag format '${TAG}'${NC}"
-  echo -e "${YELLOW}Tag must start with lowercase letter or number, and contain only lowercase letters, numbers, and hyphens.${NC}"
-  echo -e "${YELLOW}Maximum length: 128 characters${NC}"
-  exit 1
+TS=$(date +%Y%m%d%H%M%S)
+SHA=$(git rev-parse --short HEAD)
+SNAPSHOT="$TAG-$TS-$SHA"        # 0.0.0-TAG-TIMESTAMP-SHA will be added by changesets
+
+# ------------------------------------------------------------------
+# 2. Clean-up on exit (always keep branch clean)
+# ------------------------------------------------------------------
+trap 'git restore --source=HEAD --worktree --staged \
+      "**/package.json" "**/jsr.json" pnpm-lock.yaml 2>/dev/null || true' EXIT
+
+# ------------------------------------------------------------------
+# 3. Create versions
+# ------------------------------------------------------------------
+pnpm changeset version --snapshot "$SNAPSHOT"
+"$ROOT/scripts/update-jsr-json-version.sh"          # keep JSR versions in sync
+
+# ------------------------------------------------------------------
+# 4. Collect list of packages only once
+# ------------------------------------------------------------------
+mapfile -t PKGS < <(
+  find pkgs -name package.json -not -path "*/node_modules/*" -print0 |
+  xargs -0 jq -r '.name + "@" + .version' |
+  grep '^@pgflow/.*0\.0\.0-'                 # only freshly versioned snapshots
+)
+
+[[ ${#PKGS[@]} -eq 0 ]] && { echo "Nothing to publish, aborting"; exit 1; }
+
+echo "Publishing the following packages:"
+printf '  %s\n' "${PKGS[@]}"
+
+# ------------------------------------------------------------------
+# 5. Publish – npm first, then JSR
+# ------------------------------------------------------------------
+pnpm changeset publish --tag snapshot --no-git-tag-version
+
+if [[ -f pkgs/edge-worker/jsr.json ]]; then
+  ( cd pkgs/edge-worker && pnpm jsr publish --allow-slow-types --allow-dirty ) \
+    || echo "⚠️  JSR publish failed (continuing)"
 fi
 
-echo -e "${GREEN}=== pgflow Snapshot Release ===${NC}"
-echo -e "${GREEN}Snapshot tag: ${YELLOW}${TAG}${NC}"
-echo ""
+# ------------------------------------------------------------------
+# 6. Show ready-to-copy install commands
+# ------------------------------------------------------------------
+echo -e "\nInstall snapshot versions with:"
+for P in "${PKGS[@]}"; do
+  [[ $P == "@pgflow/edge-worker"* ]] && continue
+  echo "npm install $P"
+done
 
-# Check if we have uncommitted changes
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo -e "${YELLOW}Warning: You have uncommitted changes${NC}"
-
-  # Check specifically for uncommitted changesets
-  if git ls-files --others --exclude-standard .changeset/*.md | grep -q .; then
-    if [[ "$ALLOW_UNCOMMITTED_CHANGESETS" == true ]]; then
-      echo -e "${YELLOW}Note: Proceeding with uncommitted changeset files (--allow-uncommitted-changesets)${NC}"
-    else
-      echo -e "${RED}Error: Uncommitted changeset files detected!${NC}"
-      echo -e "${YELLOW}Please commit your changesets before creating a snapshot release.${NC}"
-      echo -e "\nThis prevents losing your changeset messages during cleanup."
-      echo -e "\nYou can either:"
-      echo -e "  1. Commit your changesets: ${GREEN}git add .changeset/*.md && git commit -m 'Add changeset'${NC}"
-      echo -e "  2. Use the flag: ${GREEN}--allow-uncommitted-changesets${NC}"
-      exit 1
-    fi
-  fi
-
-  if [[ "$DRY_RUN" != true ]]; then
-    # In CI, abort on uncommitted changes. In interactive mode, ask.
-    if [[ -t 0 ]]; then
-      read -p "Continue with other uncommitted changes? (y/N) " -n 1 -r
-      echo
-      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo -e "${RED}Aborted${NC}"
-        exit 1
-      fi
-    else
-      echo -e "${RED}Error: Uncommitted changes detected in CI environment${NC}"
-      exit 1
-    fi
-  fi
+if [[ -f pkgs/edge-worker/jsr.json ]]; then
+  EDGE_VER=$(jq -r '.version' pkgs/edge-worker/jsr.json)
+  echo ""
+  echo "# JSR (for Deno/Supabase Edge Functions):"
+  echo "import { EdgeWorker } from \"jsr:@pgflow/edge-worker@$EDGE_VER\""
 fi
-
-# Navigate to root directory
-cd "$ROOT_DIR"
-
-# Quick check for required tools (script will fail anyway if missing due to set -e)
-if ! command -v pnpm &> /dev/null; then
-  echo -e "${RED}Error: pnpm is required. Install from https://pnpm.io/installation${NC}"
-  exit 1
-fi
-
-if ! command -v jq &> /dev/null; then
-  echo -e "${RED}Error: jq is required for JSON parsing${NC}"
-  exit 1
-fi
-
-# Create snapshot versions with unique timestamp
-echo -e "\n${GREEN}Creating snapshot versions...${NC}"
-
-# Generate unique timestamp with milliseconds to avoid duplicates
-TIMESTAMP=$(date +%Y%m%d%H%M%S)
-SHORT_SHA=$(git rev-parse --short HEAD)
-UNIQUE_TAG="${TAG}-${TIMESTAMP}-${SHORT_SHA}"
-
-if [[ "$DRY_RUN" == true ]]; then
-  echo "(DRY RUN) Would run: pnpm changeset version --snapshot ${UNIQUE_TAG}"
-else
-  # Capture output to check for warnings
-  # In CI, ensure we don't get interactive prompts
-  if [[ -t 0 ]]; then
-    VERSION_OUTPUT=$(pnpm changeset version --snapshot "${UNIQUE_TAG}" 2>&1)
-  else
-    VERSION_OUTPUT=$(CI=true pnpm changeset version --snapshot "${UNIQUE_TAG}" 2>&1)
-  fi
-  echo "$VERSION_OUTPUT"
-
-  # Check if changesets warned about no unreleased changesets
-  if echo "$VERSION_OUTPUT" | grep -q "No unreleased changesets found"; then
-    echo -e "\n${YELLOW}Warning: No changesets found!${NC}"
-    echo -e "${YELLOW}Snapshot releases require changesets to determine which packages to publish.${NC}"
-    echo -e "\nTo create a snapshot release:"
-    echo -e "  1. Run ${GREEN}pnpm changeset${NC} to create a changeset"
-    echo -e "  2. Run this script again"
-    echo -e "\n${RED}Aborting to prevent publishing existing versions.${NC}"
-    exit 1
-  fi
-
-  # Mark that cleanup is needed from this point
-  CLEANUP_NEEDED=true
-
-  # Update JSR versions to match
-  echo -e "\n${GREEN}Syncing JSR versions...${NC}"
-  "${SCRIPT_DIR}/update-jsr-json-version.sh"
-fi
-
-# Show what would be published
-echo -e "\n${GREEN}Packages to be published:${NC}"
-SNAPSHOT_PACKAGES=""
-SNAPSHOT_COUNT=0
-
-if [[ "$DRY_RUN" == true ]]; then
-  echo "(DRY RUN) Would show packages with version 0.0.0-${TAG}-*"
-else
-  # Find packages with snapshot versions
-  while IFS= read -r pkg; do
-    if grep -q "\"version\": \"0.0.0-" "$pkg" 2>/dev/null; then
-      PKG_NAME=$(jq -r .name "$pkg" 2>/dev/null || echo "unknown")
-      PKG_VERSION=$(jq -r .version "$pkg" 2>/dev/null || echo "unknown")
-      echo -e "  ${BLUE}${PKG_NAME}${NC} @ ${YELLOW}${PKG_VERSION}${NC}"
-      SNAPSHOT_PACKAGES="${SNAPSHOT_PACKAGES}${PKG_NAME}@${PKG_VERSION}\n"
-      ((SNAPSHOT_COUNT++))
-    fi
-  done < <(find pkgs -name "package.json" -not -path "*/node_modules/*")
-
-  # Safety check: ensure we have snapshot versions before proceeding
-  if [[ $SNAPSHOT_COUNT -eq 0 ]]; then
-    echo -e "\n${RED}Error: No snapshot versions found!${NC}"
-    echo -e "${YELLOW}This usually means no changesets were applied.${NC}"
-    echo -e "\nPlease ensure you have:"
-    echo -e "  1. Created changesets with ${GREEN}pnpm changeset${NC}"
-    echo -e "  2. Not already published these changes"
-    exit 1
-  fi
-fi
-
-# Publish to npm
-# IMPORTANT: We use --tag snapshot to avoid polluting the "latest" tag
-# npm ALWAYS requires a dist-tag, so we use "snapshot" which users won't accidentally install
-if [[ "$DRY_RUN" == true ]]; then
-  echo -e "\n${YELLOW}DRY RUN: Skipping npm publish${NC}"
-  echo "Would run: pnpm changeset publish --tag snapshot ${NO_GIT_TAG}"
-else
-  echo -e "\n${GREEN}Publishing to npm with 'snapshot' tag (to protect 'latest')...${NC}"
-  pnpm changeset publish --tag snapshot ${NO_GIT_TAG}
-fi
-
-# Publish edge-worker to JSR (without dist-tags)
-if [[ "$DRY_RUN" == true ]]; then
-  echo -e "\n${YELLOW}DRY RUN: Skipping JSR publish${NC}"
-  echo "Would run: cd pkgs/edge-worker && jsr publish --allow-slow-types --allow-dirty"
-else
-  if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
-    echo -e "\n${GREEN}Publishing edge-worker to JSR...${NC}"
-    # Use --allow-dirty since we have uncommitted version changes
-    if ! (cd "pkgs/edge-worker" && pnpm jsr publish --allow-slow-types --allow-dirty); then
-      echo -e "${YELLOW}Warning: JSR publish failed - continuing${NC}"
-      echo -e "${YELLOW}You may need to manually publish to JSR or check your authentication${NC}"
-    fi
-  fi
-fi
-
-# Print installation instructions
-if [[ "$DRY_RUN" != true ]]; then
-  echo -e "\n${GREEN}=== Snapshot Release Complete! ===${NC}"
-  echo -e "\n${BLUE}Copy and paste to install:${NC}\n"
-
-  # Create machine-readable output for CI
-  SNAPSHOT_OUTPUT_DIR="${TMPDIR:-/tmp}"
-  SNAPSHOT_OUTPUT_FILE="${SNAPSHOT_OUTPUT_DIR}/snapshot-release-output.json"
-  echo '{"packages":[' > "$SNAPSHOT_OUTPUT_FILE"
-  FIRST_PKG=true
-
-  # Print npm install commands
-  echo -e "${YELLOW}# NPM packages:${NC}"
-  while IFS= read -r pkg; do
-    if grep -q "\"version\": \"0.0.0-" "$pkg" 2>/dev/null; then
-      PKG_NAME=$(jq -r .name "$pkg" 2>/dev/null || echo "unknown")
-      PKG_VERSION=$(jq -r .version "$pkg" 2>/dev/null || echo "unknown")
-      if [[ "$PKG_NAME" != "@pgflow/edge-worker" ]]; then
-        echo "npm install ${PKG_NAME}@${PKG_VERSION}"
-        # Add to JSON output
-        if [[ "$FIRST_PKG" != true ]]; then echo "," >> "$SNAPSHOT_OUTPUT_FILE"; fi
-        echo -n "{\"name\":\"${PKG_NAME}\",\"version\":\"${PKG_VERSION}\",\"registry\":\"npm\"}" >> "$SNAPSHOT_OUTPUT_FILE"
-        FIRST_PKG=false
-      fi
-    fi
-  done < <(find pkgs -name "package.json" -not -path "*/node_modules/*")
-
-  # Print JSR install command
-  if [[ -f "pkgs/edge-worker/jsr.json" ]]; then
-    EDGE_WORKER_VERSION=$(jq -r .version "pkgs/edge-worker/jsr.json" 2>/dev/null || echo "unknown")
-    echo -e "\n${YELLOW}# JSR package:${NC}"
-    echo "deno add @pgflow/edge-worker@${EDGE_WORKER_VERSION}"
-    echo -e "\n${YELLOW}# Or in import map:${NC}"
-    echo "\"@pgflow/edge-worker\": \"jsr:@pgflow/edge-worker@${EDGE_WORKER_VERSION}\""
-    # Add to JSON output
-    if [[ "$FIRST_PKG" != true ]]; then echo "," >> "$SNAPSHOT_OUTPUT_FILE"; fi
-    echo -n "{\"name\":\"@pgflow/edge-worker\",\"version\":\"${EDGE_WORKER_VERSION}\",\"registry\":\"jsr\"}" >> "$SNAPSHOT_OUTPUT_FILE"
-  fi
-
-  echo "]}" >> "$SNAPSHOT_OUTPUT_FILE"
-  if [[ -f "$SNAPSHOT_OUTPUT_FILE" ]]; then
-    echo -e "\n${GREEN}Machine-readable output saved to: ${SNAPSHOT_OUTPUT_FILE}${NC}"
-  else
-    echo -e "\n${YELLOW}Warning: Failed to create machine-readable output file${NC}"
-  fi
-fi
-
-# Cleanup happens automatically via trap on exit

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -143,31 +143,14 @@ fi
 # Navigate to root directory
 cd "$ROOT_DIR"
 
-# Check if required tools are installed
-MISSING_TOOLS=()
-for tool in pnpm changeset jq jsr; do
-  if ! command -v "$tool" &> /dev/null; then
-    MISSING_TOOLS+=("$tool")
-  fi
-done
-
-# Special check for changeset via npx
-if [[ " ${MISSING_TOOLS[@]} " =~ " changeset " ]] && command -v npx &> /dev/null && npx changeset --version &> /dev/null 2>&1; then
-  # Remove changeset from missing tools if npx can run it
-  MISSING_TOOLS=("${MISSING_TOOLS[@]/changeset}")
+# Quick check for required tools (script will fail anyway if missing due to set -e)
+if ! command -v pnpm &> /dev/null; then
+  echo -e "${RED}Error: pnpm is required. Install from https://pnpm.io/installation${NC}"
+  exit 1
 fi
 
-if [[ ${#MISSING_TOOLS[@]} -gt 0 ]]; then
-  echo -e "${RED}Error: Missing required tools: ${MISSING_TOOLS[*]}${NC}"
-  echo -e "\nPlease install:"
-  for tool in "${MISSING_TOOLS[@]}"; do
-    case "$tool" in
-      pnpm) echo "  - pnpm: https://pnpm.io/installation" ;;
-      changeset) echo "  - changesets: pnpm add -D @changesets/cli" ;;
-      jq) echo "  - jq: https://stedolan.github.io/jq/download/" ;;
-      jsr) echo "  - jsr: https://jsr.io/docs/cli" ;;
-    esac
-  done
+if ! command -v jq &> /dev/null; then
+  echo -e "${RED}Error: jq is required for JSON parsing${NC}"
   exit 1
 fi
 

--- a/scripts/update-jsr-json-version.sh
+++ b/scripts/update-jsr-json-version.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Find all directories within pkgs/ that contain both package.json and jsr.json files
-find ./pkgs -type f -name "package.json" | while read -r package_file; do
+find ./pkgs -type f -name "package.json" -print0 | while IFS= read -r -d '' package_file; do
   dir=$(dirname "$package_file")
   jsr_file="$dir/jsr.json"
 
@@ -16,7 +16,6 @@ find ./pkgs -type f -name "package.json" | while read -r package_file; do
 
     # Create a proper temporary file
     tmp_file=$(mktemp "${jsr_file}.XXXXXX")
-    trap "rm -f '$tmp_file'" EXIT
 
     # First update the package version in jsr.json
     if jq --arg version "$current_version" '.version = $version' "$jsr_file" > "$tmp_file"; then


### PR DESCRIPTION
## Summary

This PR adds a snapshot release system for creating temporary test versions of packages before merging PRs. The implementation has been dramatically simplified from 300+ lines to ~80 lines following the 80/20 principle.

## What are Snapshot Releases?

Snapshot releases create temporary versions with the format `0.0.0-{tag}-{timestamp}-{sha}` that can be published for testing without affecting the main release line. They're automatically cleaned up after publishing, keeping the branch clean.

## Key Features

- **Automatic version generation**: Uses branch name or custom tag with timestamp and SHA for uniqueness
- **npm safety**: Publishes with `snapshot` dist-tag to protect the `latest` tag from pollution
- **JSR support**: Edge-worker package publishes to both npm and JSR
- **Clean working tree**: Trap-based cleanup ensures versions are restored even on errors
- **CI integration**: Includes CI wrapper script for automated PR builds

## Usage

```bash
# Create snapshot from current branch
./scripts/snapshot-release.sh

# Create snapshot with custom tag
./scripts/snapshot-release.sh my-feature

# Allow uncommitted changesets (for quick testing)
./scripts/snapshot-release.sh --allow-uncommitted-changesets
```

## Installation

The script outputs exact installation commands:

```bash
npm install @pgflow/core@0.0.0-my-feature-20240102120000-abc1234
npm install @pgflow/cli@0.0.0-my-feature-20240102120000-abc1234

# JSR (for Deno/Supabase Edge Functions):
import { EdgeWorker } from "jsr:@pgflow/edge-worker@0.0.0-my-feature-20240102120000-abc1234"
```

## Implementation Details

The simplified implementation:
- Removed verbose output, colors, and decorative messages
- Single-pass package discovery using `mapfile`
- Relies on `set -euo pipefail` for error handling
- Minimal validation (npm will reject invalid tags)
- No machine-readable JSON (moved to CI wrapper)

## Requirements

- Bash 4+ (macOS users: `brew install bash`)
- jq for JSON parsing
- pnpm with changesets

## Fixes Included

- Proper handling of paths with spaces
- Correct grep pattern for any base version (not just 0.0.0)
- Cleanup includes `.changeset/pre.json`
- Fixed invalid `--no-git-tag-version` flag
- Added `--allow-dirty` for JSR publish