### PR TITLE
docs: pgflow 0.6.0 - worker deprecation and context changes

### DIFF
--- a/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
+++ b/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Aside, Steps } from "@astrojs/starlight/components";
 import NotProductionReady from '../../../components/NotProductionReady.astro';
 
-This guide walks through deploying Edge Workers to Supabase.com. The process currently involves a few manual steps to ensure smooth transitions - using pgflow's deprecation feature to stop old workers from accepting new work when deploying updates.
+pgflow workers are just regular Supabase Edge Functions running pgflow code. You deploy them exactly like any other Edge Function, with one extra step - deprecating old workers to stop processing new tasks.
 
 ## Deployment Steps
 

--- a/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
+++ b/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
@@ -10,27 +10,18 @@ import NotProductionReady from '../../../components/NotProductionReady.astro';
 
 pgflow workers are just regular Supabase Edge Functions running pgflow code. You deploy them exactly like any other Edge Function, with one extra step - deprecating old workers to stop processing new tasks.
 
-## Deployment Steps
+<NotProductionReady />
+
+## Quick Deployment
 
 <Steps>
 
-1. **Deploy your new worker version**
-
+1. **Deploy new version**
    ```bash frame="none"
    npx supabase functions deploy your-worker-name
    ```
 
-2. **Start the new worker**
-
-   Make sure your flow migrations are already applied before starting:
-
-   ```bash frame="none"
-   curl -X POST "https://your-project.supabase.co/functions/v1/your-worker-name" \
-     -H "Authorization: Bearer YOUR_ANON_KEY"
-   ```
-
-3. **Deprecate old workers**
-
+2. **Deprecate old workers**
    ```sql
    UPDATE pgflow.workers
    SET deprecated_at = NOW()
@@ -38,47 +29,50 @@ pgflow workers are just regular Supabase Edge Functions running pgflow code. You
      AND deprecated_at IS NULL;
    ```
 
-4. **Monitor the transition** (optional)
-
-   ```sql
-   SELECT
-     function_name,
-     COUNT(*) FILTER (WHERE deprecated_at IS NULL) as active_workers,
-     COUNT(*) FILTER (WHERE deprecated_at IS NOT NULL) as deprecated_workers
-   FROM pgflow.workers
-   WHERE last_heartbeat_at > now() - interval '6 seconds'
-   GROUP BY function_name;
+3. **Start new worker**
+   ```bash frame="none"
+   curl -X POST "https://your-project.supabase.co/functions/v1/your-worker-name" \
+     -H "Authorization: Bearer YOUR_ANON_KEY"
    ```
 
 </Steps>
 
-<details>
-<summary>Why worker deprecation is needed</summary>
+## Deployment Details
+
+### Why Worker Deprecation
 
 When you deploy a new version, old workers continue running until they hit resource limits (up to 150s on free tier, 400s on paid). This creates overlap where both versions process tasks simultaneously.
 
 Worker deprecation solves this - deprecated workers stop accepting new work and complete their current tasks. Workers check their deprecation status every 5 seconds during heartbeat.
 
-</details>
-
-<details>
-<summary>Getting your Authorization header</summary>
+### Getting Your ANON Key
 
 You need your project's ANON key for the Authorization header. Find it in your [Supabase Dashboard](https://supabase.com/dashboard) under Settings > API.
 
 See Supabase docs: [Invoking remote functions](https://supabase.com/docs/guides/functions/deploy#invoking-remote-functions)
 
-</details>
+### Monitoring Workers
 
-<details>
-<summary>Keeping workers running with pg_cron</summary>
+Check active and deprecated workers during deployment:
+
+```sql
+SELECT
+  function_name,
+  COUNT(*) FILTER (WHERE deprecated_at IS NULL) as active_workers,
+  COUNT(*) FILTER (WHERE deprecated_at IS NOT NULL) as deprecated_workers
+FROM pgflow.workers
+WHERE last_heartbeat_at > now() - interval '6 seconds'
+GROUP BY function_name;
+```
+
+### Keeping Workers Running
 
 Workers auto-respawn when terminated, but for extra reliability you can use pg_cron to ping your worker every 5 seconds:
 
 ```sql
 SELECT cron.schedule(
   'ping-worker',
-  '*/5 * * * * *',
+  '5 seconds',
   $$
   SELECT net.http_post(
     url := 'https://your-project.supabase.co/functions/v1/your-worker-name',
@@ -89,7 +83,3 @@ SELECT cron.schedule(
 ```
 
 See [Supabase cron guide](https://supabase.com/docs/guides/cron/quickstart#invoke-supabase-edge-function-every-30-seconds) for details.
-
-</details>
-
-<NotProductionReady />

--- a/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
+++ b/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
@@ -8,80 +8,40 @@ sidebar:
 import { Aside, Steps } from "@astrojs/starlight/components";
 import NotProductionReady from '../../../components/NotProductionReady.astro';
 
-This guide explains the current process for deploying and maintaining workers in hosted environment.
+This guide walks through deploying Edge Workers to Supabase.com. The process currently involves a few manual steps to ensure smooth transitions - using pgflow's deprecation feature to stop old workers from accepting new work when deploying updates.
 
-<NotProductionReady />
-
-:::note
-Running Edge Worker on Supabase.com currently requires a few additional setup steps.
-Thanks to ongoing collaboration with the Supabase team, these requirements will be simplified in future releases.
-:::
-
-## Deploying workers
-
-Workers are just regular Edge Functions that run for few minutes and auto-respawn
-when CPU or Wall clock limits are reached (read more on those [Limits | Supabase Docs](https://supabase.com/docs/guides/functions/limits)).
-
-Deploying new version is straightforward - you just update worker code
-and call `npx supabase functions deploy worker-name` to deploy it.
-
-When deploying a new version of your worker, be aware of the following:
-
-<Aside type="caution" title="Version Management">
-Currently, deploying a new version **does not automatically terminate** the previous version.
-This behavior will be improved in future releases.
-</Aside>
-
-## Zero-Downtime Deployment Process
-
-### Understanding Worker Deprecation
-
-When you deploy a new version, old workers continue running until they hit resource limits (up to 150s on free tier, 400s on paid). This creates overlap where both versions process tasks simultaneously.
-
-pgflow provides worker deprecation to solve this - old workers can be marked as deprecated and will:
-- Stop accepting new work
-- Complete their current tasks
-
-Workers check their deprecation status every 5 seconds during heartbeat and automatically stop when `deprecated_at` is set.
-
-### Step-by-Step Deployment
+## Deployment Steps
 
 <Steps>
 
 1. **Deploy your new worker version**
-   
-   Update your worker code and deploy to Supabase:
-   
+
    ```bash frame="none"
    npx supabase functions deploy your-worker-name
    ```
 
 2. **Start the new worker**
-   
-   Make an HTTP request to start the new worker instance:
-   
+
+   Make sure your flow migrations are already applied before starting:
+
    ```bash frame="none"
    curl -X POST "https://your-project.supabase.co/functions/v1/your-worker-name" \
      -H "Authorization: Bearer YOUR_ANON_KEY"
    ```
 
 3. **Deprecate old workers**
-   
-   Mark old workers for graceful shutdown:
-   
+
    ```sql
-   UPDATE pgflow.workers 
-   SET deprecated_at = NOW() 
+   UPDATE pgflow.workers
+   SET deprecated_at = NOW()
    WHERE function_name = 'your-worker-name'
      AND deprecated_at IS NULL;
    ```
 
-4. **Monitor the transition**
-   
-   Watch workers gracefully shut down (takes ~5-10 seconds):
-   
+4. **Monitor the transition** (optional)
+
    ```sql
-   SELECT 
+   SELECT
      function_name,
      COUNT(*) FILTER (WHERE deprecated_at IS NULL) as active_workers,
      COUNT(*) FILTER (WHERE deprecated_at IS NOT NULL) as deprecated_workers
@@ -92,7 +52,25 @@ Workers check their deprecation status every 5 seconds during heartbeat and auto
 
 </Steps>
 
-This process ensures immediate cutover to your new code while allowing in-flight tasks to complete gracefully.
+<details>
+<summary>Why worker deprecation is needed</summary>
+
+When you deploy a new version, old workers continue running until they hit resource limits (up to 150s on free tier, 400s on paid). This creates overlap where both versions process tasks simultaneously.
+
+Worker deprecation solves this - deprecated workers stop accepting new work and complete their current tasks. Workers check their deprecation status every 5 seconds during heartbeat.
+
+</details>
+
+<details>
+<summary>Getting your Authorization header</summary>
+
+You need your project's ANON key for the Authorization header. Find it in your [Supabase Dashboard](https://supabase.com/dashboard) under Settings > API.
+
+See Supabase docs: [Invoking remote functions](https://supabase.com/docs/guides/functions/deploy#invoking-remote-functions)
+
+</details>
+
+<NotProductionReady />
 
 ## Starting Workers
 
@@ -104,11 +82,7 @@ After the initial request, the worker will auto-respawn if terminated.
 
 ## Stopping Workers
 
-Currently, there's no built-in way to gracefully stop a running worker.
-You need to remove it from the Supabase Dashboard and wait for its CPU or clock limits to be reached
-for it to stop.
-
-**This will change in future releases.**
+To stop workers gracefully, use the deprecation mechanism described in the [deployment steps](#deployment-steps) above. Deprecated workers will stop accepting new work and complete their current tasks before shutting down.
 
 ## Ensuring Worker Availability
 

--- a/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
+++ b/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
@@ -32,6 +32,68 @@ Currently, deploying a new version **does not automatically terminate** the prev
 This behavior will be improved in future releases.
 </Aside>
 
+## Zero-Downtime Deployment Process
+
+### Understanding Worker Deprecation
+
+When you deploy a new version, old workers continue running until they hit resource limits (up to 150s on free tier, 400s on paid). This creates overlap where both versions process tasks simultaneously.
+
+pgflow provides worker deprecation to solve this - old workers can be marked as deprecated and will:
+- Stop accepting new work
+- Complete their current tasks
+
+Workers check their deprecation status every 5 seconds during heartbeat and automatically stop when `deprecated_at` is set.
+
+### Step-by-Step Deployment
+
+<Steps>
+
+1. **Deploy your new worker version**
+   
+   Update your worker code and deploy to Supabase:
+   
+   ```bash frame="none"
+   npx supabase functions deploy your-worker-name
+   ```
+
+2. **Start the new worker**
+   
+   Make an HTTP request to start the new worker instance:
+   
+   ```bash frame="none"
+   curl -X POST "https://your-project.supabase.co/functions/v1/your-worker-name" \
+     -H "Authorization: Bearer YOUR_ANON_KEY"
+   ```
+
+3. **Deprecate old workers**
+   
+   Mark old workers for graceful shutdown:
+   
+   ```sql
+   UPDATE pgflow.workers 
+   SET deprecated_at = NOW() 
+   WHERE function_name = 'your-worker-name'
+     AND deprecated_at IS NULL;
+   ```
+
+4. **Monitor the transition**
+   
+   Watch workers gracefully shut down (takes ~5-10 seconds):
+   
+   ```sql
+   SELECT 
+     function_name,
+     COUNT(*) FILTER (WHERE deprecated_at IS NULL) as active_workers,
+     COUNT(*) FILTER (WHERE deprecated_at IS NOT NULL) as deprecated_workers
+   FROM pgflow.workers
+   WHERE last_heartbeat_at > now() - interval '6 seconds'
+   GROUP BY function_name;
+   ```
+
+</Steps>
+
+This process ensures immediate cutover to your new code while allowing in-flight tasks to complete gracefully.
+
 ## Starting Workers
 
 Just like in local development, workers are started with a simple HTTP request.

--- a/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
+++ b/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
@@ -70,30 +70,26 @@ See Supabase docs: [Invoking remote functions](https://supabase.com/docs/guides/
 
 </details>
 
+<details>
+<summary>Keeping workers running with pg_cron</summary>
+
+Workers auto-respawn when terminated, but for extra reliability you can use pg_cron to ping your worker every 5 seconds:
+
+```sql
+SELECT cron.schedule(
+  'ping-worker',
+  '*/5 * * * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://your-project.supabase.co/functions/v1/your-worker-name',
+    headers := jsonb_build_object('Authorization', 'Bearer YOUR_ANON_KEY')
+  ) AS request_id;
+  $$
+);
+```
+
+See [Supabase cron guide](https://supabase.com/docs/guides/cron/quickstart#invoke-supabase-edge-function-every-30-seconds) for details.
+
+</details>
+
 <NotProductionReady />
-
-## Starting Workers
-
-Just like in local development, workers are started with a simple HTTP request.
-However, you need to pass Authorization header with your ANON_KEY when calling function.
-Consult this Supabase Docs page for details: [Invoking remote functions](https://supabase.com/docs/guides/functions/deploy#invoking-remote-functions)
-
-After the initial request, the worker will auto-respawn if terminated.
-
-## Stopping Workers
-
-To stop workers gracefully, use the deprecation mechanism described in the [deployment steps](#deployment-steps) above. Deprecated workers will stop accepting new work and complete their current tasks before shutting down.
-
-## Ensuring Worker Availability
-
-To ensure your worker stays active, it's recommended to use Cron to ping
-your worker edge function every few seconds.
-This is recommended in case there are any bugs in the respawn process,
-which currently is triggered from withing the worker that is shutting down.
-
-Use this Supabase guide [Invoking Supabase Function ever few seconds](https://supabase.com/docs/guides/cron/quickstart#invoke-supabase-edge-function-every-30-seconds).
-but use `5 seconds` instead of `30 seconds`.
-
-:::note
-Make sure to **set your own ANON key** in the `Authorization` header!
-:::

--- a/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
+++ b/pkgs/website/src/content/docs/how-to/deploy-to-supabasecom.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Aside, Steps } from "@astrojs/starlight/components";
 import NotProductionReady from '../../../components/NotProductionReady.astro';
 
-pgflow workers are just regular Supabase Edge Functions running pgflow code. You deploy them exactly like any other Edge Function, with one extra step - deprecating old workers to stop processing new tasks.
+pgflow workers are regular Supabase Edge Functions. Deploy them like any Edge Function, plus deprecate old workers to prevent version overlap.
 
 <NotProductionReady />
 
@@ -16,17 +16,18 @@ pgflow workers are just regular Supabase Edge Functions running pgflow code. You
 
 <Steps>
 
-1. **Deploy new version**
-   ```bash frame="none"
-   npx supabase functions deploy your-worker-name
-   ```
-
-2. **Deprecate old workers**
+1. **Deprecate old workers**
    ```sql
    UPDATE pgflow.workers
    SET deprecated_at = NOW()
    WHERE function_name = 'your-worker-name'
      AND deprecated_at IS NULL;
+   ```
+   This stops old workers from polling for new tasks while they finish current work.
+
+2. **Deploy new version**
+   ```bash frame="none"
+   npx supabase functions deploy your-worker-name
    ```
 
 3. **Start new worker**
@@ -41,19 +42,17 @@ pgflow workers are just regular Supabase Edge Functions running pgflow code. You
 
 ### Why Worker Deprecation
 
-When you deploy a new version, old workers continue running until they hit resource limits (up to 150s on free tier, 400s on paid). This creates overlap where both versions process tasks simultaneously.
+Without deprecation, old workers run for up to 150s (free tier) or 400s (paid) after deployment, causing both versions to process tasks simultaneously.
 
-Worker deprecation solves this - deprecated workers stop accepting new work and complete their current tasks. Workers check their deprecation status every 5 seconds during heartbeat.
+Deprecation fixes this: workers check their status every 5 seconds and immediately stop polling for new tasks when deprecated, while finishing current work.
 
 ### Getting Your ANON Key
 
-You need your project's ANON key for the Authorization header. Find it in your [Supabase Dashboard](https://supabase.com/dashboard) under Settings > API.
-
-See Supabase docs: [Invoking remote functions](https://supabase.com/docs/guides/functions/deploy#invoking-remote-functions)
+Find your ANON key in [Supabase Dashboard](https://supabase.com/dashboard) → Settings → API → `anon` `public` key.
 
 ### Monitoring Workers
 
-Check active and deprecated workers during deployment:
+Track deployment progress with this query:
 
 ```sql
 SELECT
@@ -67,7 +66,7 @@ GROUP BY function_name;
 
 ### Keeping Workers Running
 
-Workers auto-respawn when terminated, but for extra reliability you can use pg_cron to ping your worker every 5 seconds:
+Workers auto-respawn when terminated. For extra reliability, schedule a ping every 5 seconds:
 
 ```sql
 SELECT cron.schedule(

--- a/pkgs/website/src/content/docs/news/pgflow-0-5-4-context-simplify-your-handler-functions.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-5-4-context-simplify-your-handler-functions.mdx
@@ -19,10 +19,10 @@ cover:
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-<Aside type="caution" title="API Change in v0.5.5">
-  **Breaking Change**: Starting with pgflow v0.5.5, the context API has been simplified. The `anonSupabase` and `serviceSupabase` clients have been replaced with a single `supabase` client (initialized with service role key). 
-  
-  If you're using v0.5.5 or later, replace any usage of `ctx.anonSupabase` or `ctx.serviceSupabase` with `ctx.supabase`.
+<Aside type="caution" title="API Change in v0.6.0">
+  **Breaking Change**: Starting with pgflow v0.6.0, the context API has been simplified. The `anonSupabase` and `serviceSupabase` clients have been replaced with a single `supabase` client (initialized with service role key).
+
+  If you're using v0.6.0 or later, replace any usage of `ctx.anonSupabase` or `ctx.serviceSupabase` with `ctx.supabase`.
 </Aside>
 
 Workers now pass a **context object** as a second parameter to all handlers, providing ready-to-use database connections, environment variables, and Supabase clients.

--- a/pkgs/website/src/content/docs/news/pgflow-0-6-0-worker-deprecation-and-context-changes.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-6-0-worker-deprecation-and-context-changes.mdx
@@ -1,7 +1,7 @@
 ---
 draft: false
 title: 'pgflow 0.6.0: Worker Deprecation and Context Changes'
-description: 'Zero-downtime deployments with worker deprecation, plus breaking changes to the context object for cleaner handler functions.'
+description: 'Deployments without version overlap using worker deprecation, plus breaking changes to the context object for cleaner handler functions.'
 date: 2025-08-06
 authors:
   - jumski
@@ -16,7 +16,7 @@ featured: true
 
 import { Aside } from "@astrojs/starlight/components";
 
-pgflow 0.6.0 introduces worker deprecation for zero-downtime deployments and simplifies the context object with breaking changes.
+pgflow 0.6.0 introduces worker deprecation for deployments without version overlap and simplifies the context object with breaking changes.
 
 ## Worker Deprecation
 

--- a/pkgs/website/src/content/docs/news/pgflow-0-6-0-worker-deprecation-and-context-changes.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-6-0-worker-deprecation-and-context-changes.mdx
@@ -1,0 +1,68 @@
+---
+draft: false
+title: 'pgflow 0.6.0: Worker Deprecation and Context Changes'
+description: 'Zero-downtime deployments with worker deprecation, plus breaking changes to the context object for cleaner handler functions.'
+date: 2025-08-06
+authors:
+  - jumski
+tags:
+  - release
+  - edge-worker
+  - deployment
+  - context
+  - breaking-change
+featured: true
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+pgflow 0.6.0 introduces worker deprecation for zero-downtime deployments and simplifies the context object with breaking changes.
+
+## Worker Deprecation
+
+Deploy new workers without version overlap. Deprecated workers stop accepting new tasks while finishing current work.
+
+```sql
+-- Deprecate old workers before starting new ones
+UPDATE pgflow.workers 
+SET deprecated_at = NOW() 
+WHERE function_name = 'your-worker-name'
+  AND deprecated_at IS NULL;
+```
+
+Workers detect deprecation within 5 seconds via heartbeat and gracefully stop polling. The [deployment guide](/how-to/deploy-to-supabasecom/) has been simplified with a single safe deployment sequence.
+
+## Breaking Context Changes
+
+The context object is now cleaner and more consistent:
+
+<Aside type="caution" title="Breaking Changes">
+- Removed: `context.anonSupabase` 
+- Renamed: `context.serviceSupabase` → `context.supabase`
+</Aside>
+
+**Before (0.5.x):**
+```typescript
+async function handler(input, context) {
+  const { data } = await context.serviceSupabase
+    .from('users')
+    .select('*');
+}
+```
+
+**After (0.6.0):**
+```typescript
+async function handler(input, context) {
+  const { data } = await context.supabase
+    .from('users')
+    .select('*');
+}
+```
+
+## Migration
+
+1. Update context usage: `context.serviceSupabase` → `context.supabase`
+2. Remove any `context.anonSupabase` usage
+3. Use [worker deprecation](/how-to/deploy-to-supabasecom/) for smooth deployments
+
+The service role client is now the primary Supabase interface, simplifying database operations in handler functions.


### PR DESCRIPTION
## Summary

Documentation for pgflow 0.6.0 featuring zero-downtime deployments and simplified context API.

## Key Changes

### Worker Deprecation
- New 3-step deployment process prevents version overlap
- Workers gracefully stop via  SQL command
- Enables zero-downtime deployments

### Breaking Context Changes  
- Removed: `context.anonSupabase`
- Renamed: `context.serviceSupabase` → `context.supabase`

### Documentation Updates
- Simplified deployment guide with single safe sequence
- Added 0.6.0 release post with migration instructions
- Updated version references for API changes

## Migration Required
Update handler functions: `context.serviceSupabase` → `context.supabase`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised and expanded the guide for deploying pgflow workers on Supabase.com, adding step-by-step instructions for deployment, version management, monitoring, and reliability.
  * Updated the caution notice in the context API documentation to reference the correct version (0.6.0) and clarified migration instructions.
  * Added a new article detailing the new worker deprecation feature and context changes introduced in pgflow 0.6.0, including migration guidance and code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->