### PR TITLE
Fix retry limit validation for fixed strategy

### DIFF
--- a/pkgs/edge-worker/src/queue/validateRetryConfig.ts
+++ b/pkgs/edge-worker/src/queue/validateRetryConfig.ts
@@ -24,10 +24,6 @@ export function validateRetryConfig(config: RetryConfig): void {
   if (config.limit < 0) {
     throw new Error('limit must be greater than or equal to 0');
   }
-  // Prevent overflow in Math.pow(2, limit-1)
-  if (config.limit > 50) {
-    throw new Error('limit must not exceed 50');
-  }
 
   // Validate baseDelay
   if (!Number.isInteger(config.baseDelay)) {
@@ -48,6 +44,11 @@ export function validateRetryConfig(config: RetryConfig): void {
       throw new Error('maxDelay is only valid for exponential strategy');
     }
   } else if (config.strategy === 'exponential') {
+    // Prevent overflow in Math.pow(2, limit-1)
+    if (config.limit > 50) {
+      throw new Error('For exponential strategy, limit must not exceed 50 to prevent calculation overflow');
+    }
+    
     // Validate maxDelay if provided
     if (config.maxDelay !== undefined) {
       if (!Number.isInteger(config.maxDelay)) {

--- a/pkgs/edge-worker/tests/unit/validateRetryConfig.test.ts
+++ b/pkgs/edge-worker/tests/unit/validateRetryConfig.test.ts
@@ -165,4 +165,34 @@ Deno.test('validateRetryConfig - retry config validation', async (t) => {
       baseDelay: 3,
     });
   });
+
+  await t.step('should allow fixed strategy with very high retry limits', () => {
+    // Should not throw - fixed strategy has no mathematical overflow issues
+    validateRetryConfig({
+      strategy: 'fixed',
+      limit: 100000,
+      baseDelay: 10,
+    });
+  });
+
+  await t.step('should throw for exponential strategy with limit > 50', () => {
+    assertThrows(
+      () => validateRetryConfig({
+        strategy: 'exponential',
+        limit: 51,
+        baseDelay: 1,
+      }),
+      Error,
+      'For exponential strategy, limit must not exceed 50 to prevent calculation overflow'
+    );
+  });
+
+  await t.step('should allow exponential strategy with limit = 50', () => {
+    // Should not throw - exactly at the limit
+    validateRetryConfig({
+      strategy: 'exponential',
+      limit: 50,
+      baseDelay: 1,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fixes issue #199 where retry limit validation incorrectly blocked fixed strategy configurations with more than 50 retries.

## Problem
The validation applied a 50-retry limit to ALL strategies, preventing legitimate use cases like retrying every minute for 24 hours (1,440 attempts).

## Solution
- Move the 50-retry limit validation to only apply to exponential strategy
- Allow unlimited retries for fixed strategy (no mathematical overflow risk)
- Update error message to be strategy-specific

## Changes
- **validateRetryConfig.ts**: Move limit check inside exponential strategy validation
- **validateRetryConfig.test.ts**: Add comprehensive tests for both strategies

## Examples

**Now works (fixed strategy):**
```typescript
{
  strategy: "fixed",
  limit: 1440,        // 24 hours
  baseDelay: 60,      // Every minute
}
```

**Still protected (exponential strategy):**
```typescript
{
  strategy: "exponential",
  limit: 51,          // ❌ Throws error
  baseDelay: 1,
}
```

## Test Results
All tests pass including new cases:
- ✅ Fixed strategy with 100,000 retries (no limits)
- ✅ Exponential strategy still enforces 50-retry limit
- ✅ All existing validations preserved

Closes #199