### PR TITLE
refactor: unify Supabase client usage across platform and flows

### DIFF
--- a/.changeset/calm-mails-swim.md
+++ b/.changeset/calm-mails-swim.md
@@ -1,0 +1,27 @@
+---
+'@pgflow/edge-worker': patch
+'@pgflow/website': patch
+'@pgflow/dsl': patch
+---
+
+🚨 **BREAKING**: Remove `anonSupabase` and `serviceSupabase` from context, replaced with single `supabase` client (initialized with service role key)
+
+The dual-client approach was unnecessary complexity. Edge Functions run in a trusted environment with service role access, so a single client is sufficient.
+
+**Migration guide**:
+```typescript
+// Before
+const { data } = await context.supabase.from('users').select();
+const { data: publicData } = await context.anonSupabase.from('posts').select();
+
+// After
+const { data } = await context.supabase.from('users').select();
+// For RLS-respecting queries, implement proper policies in your database
+```
+
+⚠️ **Breaking changes**:
+- Removed `SUPABASE_ANON_KEY` from required environment variables
+- Removed `anonSupabase` from context interface
+- Removed `serviceSupabase` from context interface
+- Added `supabase` field (initialized with service role key)
+- Removed `createAnonSupabaseClient` function

--- a/examples/playground/supabase/functions/_flows/analyze_website.ts
+++ b/examples/playground/supabase/functions/_flows/analyze_website.ts
@@ -32,14 +32,14 @@ export default new Flow<Input>({
   })
   .step(
     { slug: 'saveToDb', dependsOn: ['summary', 'tags'] },
-    async (input, { serviceSupabase }) => {
+    async (input, { supabase }) => {
       const websiteData = {
         user_id: input.run.user_id,
         website_url: input.run.url,
         summary: input.summary,
         tags: input.tags,
       };
-      const { website } = await saveWebsite(websiteData, serviceSupabase);
+      const { website } = await saveWebsite(websiteData, supabase);
 
       return website;
     },

--- a/pkgs/dsl/CHANGELOG.md
+++ b/pkgs/dsl/CHANGELOG.md
@@ -16,7 +16,7 @@
 
   // Flow step handler
   .step({ slug: 'process' }, async (input, context) => {
-    const result = await context.serviceSupabase.from('users').select();
+    const result = await context.supabase.from('users').select();
   })
   ```
 
@@ -30,8 +30,7 @@
   **Supabase platform resources**:
 
   - `context.sql` - PostgreSQL client (postgres.js)
-  - `context.anonSupabase` - Supabase client with anonymous key
-  - `context.serviceSupabase` - Supabase client with service role key
+  - `context.supabase` - Supabase client with service role key
 
   To use Supabase resources in flows, import from the Supabase preset:
 

--- a/pkgs/dsl/README.md
+++ b/pkgs/dsl/README.md
@@ -120,8 +120,7 @@ All platforms provide these core resources:
 When using the Supabase platform with EdgeWorker, additional resources are available:
 
 - **`context.sql`** - PostgreSQL client (postgres.js)
-- **`context.anonSupabase`** - Supabase client with anonymous key
-- **`context.serviceSupabase`** - Supabase client with service role key
+- **`context.supabase`** - Supabase client with service role key for full database access
 
 To use Supabase resources, import the `Flow` class from the Supabase preset:
 
@@ -132,7 +131,7 @@ const MyFlow = new Flow<{ userId: string }>({
   slug: 'my_flow',
 }).step({ slug: 'process' }, async (input, context) => {
   // TypeScript knows context includes Supabase resources
-  const { data } = await context.serviceSupabase
+  const { data } = await context.supabase
     .from('users')
     .select('*')
     .eq('id', input.userId);

--- a/pkgs/dsl/__tests__/env-validation.test.ts
+++ b/pkgs/dsl/__tests__/env-validation.test.ts
@@ -36,8 +36,7 @@ describe('Environment Type Validation', () => {
       .step({ slug: 'process' }, async (input, ctx) => {
         // Should have all platform resources
         void ctx.sql;
-        void ctx.anonSupabase;
-        void ctx.serviceSupabase;
+        void ctx.supabase;
         
         // Plus custom resources
         ctx.logger.log('test');

--- a/pkgs/dsl/__tests__/supabase-preset.test.ts
+++ b/pkgs/dsl/__tests__/supabase-preset.test.ts
@@ -13,8 +13,7 @@ describe('Supabase Preset Flow', () => {
         // These should all be available with full types
         // without needing to annotate ctx
         void ctx.sql;
-        void ctx.anonSupabase;
-        void ctx.serviceSupabase;
+        void ctx.supabase;
         void ctx.env;
         void ctx.shutdownSignal;
         
@@ -37,8 +36,7 @@ describe('Supabase Preset Flow', () => {
       .step({ slug: 'process' }, async (input, ctx) => {
         // Should have all platform resources
         void ctx.sql;
-        void ctx.anonSupabase;
-        void ctx.serviceSupabase;
+        void ctx.supabase;
         
         // Plus custom resources
         ctx.logger.log('test');

--- a/pkgs/dsl/__tests__/types/supabase-preset.test-d.ts
+++ b/pkgs/dsl/__tests__/types/supabase-preset.test-d.ts
@@ -27,8 +27,7 @@ describe('Supabase Flow Type Tests', () => {
       (input, context) => {
         // Should have all Supabase platform resources
         expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-        expectTypeOf(context.anonSupabase).toEqualTypeOf<SupabaseClient>();
-        expectTypeOf(context.serviceSupabase).toEqualTypeOf<SupabaseClient>();
+        expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
 
         // Should still have base context
         expectTypeOf(context.env).toMatchTypeOf<SupabaseEnv>();
@@ -81,8 +80,7 @@ describe('Supabase Flow Type Tests', () => {
         (input, context: Context<{ redis: CustomRedis }>) => {
           // Should have all Supabase platform resources
           expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-          expectTypeOf(context.anonSupabase).toEqualTypeOf<SupabaseClient>();
-          expectTypeOf(context.serviceSupabase).toEqualTypeOf<SupabaseClient>();
+          expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
 
           // Should have custom resource from handler annotation
           expectTypeOf(context.redis).toEqualTypeOf<CustomRedis>();
@@ -126,8 +124,7 @@ describe('Supabase Flow Type Tests', () => {
     }).step({ slug: 'fetch_user' }, (input, context) => {
       // Should have Supabase platform resources
       expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-      expectTypeOf(context.anonSupabase).toEqualTypeOf<SupabaseClient>();
-      expectTypeOf(context.serviceSupabase).toEqualTypeOf<SupabaseClient>();
+      expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
 
       // Should have explicit custom context
       expectTypeOf(context.cache).toEqualTypeOf<CustomRedis>();
@@ -159,7 +156,7 @@ describe('Supabase Flow Type Tests', () => {
       .step({ slug: 'process' }, (input, context) => {
         // Has Supabase platform resources
         expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-        expectTypeOf(context.serviceSupabase).toEqualTypeOf<SupabaseClient>();
+        expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
 
         // Has explicit context
         expectTypeOf(context.logger).toEqualTypeOf<{
@@ -173,7 +170,7 @@ describe('Supabase Flow Type Tests', () => {
         (input, context: Context<{ ai: CustomAI }>) => {
           // Should have Supabase platform resources
           expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-          expectTypeOf(context.anonSupabase).toEqualTypeOf<SupabaseClient>();
+          expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
 
           // Should have both explicit and inferred context
           expectTypeOf(context.logger).toEqualTypeOf<{
@@ -199,8 +196,7 @@ describe('Supabase Flow Type Tests', () => {
     // Verify the SupabaseResources interface has correct structure
     expectTypeOf<SupabaseResources>().toEqualTypeOf<{
       sql: Sql;
-      anonSupabase: SupabaseClient;
-      serviceSupabase: SupabaseClient;
+      supabase: SupabaseClient;
     }>();
   });
 
@@ -235,7 +231,7 @@ describe('Supabase Flow Type Tests', () => {
 
         // Should still have all accumulated context
         expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-        expectTypeOf(context.anonSupabase).toEqualTypeOf<SupabaseClient>();
+        expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
         expectTypeOf(context.factor).toEqualTypeOf<number>();
 
         return { formatted: `Result: ${input.multiply.result}` };
@@ -279,7 +275,7 @@ describe('Supabase Flow Type Tests', () => {
       .step({ slug: 'step3' }, (input, context) => {
         // Should have Supabase platform resources without explicit typing
         expectTypeOf(context.sql).toEqualTypeOf<Sql>();
-        expectTypeOf(context.serviceSupabase).toEqualTypeOf<SupabaseClient>();
+        expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
 
         // Should have accumulated context from previous steps
         expectTypeOf(context.step1Resource).toEqualTypeOf<string>();

--- a/pkgs/dsl/src/platforms/supabase.ts
+++ b/pkgs/dsl/src/platforms/supabase.ts
@@ -10,15 +10,17 @@ import {
 /* ---------- 1. Resources ------------------------------------------- */
 export interface SupabaseResources extends Record<string, unknown> {
   sql            : Sql;
-  anonSupabase   : SupabaseClient;
-  serviceSupabase: SupabaseClient;
+  /**
+   * Supabase client with service role key for full database access
+   */
+  supabase       : SupabaseClient;
 }
 
 /* ---------- 2. Environment ----------------------------------------- */
 export interface SupabaseEnv extends Env {
   EDGE_WORKER_DB_URL      : string;
   SUPABASE_URL            : string;
-  SUPABASE_ANON_KEY       : string;
+  SUPABASE_ANON_KEY      : string;
   SUPABASE_SERVICE_ROLE_KEY: string;
   SB_EXECUTION_ID         : string;
   EDGE_WORKER_LOG_LEVEL?  : string;

--- a/pkgs/edge-worker/CHANGELOG.md
+++ b/pkgs/edge-worker/CHANGELOG.md
@@ -22,7 +22,7 @@
 
   // Flow step handler
   .step({ slug: 'process' }, async (input, context) => {
-    const result = await context.serviceSupabase.from('users').select();
+    const result = await context.supabase.from('users').select();
   })
   ```
 
@@ -36,8 +36,7 @@
   **Supabase platform resources**:
 
   - `context.sql` - PostgreSQL client (postgres.js)
-  - `context.anonSupabase` - Supabase client with anonymous key
-  - `context.serviceSupabase` - Supabase client with service role key
+  - `context.supabase` - Supabase client with service role key
 
   To use Supabase resources in flows, import from the Supabase preset:
 

--- a/pkgs/edge-worker/src/__tests__/types/flow-compatibility.test-d.ts
+++ b/pkgs/edge-worker/src/__tests__/types/flow-compatibility.test-d.ts
@@ -16,7 +16,7 @@ describe('Flow Compatibility Type Tests', () => {
       .step({ slug: 'query' }, (_input, _ctx: Context<{ sql: Sql }>) => {
         return { result: 'data' };
       })
-      .step({ slug: 'auth' }, (_input, _ctx: Context<{ anonSupabase: SupabaseClient }>) => {
+      .step({ slug: 'auth' }, (_input, _ctx: Context<{ supabase: SupabaseClient }>) => {
         return { authenticated: true };
       });
 
@@ -53,7 +53,7 @@ describe('Flow Compatibility Type Tests', () => {
       })
       .step({ slug: 'store' }, (_input, _ctx: Context<{ 
         sql: Sql,
-        serviceSupabase: SupabaseClient 
+        supabase: SupabaseClient 
       }>) => {
         return { stored: true };
       });

--- a/pkgs/edge-worker/src/core/context.ts
+++ b/pkgs/edge-worker/src/core/context.ts
@@ -10,7 +10,7 @@ import type { StepTaskRecord } from '../flow/types.js';
 
 /**
  * Context guaranteed by **any** concrete platform adapter
- * (`sql`, `anonSupabase`, … are filled in by that adapter).
+ * (`sql`, `supabase`, … are filled in by that adapter).
  */
 export type PlatformContext<
   TResources extends Record<string, unknown>

--- a/pkgs/edge-worker/src/core/supabase-test-utils.ts
+++ b/pkgs/edge-worker/src/core/supabase-test-utils.ts
@@ -7,7 +7,7 @@ import type {
   StepTaskWithMessage
 } from './context.js';
 import type { SupabaseEnv } from '@pgflow/dsl/supabase';
-import { createAnonSupabaseClient, createServiceSupabaseClient } from './supabase-utils.js';
+import { createServiceSupabaseClient } from './supabase-utils.js';
 
 /**
  * Creates a test context that mimics what SupabasePlatformAdapter provides.
@@ -21,15 +21,8 @@ export function createQueueWorkerContext<TPayload extends Json>(params: {
 }) {
   const { env, sql, abortSignal, rawMessage } = params;
 
-  // Create Supabase clients if env vars exist, otherwise create mocks
-  const anonSupabase = env.SUPABASE_URL && env.SUPABASE_ANON_KEY
-    ? createAnonSupabaseClient({
-        SUPABASE_URL: env.SUPABASE_URL,
-        SUPABASE_ANON_KEY: env.SUPABASE_ANON_KEY
-      })
-    : createMockSupabaseClient();
-
-  const serviceSupabase = env.SUPABASE_URL && env.SUPABASE_SERVICE_ROLE_KEY
+  // Create Supabase client if env vars exist, otherwise create mock
+  const supabase = env.SUPABASE_URL && env.SUPABASE_SERVICE_ROLE_KEY
     ? createServiceSupabaseClient({
         SUPABASE_URL: env.SUPABASE_URL,
         SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY
@@ -46,8 +39,7 @@ export function createQueueWorkerContext<TPayload extends Json>(params: {
     
     // Supabase-specific resources (always present in Phase 1)
     sql,
-    anonSupabase,
-    serviceSupabase
+    supabase
   };
 }
 
@@ -64,15 +56,8 @@ export function createFlowWorkerContext<TFlow extends AnyFlow = AnyFlow>(params:
 }) {
   const { env, sql, abortSignal, taskWithMessage } = params;
 
-  // Create Supabase clients if env vars exist, otherwise create mocks
-  const anonSupabase = env.SUPABASE_URL && env.SUPABASE_ANON_KEY
-    ? createAnonSupabaseClient({
-        SUPABASE_URL: env.SUPABASE_URL,
-        SUPABASE_ANON_KEY: env.SUPABASE_ANON_KEY
-      })
-    : createMockSupabaseClient();
-
-  const serviceSupabase = env.SUPABASE_URL && env.SUPABASE_SERVICE_ROLE_KEY
+  // Create Supabase client if env vars exist, otherwise create mock
+  const supabase = env.SUPABASE_URL && env.SUPABASE_SERVICE_ROLE_KEY
     ? createServiceSupabaseClient({
         SUPABASE_URL: env.SUPABASE_URL,
         SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY
@@ -94,8 +79,7 @@ export function createFlowWorkerContext<TFlow extends AnyFlow = AnyFlow>(params:
     
     // Supabase-specific resources (always present in Phase 1)
     sql,
-    anonSupabase,
-    serviceSupabase
+    supabase
   };
 }
 

--- a/pkgs/edge-worker/src/core/supabase-utils.ts
+++ b/pkgs/edge-worker/src/core/supabase-utils.ts
@@ -2,28 +2,14 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 interface SupabaseClientEnv {
   SUPABASE_URL: string;
-  SUPABASE_ANON_KEY?: string;
-  SUPABASE_SERVICE_ROLE_KEY?: string;
-}
-
-/**
- * Creates an anonymous Supabase client.
- * Expects SUPABASE_URL and SUPABASE_ANON_KEY to be present in env.
- */
-export function createAnonSupabaseClient(env: SupabaseClientEnv & { SUPABASE_ANON_KEY: string }): SupabaseClient {
-  return createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
-    auth: {
-      persistSession: false,
-      autoRefreshToken: false,
-    },
-  });
+  SUPABASE_SERVICE_ROLE_KEY: string;
 }
 
 /**
  * Creates a service role Supabase client.
  * Expects SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY to be present in env.
  */
-export function createServiceSupabaseClient(env: SupabaseClientEnv & { SUPABASE_SERVICE_ROLE_KEY: string }): SupabaseClient {
+export function createServiceSupabaseClient(env: SupabaseClientEnv): SupabaseClient {
   return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
     auth: {
       persistSession: false,

--- a/pkgs/edge-worker/src/examples/supabase-flow-example.ts
+++ b/pkgs/edge-worker/src/examples/supabase-flow-example.ts
@@ -12,8 +12,8 @@ const myFlow = new Flow({ slug: 'supabase_example' })
     return { users };
   })
   .step({ slug: 'notify_admin' }, async (input, ctx) => {
-    // All Supabase resources available
-    const { data: _data, error } = await ctx.serviceSupabase
+    // Supabase client available with service role access
+    const { data: _data, error } = await ctx.supabase
       .from('admin_notifications')
       .insert({
         message: `Found ${input.query_users.users.length} active users`,
@@ -24,8 +24,8 @@ const myFlow = new Flow({ slug: 'supabase_example' })
     return { notified: true };
   })
   .step({ slug: 'public_update' }, async (input, ctx) => {
-    // Can use anon client for public operations
-    const { data: _data } = await ctx.anonSupabase
+    // Use the same client for all operations
+    const { data: _data } = await ctx.supabase
       .from('public_stats')
       .update({ last_user_count: input.query_users.users.length })
       .eq('id', 1);

--- a/pkgs/edge-worker/src/examples/type-check-example.ts
+++ b/pkgs/edge-worker/src/examples/type-check-example.ts
@@ -9,8 +9,8 @@ const validFlow = new Flow({ slug: 'valid_flow' })
     const result = await ctx.sql`SELECT * FROM users`;
     return { users: result };
   })
-  .step({ slug: 'notify' }, (_input, _ctx: { serviceSupabase: SupabaseClient }) => {
-    // Use service role client for admin operations
+  .step({ slug: 'notify' }, (_input, _ctx: { supabase: SupabaseClient }) => {
+    // Use Supabase client for operations
     return { notified: true };
   });
 

--- a/pkgs/edge-worker/src/test/test-helpers.ts
+++ b/pkgs/edge-worker/src/test/test-helpers.ts
@@ -9,7 +9,7 @@ import type {
   SupabaseStepTaskContext
 } from '../core/context.js';
 import type { StepTaskRecord } from '../flow/types.js';
-import { createAnonSupabaseClient, createServiceSupabaseClient } from '../core/supabase-utils.js';
+import { createServiceSupabaseClient } from '../core/supabase-utils.js';
 
 /**
  * Creates a full Supabase context for testing message handlers.
@@ -25,14 +25,10 @@ export function createSupabaseMessageContext<TPayload extends Json = Json>(param
 
   // Validate required environment variables
   const supabaseUrl = env.SUPABASE_URL;
-  const supabaseAnonKey = env.SUPABASE_ANON_KEY;
   const supabaseServiceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl) {
     throw new Error('SUPABASE_URL environment variable is required but not defined');
-  }
-  if (!supabaseAnonKey) {
-    throw new Error('SUPABASE_ANON_KEY environment variable is required but not defined');
   }
   if (!supabaseServiceRoleKey) {
     throw new Error('SUPABASE_SERVICE_ROLE_KEY environment variable is required but not defined');
@@ -40,12 +36,7 @@ export function createSupabaseMessageContext<TPayload extends Json = Json>(param
 
   // In production, these would be validated at startup
   // For tests, we create them on demand
-  const anonSupabase = createAnonSupabaseClient({
-    SUPABASE_URL: supabaseUrl,
-    SUPABASE_ANON_KEY: supabaseAnonKey
-  });
-
-  const serviceSupabase = createServiceSupabaseClient({
+  const supabase = createServiceSupabaseClient({
     SUPABASE_URL: supabaseUrl,
     SUPABASE_SERVICE_ROLE_KEY: supabaseServiceRoleKey
   });
@@ -60,8 +51,7 @@ export function createSupabaseMessageContext<TPayload extends Json = Json>(param
     
     // Supabase-specific resources (always present)
     sql,
-    anonSupabase,
-    serviceSupabase
+    supabase
   };
 }
 
@@ -80,14 +70,10 @@ export function createSupabaseStepTaskContext<TFlow extends AnyFlow>(params: {
 
   // Validate required environment variables
   const supabaseUrl = env.SUPABASE_URL;
-  const supabaseAnonKey = env.SUPABASE_ANON_KEY;
   const supabaseServiceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl) {
     throw new Error('SUPABASE_URL environment variable is required but not defined');
-  }
-  if (!supabaseAnonKey) {
-    throw new Error('SUPABASE_ANON_KEY environment variable is required but not defined');
   }
   if (!supabaseServiceRoleKey) {
     throw new Error('SUPABASE_SERVICE_ROLE_KEY environment variable is required but not defined');
@@ -95,12 +81,7 @@ export function createSupabaseStepTaskContext<TFlow extends AnyFlow>(params: {
 
   // In production, these would be validated at startup
   // For tests, we create them on demand
-  const anonSupabase = createAnonSupabaseClient({
-    SUPABASE_URL: supabaseUrl,
-    SUPABASE_ANON_KEY: supabaseAnonKey
-  });
-
-  const serviceSupabase = createServiceSupabaseClient({
+  const supabase = createServiceSupabaseClient({
     SUPABASE_URL: supabaseUrl,
     SUPABASE_SERVICE_ROLE_KEY: supabaseServiceRoleKey
   });
@@ -116,8 +97,7 @@ export function createSupabaseStepTaskContext<TFlow extends AnyFlow>(params: {
     
     // Supabase-specific resources (always present)
     sql,
-    anonSupabase,
-    serviceSupabase
+    supabase
   };
 }
 
@@ -136,8 +116,7 @@ export function createMockSupabaseClient(): SupabaseClient {
 export function createMockSupabaseResources(overrides?: Partial<SupabaseResources>): SupabaseResources {
   return {
     sql: {} as unknown as Sql,
-    anonSupabase: createMockSupabaseClient(),
-    serviceSupabase: createMockSupabaseClient(),
+    supabase: createMockSupabaseClient(),
     ...overrides
   };
 }

--- a/pkgs/edge-worker/tests/integration/_helpers.ts
+++ b/pkgs/edge-worker/tests/integration/_helpers.ts
@@ -7,12 +7,11 @@ import type { postgres } from '../sql.ts';
 import { PgflowSqlClient } from '@pgflow/core';
 import type { PlatformAdapter, CreateWorkerFn } from '../../src/platform/types.ts';
 import type { SupabaseResources, SupabaseEnv } from '@pgflow/dsl/supabase';
-import { createAnonSupabaseClient, createServiceSupabaseClient } from '../../src/core/supabase-utils.ts';
+import { createServiceSupabaseClient } from '../../src/core/supabase-utils.ts';
 
 const DEFAULT_TEST_SUPABASE_ENV: SupabaseEnv = {
   EDGE_WORKER_DB_URL: 'postgresql://postgres:postgres@localhost:5432/postgres',
   SUPABASE_URL: 'https://test.supabase.co',
-  SUPABASE_ANON_KEY: 'test-anon-key',
   SUPABASE_SERVICE_ROLE_KEY: 'test-service-key',
   SB_EXECUTION_ID: 'test-execution-id',
 };
@@ -32,8 +31,7 @@ export function createTestPlatformAdapter(sql: postgres.Sql): PlatformAdapter<Su
 
   const platformResources: SupabaseResources = {
     sql,
-    anonSupabase: createAnonSupabaseClient(DEFAULT_TEST_SUPABASE_ENV),
-    serviceSupabase: createServiceSupabaseClient(DEFAULT_TEST_SUPABASE_ENV),
+    supabase: createServiceSupabaseClient(DEFAULT_TEST_SUPABASE_ENV),
   };
 
   return {

--- a/pkgs/edge-worker/tests/integration/flow/contextResourcesFlow.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/contextResourcesFlow.test.ts
@@ -18,11 +18,7 @@ const ContextResourcesFlow = new Flow<{ testId: number }>({
     'context.shutdownSignal should be provided'
   );
   assertExists(context.sql, 'context.sql should be provided');
-  assertExists(context.anonSupabase, 'context.anonSupabase should be provided');
-  assertExists(
-    context.serviceSupabase,
-    'context.serviceSupabase should be provided'
-  );
+  assertExists(context.supabase, 'context.supabase should be provided');
   assertExists(context.rawMessage, 'context.rawMessage should be provided');
   assertExists(context.stepTask, 'context.stepTask should be provided');
 
@@ -34,14 +30,9 @@ const ContextResourcesFlow = new Flow<{ testId: number }>({
   );
   assertEquals(typeof context.sql, 'function', 'sql should be function');
   assertEquals(
-    typeof context.anonSupabase,
+    typeof context.supabase,
     'object',
-    'anonSupabase should be object'
-  );
-  assertEquals(
-    typeof context.serviceSupabase,
-    'object',
-    'serviceSupabase should be object'
+    'supabase should be object'
   );
   assertEquals(
     typeof context.rawMessage,

--- a/pkgs/edge-worker/tests/integration/messageExecutorContext.test.ts
+++ b/pkgs/edge-worker/tests/integration/messageExecutorContext.test.ts
@@ -162,16 +162,14 @@ Deno.test(
 
     const abortController = new AbortController();
 
-    let anonClientExists = false;
-    let serviceClientExists = false;
+    let supabaseClientExists = false;
 
-    // Handler that checks Supabase clients - TypeScript infers the exact type
+    // Handler that checks Supabase client - TypeScript infers the exact type
     const handler = (
       _payload: { test: string },
       context?: ReturnType<typeof createQueueWorkerContext<{ test: string }>>
     ) => {
-      anonClientExists = context?.anonSupabase !== undefined;
-      serviceClientExists = context?.serviceSupabase !== undefined;
+      supabaseClientExists = context?.supabase !== undefined;
     };
 
     // Create context with Supabase env vars
@@ -185,8 +183,7 @@ Deno.test(
     // Mock handler call with context
     await handler(mockMessage.message!, context);
 
-    // Verify Supabase clients are available
-    assertEquals(anonClientExists, true);
-    assertEquals(serviceClientExists, true);
+    // Verify Supabase client is available
+    assertEquals(supabaseClientExists, true);
   })
 );

--- a/pkgs/edge-worker/tests/integration/stepTaskExecutorContext.test.ts
+++ b/pkgs/edge-worker/tests/integration/stepTaskExecutorContext.test.ts
@@ -90,8 +90,7 @@ Deno.test(
     assertEquals(receivedContext.sql, _sql);
     assertEquals(receivedContext.shutdownSignal, abortController.signal);
     assertExists(receivedContext.env);
-    assertExists(receivedContext.anonSupabase);
-    assertExists(receivedContext.serviceSupabase);
+    assertExists(receivedContext.supabase);
   })
 );
 
@@ -202,15 +201,13 @@ Deno.test(
   withTransaction(async (_sql) => {
     const abortController = new AbortController();
 
-    let anonClientExists = false;
-    let serviceClientExists = false;
+    let supabaseClientExists = false;
 
-    // Flow that checks Supabase clients
+    // Flow that checks Supabase client
     const SupabaseFlow = new Flow<Record<string, never>>({ slug: 'supabase_flow' }).step(
       { slug: 'check_clients' },
       (_input, context) => {
-        anonClientExists = context?.anonSupabase !== undefined;
-        serviceClientExists = context?.serviceSupabase !== undefined;
+        supabaseClientExists = context?.supabase !== undefined;
         return { checked: true };
       }
     );
@@ -254,8 +251,7 @@ Deno.test(
     await stepDef.handler(mockTask.input, context);
 
     // Verify Supabase clients are available
-    assertEquals(anonClientExists, true);
-    assertEquals(serviceClientExists, true);
+    assertEquals(supabaseClientExists, true);
   })
 );
 

--- a/pkgs/edge-worker/tests/unit/contextUtils.test.ts
+++ b/pkgs/edge-worker/tests/unit/contextUtils.test.ts
@@ -68,9 +68,8 @@ Deno.test('createSupabaseMessageContext - creates context with all Supabase reso
   assertEquals(context.shutdownSignal, mockAbortSignal);
   assertEquals(context.rawMessage, mockMessage);
   
-  // Supabase clients should always be present
-  assertExists(context.anonSupabase);
-  assertExists(context.serviceSupabase);
+  // Supabase client should always be present
+  assertExists(context.supabase);
 });
 
 Deno.test('createTestMessageContext - allows custom resources for testing', () => {
@@ -112,9 +111,8 @@ Deno.test('createSupabaseStepTaskContext - creates context with step task', () =
   assertEquals(context.stepTask, mockStepTask);
   assertEquals(context.rawMessage, mockStepMessage);
   
-  // Supabase clients should always be present
-  assertExists(context.anonSupabase);
-  assertExists(context.serviceSupabase);
+  // Supabase client should always be present
+  assertExists(context.supabase);
 });
 
 Deno.test('context - rawMessage is accessible', () => {
@@ -135,9 +133,8 @@ Deno.test('test helpers - mock resources work correctly', () => {
   });
   
   assertExists(mockResources.sql);
-  assertExists(mockResources.anonSupabase);
-  assertExists(mockResources.serviceSupabase);
+  assertExists(mockResources.supabase);
   
-  // Mock clients should have basic structure
-  assertExists(mockResources.anonSupabase.from);
+  // Mock client should have basic structure
+  assertExists(mockResources.supabase.from);
 });

--- a/pkgs/edge-worker/tests/unit/supabaseUtils.test.ts
+++ b/pkgs/edge-worker/tests/unit/supabaseUtils.test.ts
@@ -1,38 +1,13 @@
 import { assertEquals } from '@std/assert';
 import { 
-  createAnonSupabaseClient, 
   createServiceSupabaseClient
 } from '../../src/core/supabase-utils.ts';
 
 // Mock env for testing
 const mockEnvWithAllKeys = {
   SUPABASE_URL: 'https://test.supabase.co',
-  SUPABASE_ANON_KEY: 'test-anon-key',
   SUPABASE_SERVICE_ROLE_KEY: 'test-service-key',
 };
-
-Deno.test('createAnonSupabaseClient - creates client with valid env', () => {
-  const env = {
-    SUPABASE_URL: 'https://test.supabase.co',
-    SUPABASE_ANON_KEY: 'test-anon-key',
-  };
-
-  const client = createAnonSupabaseClient(env);
-  assertEquals(client !== undefined, true);
-});
-
-Deno.test('createAnonSupabaseClient - creates new instance each time (no memoization)', () => {
-  const env = {
-    SUPABASE_URL: 'https://test.supabase.co',
-    SUPABASE_ANON_KEY: 'test-anon-key',
-  };
-
-  const client1 = createAnonSupabaseClient(env);
-  const client2 = createAnonSupabaseClient(env);
-  
-  // Should be different instances since no memoization
-  assertEquals(client1 === client2, false);
-});
 
 Deno.test('createServiceSupabaseClient - creates client with valid env', () => {
   const env = {
@@ -57,20 +32,12 @@ Deno.test('createServiceSupabaseClient - creates new instance each time (no memo
   assertEquals(client1 === client2, false);
 });
 
-Deno.test('client isolation - maintains separate instances for anon and service clients', () => {
-  const anonClient = createAnonSupabaseClient(mockEnvWithAllKeys);
-  const serviceClient = createServiceSupabaseClient(mockEnvWithAllKeys);
-
-  // Should be different instances
-  assertEquals(anonClient === serviceClient, false);
-});
-
 Deno.test('edge cases - works with different URL formats', () => {
   const envWithTrailingSlash = {
     SUPABASE_URL: 'https://test.supabase.co/',
-    SUPABASE_ANON_KEY: 'test-anon-key',
+    SUPABASE_SERVICE_ROLE_KEY: 'test-service-key',
   };
 
-  const client = createAnonSupabaseClient(envWithTrailingSlash);
+  const client = createServiceSupabaseClient(envWithTrailingSlash);
   assertEquals(client !== undefined, true);
 });

--- a/pkgs/website/src/content/docs/concepts/context.mdx
+++ b/pkgs/website/src/content/docs/concepts/context.mdx
@@ -60,11 +60,11 @@ async function processUser(input: { userId: string }) {
 ```
 </TabItem>
 <TabItem label="After (Context)">
-```typescript ins="ctx: Context" "ctx.sql" "ctx.env" "ctx.anonSupabase"
+```typescript ins="ctx: Context" "ctx.sql" "ctx.env" "ctx.supabase"
 async function processUser(input: { userId: string }, ctx: Context) {
   const [user] = await ctx.sql`SELECT * FROM users WHERE id = ${input.userId}`;
   const apiKey = ctx.env.EXTERNAL_API_KEY;
-  const { data } = await ctx.anonSupabase.auth.getUser();
+  const { data } = await ctx.supabase.auth.getUser();
 
   return { user };
 }
@@ -74,14 +74,14 @@ async function processUser(input: { userId: string }, ctx: Context) {
 
 ### Complete Flow Example
 
-```typescript title="Using context in flows" ins="ctx" "ctx.sql" "ctx.env" "ctx.anonSupabase"
+```typescript title="Using context in flows" ins="ctx" "ctx.sql" "ctx.env" "ctx.supabase"
 const ProcessUserFlow = new Flow<{ userId: string }>({
   slug: 'process_user'
 })
   .step({ slug: 'validate' }, async (input, ctx) => {
     const [user] = await ctx.sql`SELECT * FROM users WHERE id = ${input.userId}`;
     const apiKey = ctx.env.EXTERNAL_API_KEY;
-    const { data } = await ctx.anonSupabase.auth.getUser();
+    const { data } = await ctx.supabase.auth.getUser();
 
     // ... process with resources
     return { user };
@@ -202,35 +202,28 @@ async function handler(input, ctx) {
 }
 ```
 
-### `anonSupabase`
+### `supabase`
 **Type:** `SupabaseClient`
 **Available:** Supabase platform
 
-Supabase client authenticated with the anonymous key. Use this for operations that respect Row Level Security (RLS) policies as if performed by an unauthenticated user.
+Supabase client authenticated with the service role key. This has full database access and bypasses RLS. Since Edge Functions run in a trusted environment, this is the only client you need.
 
-```typescript "ctx.anonSupabase"
+```typescript "ctx.supabase"
 // Step handler
-.step({ slug: 'fetch_posts' }, async (input, ctx) => {
-  const { data, error } = await ctx.anonSupabase
-    .from('public_posts')
-    .select('*')
-    .limit(10);
+.step({ slug: 'process_order' }, async (input, ctx) => {
+  const { data, error } = await ctx.supabase
+    .from('orders')
+    .update({ status: 'processing' })
+    .eq('id', input.orderId);
     
-  return { posts: data || [] };
+  return { order: data };
 })
 ```
 
-### `serviceSupabase`
-**Type:** `SupabaseClient`
-**Available:** Supabase platform
-
-Supabase client authenticated with the service role key. This bypasses RLS and has full database access. Use with caution and only for admin operations.
-
-```typescript "ctx.serviceSupabase" ins="// Service client bypasses RLS"
+```typescript "ctx.supabase"
 // Queue handler
 async function handler(input, ctx) {
-  // Service client bypasses RLS
-  const { data, error } = await ctx.serviceSupabase
+  const { data, error } = await ctx.supabase
     .from('users')
     .update({ verified: true })
     .eq('id', input.userId);
@@ -254,14 +247,14 @@ async function processOrder(input, { sql, env, rawMessage }) {
 }
 ```
 
-```typescript ins="{ sql, serviceSupabase, stepTask }"
+```typescript ins="{ sql, supabase, stepTask }"
 // Step handler - clean and focused
-.step({ slug: 'sync_data' }, async (input, { sql, serviceSupabase, stepTask }) => {
+.step({ slug: 'sync_data' }, async (input, { sql, supabase, stepTask }) => {
   console.log(`Syncing for run ${stepTask.run_id}`);
   
   const data = await sql`SELECT * FROM pending_sync WHERE user_id = ${input.userId}`;
   
-  const synced = await serviceSupabase
+  const synced = await supabase
     .from('synced_data')
     .upsert(data)
     .select();

--- a/pkgs/website/src/content/docs/news/pgflow-0-5-4-context-simplify-your-handler-functions.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-5-4-context-simplify-your-handler-functions.mdx
@@ -25,7 +25,7 @@ Workers now pass a **context object** as a second parameter to all handlers, pro
 
 Previously, handlers relied on global singletons or manual resource initialization:
 
-```typescript del={2,3} ins="ctx" ins="ctx.sql" ins="ctx.serviceSupabase"
+```typescript del={2,3} ins="ctx" ins="ctx.sql" ins="ctx.supabase"
 // Before: Global resources that complicated testing and lifecycle management
 import { sql } from '../db.js';
 import { supabase } from '../supabase-client.js';
@@ -35,7 +35,7 @@ async function processPayment(input, ctx) {
   const [payment] = await ctx.sql`
     SELECT * FROM payments WHERE id = ${input.paymentId}
   `;
-  await ctx.serviceSupabase.from('audit_logs').insert({
+  await ctx.supabase.from('audit_logs').insert({
     action: 'payment_processed',
     payment_id: input.paymentId
   });
@@ -52,8 +52,7 @@ async function processPayment(input, ctx) {
 
 **Supabase resources**:
 - `sql` - PostgreSQL client (postgres.js)
-- `anonSupabase` - Client with anon key (respects RLS)
-- `serviceSupabase` - Client with service role (bypasses RLS)
+- `supabase` - Client with service role key (full database access)
 
 ## Key Benefits
 


### PR DESCRIPTION
## Summary

This PR simplifies pgflow's Supabase integration by removing the dual-client approach (anonSupabase/serviceSupabase) in favor of a single, unified Supabase client initialized with the service role key.

## Motivation

The dual-client pattern added unnecessary complexity without providing meaningful benefits. Since Edge Functions run in a trusted environment with service role access, maintaining separate clients for anonymous and authenticated operations was redundant.

## Changes

### Core Refactoring
- Replaced `anonSupabase` and `serviceSupabase` with a single `supabase` client throughout the codebase
- Updated all imports and references across edge-worker, DSL, and flow packages
- Simplified context creation and type definitions

### Breaking Changes
- **Removed environment variables**: `SUPABASE_ANON_KEY` is no longer required
- **Context interface changes**:
  - Removed: `context.anonSupabase` 
  - Removed: `context.serviceSupabase`
  - Added: `context.supabase` (initialized with service role key)
- **Removed functions**: `createAnonSupabaseClient` is no longer available

### Files Updated
- Platform adapters and context utilities
- Flow examples and test helpers
- Documentation and README files
- Type definitions and interfaces

## Migration Guide

```typescript
// Before
const { data } = await context.serviceSupabase.from('users').select();
const { data: publicData } = await context.anonSupabase.from('posts').select();

// After
const { data } = await context.supabase.from('users').select();
// For RLS-respecting queries, implement proper policies in your database
```

## Testing
- Updated all integration and unit tests to use the unified client
- Verified flow execution with the new context structure
- Ensured backward compatibility for existing flows (after migration)

## Impact
This change significantly reduces the complexity of pgflow's Supabase integration while maintaining all functionality. Developers now have a cleaner, more straightforward API for interacting with Supabase resources within their workflows.