### PR TITLE
fix(edge-worker): refine task logging experience for (pgflow-dev/pgflow#167)

### DIFF
--- a/.changeset/stupid-showers-speak.md
+++ b/.changeset/stupid-showers-speak.md
@@ -1,0 +1,10 @@
+---
+'@pgflow/edge-worker': patch
+---
+
+Refine task logging levels for better visibility
+
+- Move detailed execution logs from ExecutionController to MessageExecutor
+- Demote controller-level logs from info to debug
+- Promote task execution, retry, and error logs from debug to appropriate levels (info/error)
+- Improve visibility of task lifecycle events and failures

--- a/pkgs/edge-worker/src/core/ExecutionController.ts
+++ b/pkgs/edge-worker/src/core/ExecutionController.ts
@@ -27,13 +27,13 @@ export class ExecutionController<TMessage extends IMessage> {
   async start(record: TMessage) {
     const executor = this.createExecutor(record, this.signal);
 
-    this.logger.info(`Scheduling execution of task ${executor.msgId}`);
+    this.logger.debug(`Scheduling execution of task ${executor.msgId}`);
 
     return await this.promiseQueue.add(async () => {
       try {
         this.logger.debug(`Executing task ${executor.msgId}...`);
         await executor.execute();
-        this.logger.info(`Execution successful for ${executor.msgId}`);
+        this.logger.debug(`Execution successful for ${executor.msgId}`);
       } catch (error) {
         this.logger.error(`Execution failed for ${executor.msgId}`, error);
         throw error;


### PR DESCRIPTION
- Move info logging from ExecutionController to MessageExecutor to get more granular detail about failure and retry
- Current version displays "successful execution" even if technically worker crashed and will be restarted.
- Moving error logging for exception in worker from .debug to .error
- More task retry details from .debug to .info
