### PR TITLE
chore(ci): add workflow to prevent temporary migrations from being merged into main

### DIFF
--- a/.claude/schema_development.md
+++ b/.claude/schema_development.md
@@ -78,11 +78,37 @@ pnpm nx verify-migrations core
 pnpm nx test:pgtap core
 ```
 
+## Working with Stacked PRs (Graphite)
+
+When developing features across multiple stacked PRs, use temporary migrations:
+
+### Each PR in Stack
+Follow normal development workflow (see above), but when generating migrations:
+```bash
+# Use TEMP_ prefix for non-final migrations
+./scripts/atlas-migrate-diff TEMP_feature_part_1  # Will create *_pgflow_TEMP_*.sql
+```
+
+### Before Merging to Main (Top PR Only)
+```bash
+# Remove ALL temp migrations
+git rm -f supabase/migrations/*_pgflow_{TEMP,temp}_*.sql
+
+# Regenerate as final migration (follow "Regenerating Migrations" section above)
+./scripts/atlas-migrate-diff actual_feature_name  # No TEMP_ prefix
+```
+
+### Why?
+- Each PR passes CI independently
+- Single clean migration ships to users
+- CI automatically blocks TEMP_/temp_ migrations from main
+
 ## Best Practices
 
 **Development**: Edit schemas/*.sql first, psql iteration, test incrementally, TDD
 **Migrations**: Generate only (never hand-write), one per PR, descriptive names, test thoroughly, commit with schemas
-**Avoid**: Manual migration edits, forgetting to remove old migration, skipping hash reset, failing tests, mixing changes
+**Temp Migrations**: Use TEMP_ prefix for stacked PRs, remove before final merge, CI enforces this
+**Avoid**: Manual migration edits, forgetting to remove old migration, skipping hash reset, failing tests, mixing changes, merging temp migrations to main
 
 ## Troubleshooting
 

--- a/.github/workflows/prevent-temp-migrations.yml
+++ b/.github/workflows/prevent-temp-migrations.yml
@@ -1,0 +1,40 @@
+name: Prevent Temporary Migrations on Main
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  block-temp-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check for temporary migrations
+        run: |
+          # Check for any temp migrations (both TEMP and temp)
+          shopt -s nullglob
+          temp_migrations=(pkgs/core/supabase/migrations/*_pgflow_TEMP_*.sql pkgs/core/supabase/migrations/*_pgflow_temp_*.sql)
+          
+          if [ ${#temp_migrations[@]} -gt 0 ]; then
+            echo "::error::❌ Temporary migrations found! These cannot be merged to main."
+            echo -e "\033[31m"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "❌ TEMPORARY MIGRATIONS DETECTED - CANNOT MERGE TO MAIN"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            echo "Found temporary migrations:"
+            printf '  • %s\n' "${temp_migrations[@]}"
+            echo ""
+            echo "TO FIX: Remove temp migrations and generate final migration:"
+            echo ""
+            echo "  git rm -f pkgs/core/supabase/migrations/*_pgflow_TEMP_*.sql"
+            echo "  git rm -f pkgs/core/supabase/migrations/*_pgflow_temp_*.sql"
+            echo "  cd pkgs/core"
+            echo "  ./scripts/atlas-migrate-hash --yes"
+            echo "  ./scripts/atlas-migrate-diff your_feature_name"
+            echo ""
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo -e "\033[0m"
+            exit 1
+          fi
+          echo "✅ No temporary migrations found"


### PR DESCRIPTION
This update introduces a GitHub Actions workflow that checks for temporary migration files
matching specific patterns.
If such files are found in a pull request targeting main,
the workflow will block the merge and provide instructions to remove temporary migrations
and generate a final migration.
This helps maintain migration integrity and prevents
incomplete or placeholder migrations from reaching production.