### PR TITLE
fix: Data Pruning Foreign Key Constraint Bug

### DIFF
--- a/pkgs/core/supabase/tests/_shared/prune_data_older_than.sql.raw
+++ b/pkgs/core/supabase/tests/_shared/prune_data_older_than.sql.raw
@@ -2,6 +2,15 @@
  * Prunes old records from pgflow tables and PGMQ archive tables.
  *
  * @param retention_interval - Interval of recent records to keep (e.g., interval '28 days', interval '3 months')
+ *
+ * IMPORTANT: This function deletes ALL associated records for runs that completed or failed
+ * more than retention_interval ago, regardless of individual record status. This includes:
+ * - step_states with status='created' or status='started' (never executed)
+ * - step_tasks with status='queued' or status='started' (never completed)
+ * - PGMQ messages in active queues
+ *
+ * WARNING: Ensure retention_interval is longer than your longest start_delay to avoid
+ * deleting tasks before they have a chance to execute.
  */
 create or replace function pgflow.prune_data_older_than(
   retention_interval INTERVAL
@@ -16,18 +25,45 @@ BEGIN
   DELETE FROM pgflow.workers
   WHERE last_heartbeat_at < cutoff_timestamp;
 
-  -- Delete old step_tasks records
+  -- Delete PGMQ messages from active queues BEFORE deleting step_tasks
+  -- This prevents orphaned messages that would appear after tasks are deleted
+  FOR flow_record IN
+    SELECT
+      r.flow_slug,
+      ARRAY_AGG(st.message_id) FILTER (WHERE st.message_id IS NOT NULL) as message_ids
+    FROM pgflow.runs r
+    JOIN pgflow.step_tasks st ON st.run_id = r.run_id
+    WHERE (
+      (r.completed_at IS NOT NULL AND r.completed_at < cutoff_timestamp) OR
+      (r.failed_at IS NOT NULL AND r.failed_at < cutoff_timestamp)
+    )
+    GROUP BY r.flow_slug
+  LOOP
+    -- Delete messages in batch (pgmq.delete ignores non-existent messages)
+    IF flow_record.message_ids IS NOT NULL AND array_length(flow_record.message_ids, 1) > 0 THEN
+      PERFORM pgmq.delete(flow_record.flow_slug, flow_record.message_ids);
+    END IF;
+  END LOOP;
+
+  -- Delete ALL step_tasks for old runs (regardless of individual task status)
+  -- This fixes FK constraint violation when deleting runs with unexecuted steps
   DELETE FROM pgflow.step_tasks
-  WHERE (
-    (completed_at IS NOT NULL AND completed_at < cutoff_timestamp) OR
-    (failed_at IS NOT NULL AND failed_at < cutoff_timestamp)
+  WHERE run_id IN (
+    SELECT run_id FROM pgflow.runs
+    WHERE (
+      (completed_at IS NOT NULL AND completed_at < cutoff_timestamp) OR
+      (failed_at IS NOT NULL AND failed_at < cutoff_timestamp)
+    )
   );
 
-  -- Delete old step_states records
+  -- Delete ALL step_states for old runs (regardless of individual step status)
   DELETE FROM pgflow.step_states
-  WHERE (
-    (completed_at IS NOT NULL AND completed_at < cutoff_timestamp) OR
-    (failed_at IS NOT NULL AND failed_at < cutoff_timestamp)
+  WHERE run_id IN (
+    SELECT run_id FROM pgflow.runs
+    WHERE (
+      (completed_at IS NOT NULL AND completed_at < cutoff_timestamp) OR
+      (failed_at IS NOT NULL AND failed_at < cutoff_timestamp)
+    )
   );
 
   -- Delete old runs records

--- a/pkgs/core/supabase/tests/maintenance/prune_cleans_orphaned_pgmq_messages.test.sql
+++ b/pkgs/core/supabase/tests/maintenance/prune_cleans_orphaned_pgmq_messages.test.sql
@@ -1,0 +1,86 @@
+begin;
+select plan(5);
+select pgflow_tests.reset_db();
+
+-- Load the prune_data_older_than function
+\i _shared/prune_data_older_than.sql.raw
+
+-- Create a flow with 2 steps
+select pgflow.create_flow('pgmq_test_flow', max_attempts => 0);
+select pgflow.add_step('pgmq_test_flow', 'step1');
+select pgflow.add_step('pgmq_test_flow', 'step2', ARRAY['step1']);
+
+-- Start the flow - this creates PGMQ messages for step1
+select pgflow.start_flow('pgmq_test_flow', '{}'::jsonb);
+
+-- Manually fail the run without consuming the PGMQ message
+-- This simulates a situation where the run failed but messages remain in the queue
+update pgflow.runs
+set status = 'failed',
+    failed_at = now()
+where flow_slug = 'pgmq_test_flow';
+
+update pgflow.step_states
+set status = 'failed',
+    failed_at = now()
+where flow_slug = 'pgmq_test_flow' and step_slug = 'step1';
+
+-- Verify PGMQ queue exists and contains messages
+select is(
+  (select count(*) > 0 from pgmq.q_pgmq_test_flow),
+  true,
+  'PGMQ queue should exist with messages before pruning'
+);
+
+-- Age the failed run to make it eligible for pruning
+update pgflow.runs
+set
+  started_at = now() - interval '31 days',
+  failed_at = now() - interval '31 days'
+where flow_slug = 'pgmq_test_flow';
+
+update pgflow.step_states
+set
+  created_at = now() - interval '31 days',
+  started_at = now() - interval '31 days' + interval '1 minute',
+  failed_at = now() - interval '31 days' + interval '2 minutes'
+where flow_slug = 'pgmq_test_flow' and step_slug = 'step1';
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '31 days'
+where flow_slug = 'pgmq_test_flow' and step_slug = 'step1';
+
+-- Verify setup
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'pgmq_test_flow'),
+  1::bigint,
+  'Should have 1 run before pruning'
+);
+
+select is(
+  (select count(*) from pgflow.step_tasks where flow_slug = 'pgmq_test_flow'),
+  1::bigint,
+  'Should have 1 step_task before pruning'
+);
+
+-- Prune old records
+-- This should delete PGMQ messages BEFORE deleting step_tasks
+select pgflow.prune_data_older_than(make_interval(days => 30));
+
+-- TEST: All database records deleted
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'pgmq_test_flow'),
+  0::bigint,
+  'Run should be deleted after pruning'
+);
+
+-- TEST: PGMQ messages deleted (queue should be empty)
+select is(
+  (select count(*) from pgmq.q_pgmq_test_flow),
+  0::bigint,
+  'PGMQ queue should be empty after pruning'
+);
+
+select finish();
+rollback;

--- a/pkgs/core/supabase/tests/maintenance/prune_deletes_all_child_statuses.test.sql
+++ b/pkgs/core/supabase/tests/maintenance/prune_deletes_all_child_statuses.test.sql
@@ -1,0 +1,137 @@
+begin;
+select plan(6);
+select pgflow_tests.reset_db();
+
+-- Load the prune_data_older_than function
+\i _shared/prune_data_older_than.sql.raw
+
+-- Create a flow with 4 steps to test different status combinations
+select pgflow.create_flow('status_test_flow', max_attempts => 0);
+select pgflow.add_step('status_test_flow', 'step1');
+select pgflow.add_step('status_test_flow', 'step2', ARRAY['step1']);
+select pgflow.add_step('status_test_flow', 'step3', ARRAY['step2']);
+select pgflow.add_step('status_test_flow', 'step4', ARRAY['step3']);
+
+-- Start the flow to create all step_states
+select pgflow.start_flow('status_test_flow', '{}'::jsonb);
+
+-- Manually set up different statuses to test edge cases
+-- step1: completed (normal case)
+-- step2: started but not completed (worker crashed)
+-- step3: created (never started)
+-- step4: created (never started)
+
+-- Update run to completed status with old timestamp
+update pgflow.runs
+set
+  started_at = now() - interval '35 days',
+  completed_at = now() - interval '35 days',
+  status = 'completed',
+  remaining_steps = 0
+where flow_slug = 'status_test_flow';
+
+-- step1: completed
+update pgflow.step_states
+set
+  created_at = now() - interval '36 days',
+  started_at = now() - interval '35 days' - interval '1 minute',
+  completed_at = now() - interval '35 days',
+  status = 'completed',
+  remaining_tasks = 0
+where flow_slug = 'status_test_flow' and step_slug = 'step1';
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '36 days',
+  started_at = now() - interval '35 days' - interval '1 minute',
+  completed_at = now() - interval '35 days',
+  status = 'completed'
+where flow_slug = 'status_test_flow' and step_slug = 'step1';
+
+-- step2: started but not completed (simulates worker crash)
+update pgflow.step_states
+set
+  created_at = now() - interval '36 days',
+  started_at = now() - interval '35 days',
+  status = 'started',
+  completed_at = NULL,
+  failed_at = NULL
+where flow_slug = 'status_test_flow' and step_slug = 'step2';
+
+insert into pgflow.step_tasks (flow_slug, run_id, step_slug, task_index, status, queued_at, started_at)
+select
+  'status_test_flow',
+  run_id,
+  'step2',
+  0,
+  'started',
+  now() - interval '36 days',
+  now() - interval '35 days'
+from pgflow.runs where flow_slug = 'status_test_flow';
+
+-- step3: created but never started
+update pgflow.step_states
+set
+  created_at = now() - interval '36 days',
+  status = 'created',
+  started_at = NULL,
+  completed_at = NULL,
+  failed_at = NULL
+where flow_slug = 'status_test_flow' and step_slug = 'step3';
+
+-- step4: created but never started
+update pgflow.step_states
+set
+  created_at = now() - interval '36 days',
+  status = 'created',
+  started_at = NULL,
+  completed_at = NULL,
+  failed_at = NULL
+where flow_slug = 'status_test_flow' and step_slug = 'step4';
+
+-- Verify the setup before pruning
+select is(
+  (select count(*) from pgflow.step_states where flow_slug = 'status_test_flow' and status = 'completed'),
+  1::bigint,
+  'Should have 1 completed step'
+);
+
+select is(
+  (select count(*) from pgflow.step_states where flow_slug = 'status_test_flow' and status = 'started'),
+  1::bigint,
+  'Should have 1 started step'
+);
+
+select is(
+  (select count(*) from pgflow.step_states where flow_slug = 'status_test_flow' and status = 'created'),
+  2::bigint,
+  'Should have 2 created steps'
+);
+
+-- Prune with 30-day retention
+-- All records should be deleted regardless of individual status
+select pgflow.prune_data_older_than(make_interval(days => 30));
+
+-- TEST: All runs deleted
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'status_test_flow'),
+  0::bigint,
+  'Completed run should be deleted'
+);
+
+-- TEST: All step_states deleted (completed, started, and created)
+select is(
+  (select count(*) from pgflow.step_states where flow_slug = 'status_test_flow'),
+  0::bigint,
+  'All step_states should be deleted regardless of status'
+);
+
+-- TEST: All step_tasks deleted
+select is(
+  (select count(*) from pgflow.step_tasks where flow_slug = 'status_test_flow'),
+  0::bigint,
+  'All step_tasks should be deleted regardless of status'
+);
+
+select finish();
+rollback;

--- a/pkgs/core/supabase/tests/maintenance/prune_failed_run_with_unexecuted_steps.test.sql
+++ b/pkgs/core/supabase/tests/maintenance/prune_failed_run_with_unexecuted_steps.test.sql
@@ -1,0 +1,94 @@
+begin;
+select plan(7);
+select pgflow_tests.reset_db();
+
+-- Load the prune_data_older_than function
+\i _shared/prune_data_older_than.sql.raw
+
+-- Create a flow with 3 sequential steps
+select pgflow.create_flow('multi_step_flow', max_attempts => 0);
+select pgflow.add_step('multi_step_flow', 'step1');
+select pgflow.add_step('multi_step_flow', 'step2', ARRAY['step1']);
+select pgflow.add_step('multi_step_flow', 'step3', ARRAY['step2']);
+
+-- Start the flow and fail step1
+-- This causes the run to fail, leaving step2 and step3 unexecuted
+select pgflow.start_flow('multi_step_flow', '{}'::jsonb);
+select pgflow_tests.poll_and_fail('multi_step_flow');
+
+-- Verify setup: Run failed, step1 failed, step2 and step3 never executed
+select is(
+  (select status from pgflow.runs where flow_slug = 'multi_step_flow'),
+  'failed',
+  'Run should be marked as failed'
+);
+
+select is(
+  (select status from pgflow.step_states where flow_slug = 'multi_step_flow' and step_slug = 'step1'),
+  'failed',
+  'step1 should be failed'
+);
+
+select is(
+  (select status from pgflow.step_states where flow_slug = 'multi_step_flow' and step_slug = 'step2'),
+  'created',
+  'step2 should remain in created status (unexecuted)'
+);
+
+select is(
+  (select status from pgflow.step_states where flow_slug = 'multi_step_flow' and step_slug = 'step3'),
+  'created',
+  'step3 should remain in created status (unexecuted)'
+);
+
+-- Age the failed run to make it old
+update pgflow.runs
+set
+  started_at = now() - interval '31 days',
+  failed_at = now() - interval '31 days',
+  status = 'failed'
+where flow_slug = 'multi_step_flow';
+
+update pgflow.step_states
+set
+  created_at = now() - interval '31 days',
+  started_at = now() - interval '31 days' + interval '1 minute',
+  failed_at = now() - interval '31 days' + interval '2 minutes',
+  status = 'failed'
+where flow_slug = 'multi_step_flow' and step_slug = 'step1';
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '31 days',
+  started_at = now() - interval '31 days' + interval '1 minute',
+  failed_at = now() - interval '31 days' + interval '2 minutes',
+  status = 'failed'
+where flow_slug = 'multi_step_flow' and step_slug = 'step1';
+
+-- Prune old records with 30-day retention
+-- This should delete ALL records for the failed run, including unexecuted steps
+select pgflow.prune_data_older_than(make_interval(days => 30));
+
+-- TEST: All runs should be deleted
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'multi_step_flow'),
+  0::bigint,
+  'Failed run should be deleted'
+);
+
+-- TEST: All step_states should be deleted (including unexecuted ones)
+select is(
+  (select count(*) from pgflow.step_states where flow_slug = 'multi_step_flow'),
+  0::bigint,
+  'All step_states should be deleted, including unexecuted steps'
+);
+
+-- TEST: All step_tasks should be deleted
+select is(
+  (select count(*) from pgflow.step_tasks where flow_slug = 'multi_step_flow'),
+  0::bigint,
+  'All step_tasks should be deleted'
+);
+
+select finish();
+rollback;

--- a/pkgs/core/supabase/tests/maintenance/prune_multiple_runs_same_flow.test.sql
+++ b/pkgs/core/supabase/tests/maintenance/prune_multiple_runs_same_flow.test.sql
@@ -1,0 +1,208 @@
+begin;
+select plan(8);
+select pgflow_tests.reset_db();
+
+-- Load the prune_data_older_than function
+\i _shared/prune_data_older_than.sql.raw
+
+-- Create a single flow that will have multiple runs
+select pgflow.create_flow('multi_run_flow', max_attempts => 0);
+select pgflow.add_step('multi_run_flow', 'step1');
+
+-- Start 5 runs of the same flow with different outcomes
+-- Run 1: Will complete and be aged to 31 days (should be pruned)
+select pgflow.start_flow('multi_run_flow', '{"run": 1}'::jsonb);
+select pgflow_tests.poll_and_complete('multi_run_flow');
+
+-- Run 2: Will fail and be aged to 31 days (should be pruned)
+select pgflow.start_flow('multi_run_flow', '{"run": 2}'::jsonb);
+select pgflow_tests.poll_and_fail('multi_run_flow');
+
+-- Run 3: Will complete and be aged to 29 days (should NOT be pruned)
+select pgflow.start_flow('multi_run_flow', '{"run": 3}'::jsonb);
+select pgflow_tests.poll_and_complete('multi_run_flow');
+
+-- Run 4: Will fail and be aged to 29 days (should NOT be pruned)
+select pgflow.start_flow('multi_run_flow', '{"run": 4}'::jsonb);
+select pgflow_tests.poll_and_fail('multi_run_flow');
+
+-- Run 5: Will remain running (should NOT be pruned regardless of age)
+select pgflow.start_flow('multi_run_flow', '{"run": 5}'::jsonb);
+
+-- Verify setup: should have 5 runs
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'multi_run_flow'),
+  5::bigint,
+  'Should have 5 runs before pruning'
+);
+
+-- Store run_ids for verification
+create temp table run_ids as
+select
+  run_id,
+  input->>'run' as run_number,
+  status
+from pgflow.runs
+where flow_slug = 'multi_run_flow'
+order by (input->>'run')::int;
+
+-- Age run 1 (completed, 31 days old - should be pruned)
+update pgflow.runs
+set
+  started_at = now() - interval '32 days',
+  completed_at = now() - interval '31 days'
+where run_id = (select run_id from run_ids where run_number = '1');
+
+update pgflow.step_states
+set
+  created_at = now() - interval '32 days',
+  started_at = now() - interval '31 days' - interval '1 minute',
+  completed_at = now() - interval '31 days'
+where run_id = (select run_id from run_ids where run_number = '1');
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '32 days',
+  started_at = now() - interval '31 days' - interval '1 minute',
+  completed_at = now() - interval '31 days'
+where run_id = (select run_id from run_ids where run_number = '1');
+
+-- Age run 2 (failed, 31 days old - should be pruned)
+update pgflow.runs
+set
+  started_at = now() - interval '32 days',
+  failed_at = now() - interval '31 days'
+where run_id = (select run_id from run_ids where run_number = '2');
+
+update pgflow.step_states
+set
+  created_at = now() - interval '32 days',
+  started_at = now() - interval '31 days' - interval '1 minute',
+  failed_at = now() - interval '31 days'
+where run_id = (select run_id from run_ids where run_number = '2');
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '32 days',
+  started_at = now() - interval '31 days' - interval '1 minute',
+  failed_at = now() - interval '31 days'
+where run_id = (select run_id from run_ids where run_number = '2');
+
+-- Age run 3 (completed, 29 days old - should NOT be pruned)
+update pgflow.runs
+set
+  started_at = now() - interval '30 days',
+  completed_at = now() - interval '29 days'
+where run_id = (select run_id from run_ids where run_number = '3');
+
+update pgflow.step_states
+set
+  created_at = now() - interval '30 days',
+  started_at = now() - interval '29 days' - interval '1 minute',
+  completed_at = now() - interval '29 days'
+where run_id = (select run_id from run_ids where run_number = '3');
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '30 days',
+  started_at = now() - interval '29 days' - interval '1 minute',
+  completed_at = now() - interval '29 days'
+where run_id = (select run_id from run_ids where run_number = '3');
+
+-- Age run 4 (failed, 29 days old - should NOT be pruned)
+update pgflow.runs
+set
+  started_at = now() - interval '30 days',
+  failed_at = now() - interval '29 days'
+where run_id = (select run_id from run_ids where run_number = '4');
+
+update pgflow.step_states
+set
+  created_at = now() - interval '30 days',
+  started_at = now() - interval '29 days' - interval '1 minute',
+  failed_at = now() - interval '29 days'
+where run_id = (select run_id from run_ids where run_number = '4');
+
+update pgflow.step_tasks
+set
+  queued_at = now() - interval '30 days',
+  started_at = now() - interval '29 days' - interval '1 minute',
+  failed_at = now() - interval '29 days'
+where run_id = (select run_id from run_ids where run_number = '4');
+
+-- Age run 5 (still running, 40 days old - should NOT be pruned despite age)
+update pgflow.runs
+set started_at = now() - interval '40 days'
+where run_id = (select run_id from run_ids where run_number = '5');
+
+update pgflow.step_states
+set created_at = now() - interval '40 days'
+where run_id = (select run_id from run_ids where run_number = '5');
+
+update pgflow.step_tasks
+set queued_at = now() - interval '40 days'
+where run_id = (select run_id from run_ids where run_number = '5');
+
+-- Prune with 30-day retention
+select pgflow.prune_data_older_than(make_interval(days => 30));
+
+-- TEST: Should have 3 runs left (runs 3, 4, 5)
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'multi_run_flow'),
+  3::bigint,
+  'Should have 3 runs after pruning (kept runs 3, 4, 5)'
+);
+
+-- TEST: Verify specific runs are deleted
+select is(
+  (select count(*) from pgflow.runs
+   where run_id in (
+     select run_id from run_ids where run_number in ('1', '2')
+   )),
+  0::bigint,
+  'Runs 1 and 2 should be deleted (old completed/failed)'
+);
+
+-- TEST: Verify specific runs are kept
+select is(
+  (select count(*) from pgflow.runs
+   where run_id in (
+     select run_id from run_ids where run_number in ('3', '4', '5')
+   )),
+  3::bigint,
+  'Runs 3, 4, and 5 should be kept (recent or still running)'
+);
+
+-- TEST: Verify step_states count matches
+select is(
+  (select count(*) from pgflow.step_states where flow_slug = 'multi_run_flow'),
+  3::bigint,
+  'Should have 3 step_states after pruning'
+);
+
+-- TEST: Verify step_tasks count matches
+select is(
+  (select count(*) from pgflow.step_tasks where flow_slug = 'multi_run_flow'),
+  3::bigint,
+  'Should have 3 step_tasks after pruning'
+);
+
+-- TEST: Verify still-running run is kept despite being very old
+select is(
+  (select count(*) from pgflow.runs
+   where run_id = (select run_id from run_ids where run_number = '5')
+   and status = 'started'),
+  1::bigint,
+  'Still-running run should be kept even though it is 40 days old'
+);
+
+-- TEST: Verify run data integrity - run 3 should have correct input
+select is(
+  (select input->>'run' from pgflow.runs
+   where run_id = (select run_id from run_ids where run_number = '3')),
+  '3',
+  'Kept run should maintain correct data (run 3 input preserved)'
+);
+
+select finish();
+rollback;

--- a/pkgs/core/supabase/tests/maintenance/prune_null_message_ids.test.sql
+++ b/pkgs/core/supabase/tests/maintenance/prune_null_message_ids.test.sql
@@ -1,0 +1,98 @@
+begin;
+select plan(6);
+select pgflow_tests.reset_db();
+
+-- Load the prune_data_older_than function
+\i _shared/prune_data_older_than.sql.raw
+
+-- Create a flow with one step
+select pgflow.create_flow('null_msg_flow', max_attempts => 0);
+select pgflow.add_step('null_msg_flow', 'step1');
+
+-- Start the flow - this creates a task with a message_id
+select pgflow.start_flow('null_msg_flow', '{}'::jsonb);
+
+-- Verify the task was created with a message_id
+select is(
+  (select message_id is not null from pgflow.step_tasks where flow_slug = 'null_msg_flow'),
+  true,
+  'Task should have a message_id after start_flow'
+);
+
+-- Manually set message_id to NULL to simulate tasks that never got queued to PGMQ
+-- This can happen in edge cases or during failure scenarios
+update pgflow.step_tasks
+set message_id = null
+where flow_slug = 'null_msg_flow';
+
+-- Verify message_id is now NULL
+select is(
+  (select message_id from pgflow.step_tasks where flow_slug = 'null_msg_flow'),
+  null::bigint,
+  'Task message_id should be NULL after manual update'
+);
+
+-- Mark the run as failed (simulating a failure scenario)
+update pgflow.runs
+set
+  status = 'failed',
+  failed_at = now()
+where flow_slug = 'null_msg_flow';
+
+update pgflow.step_states
+set
+  status = 'failed',
+  failed_at = now()
+where flow_slug = 'null_msg_flow';
+
+-- Age the run to make it eligible for pruning
+update pgflow.runs
+set
+  started_at = now() - interval '31 days',
+  failed_at = now() - interval '31 days'
+where flow_slug = 'null_msg_flow';
+
+update pgflow.step_states
+set
+  created_at = now() - interval '31 days',
+  started_at = now() - interval '31 days' + interval '1 minute',
+  failed_at = now() - interval '31 days' + interval '2 minutes'
+where flow_slug = 'null_msg_flow';
+
+update pgflow.step_tasks
+set queued_at = now() - interval '31 days'
+where flow_slug = 'null_msg_flow';
+
+-- Verify setup before pruning
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'null_msg_flow'),
+  1::bigint,
+  'Should have 1 run before pruning'
+);
+
+select is(
+  (select count(*) from pgflow.step_tasks where flow_slug = 'null_msg_flow'),
+  1::bigint,
+  'Should have 1 step_task before pruning'
+);
+
+-- Prune with 30-day retention
+-- This should handle NULL message_id gracefully without errors
+select pgflow.prune_data_older_than(make_interval(days => 30));
+
+-- TEST: All records should be deleted despite NULL message_id
+select is(
+  (select count(*) from pgflow.runs where flow_slug = 'null_msg_flow'),
+  0::bigint,
+  'Run should be deleted even with NULL message_id in step_tasks'
+);
+
+-- TEST: step_tasks with NULL message_id should also be deleted
+select is(
+  (select count(*) from pgflow.step_tasks where flow_slug = 'null_msg_flow'),
+  0::bigint,
+  'step_tasks with NULL message_id should be deleted'
+);
+
+select finish();
+rollback;

--- a/pkgs/website/src/content/docs/how-to/prune-old-records.mdx
+++ b/pkgs/website/src/content/docs/how-to/prune-old-records.mdx
@@ -11,15 +11,43 @@ import pruningFunctionCode from '../../../../../core/supabase/tests/_shared/prun
 
 As your workflows accumulate, pgflow tables gather historical data. While valuable for auditing, keeping this data indefinitely can impact performance and storage costs.
 
-<Aside type="note" title="What gets pruned">
-The pruning function removes completed and failed records from:
-- `pgflow.workers` - Inactive worker records
-- `pgflow.step_tasks` - Completed or failed task records
-- `pgflow.step_states` - Completed or failed step state records
-- `pgflow.runs` - Completed or failed workflow run records
-- `pgmq.a_{flow_slug}` - Archived messages from PGMQ tables
+<Aside type="danger" title="DANGER: This function is destructive and irreversible">
+**Read this entire page carefully before using this function.** Incorrect usage can delete data before tasks have a chance to execute, especially when using [startDelay](/getting-started/configuration/#startdelay).
 
-Important: Only records older than the specified retention period are pruned. Active or running records (including tasks with 'started' status) are never removed regardless of age.
+**This function deletes BOTH completed AND failed runs.** There is no way to preserve failed runs for longer investigation periods.
+</Aside>
+
+<Aside type="note" title="What gets pruned">
+When a run (completed or failed) is older than the retention period, **ALL** associated records are deleted, including:
+
+**Database records deleted:**
+- `pgflow.runs` - The run record itself
+- `pgflow.step_states` - ALL step states, regardless of status (created, started, completed, failed)
+- `pgflow.step_tasks` - ALL tasks, regardless of status (queued, started, completed, failed)
+- `pgflow.workers` - Inactive workers (based on last_heartbeat_at)
+
+**PGMQ messages deleted:**
+- Active queue messages (`pgmq.q_{flow_slug}`) - Including delayed/queued messages
+- Archived messages (`pgmq.a_{flow_slug}`) - Already completed/failed messages
+
+**What is NOT pruned:**
+- Runs that are still active (status='started'), regardless of age
+- Flow and step definitions (these are never pruned)
+</Aside>
+
+<Aside type="danger" title="CRITICAL: Retention period vs startDelay">
+If you use [startDelay](/getting-started/configuration/#startdelay) on any steps, your retention period **MUST be longer** than your longest delay.
+
+**Example of what goes wrong:**
+- Step has `startDelay='60 days'` (e.g., "send reminder in 60 days")
+- Run fails on day 1, leaving delayed task queued
+- Prune runs on day 30 with retention='30 days'
+- Task and message deleted on day 30
+- Message would have executed on day 60 → **Lost!**
+
+**Safe retention period:** `longest_startDelay + 30 days` (buffer for run completion)
+
+Example: If longest startDelay is 60 days, use at least 90-day retention.
 </Aside>
 
 ## Using the Pruning Function
@@ -30,19 +58,28 @@ pgflow includes a pruning function that accepts an INTERVAL parameter specifying
 pgflow.prune_data_older_than(retention_interval INTERVAL)
 ```
 
+<Aside type="caution" title="Test on staging first">
+**Always test pruning on a staging environment first** to verify:
+- Retention period is appropriate for your workflows
+- No tasks with long start_delay will be affected
+- Database performance impact is acceptable
+
+This operation is **irreversible** - there is no undo or recovery.
+</Aside>
+
 Examples:
 ```sql
--- Keep 30 days of data using make_interval
+-- Keep 90 days of data (recommended default)
+SELECT pgflow.prune_data_older_than(make_interval(days => 90));
+
+-- Keep 30 days of data (only if no long start_delay)
 SELECT pgflow.prune_data_older_than(make_interval(days => 30));
 
--- Keep 7 days of data
-SELECT pgflow.prune_data_older_than(make_interval(days => 7));
+-- Keep 6 months of data using interval literals
+SELECT pgflow.prune_data_older_than(INTERVAL '6 months');
 
--- Keep 3 months of data using interval literals
-SELECT pgflow.prune_data_older_than(INTERVAL '3 months');
-
--- Keep 2 weeks
-SELECT pgflow.prune_data_older_than(INTERVAL '2 weeks');
+-- Keep 1 year for compliance requirements
+SELECT pgflow.prune_data_older_than(INTERVAL '1 year');
 ```
 
 <Aside type="caution">
@@ -54,7 +91,11 @@ This function is not yet included in the default pgflow migrations as we're gath
 You can use pg_cron to schedule automated pruning.
 
 <Aside type="tip" title="Performance Impact">
-Make sure to adjust intervals and time of pruning based on size of your tables and queues!
+Run pruning during low-traffic periods. The operation can be resource-intensive for large datasets. Monitor database performance during first few runs to determine optimal schedule.
+</Aside>
+
+<Aside type="danger" title="Before automating">
+**Test the retention period manually first!** Only automate pruning after you've verified the retention period is safe for your workflows on staging.
 </Aside>
 
 ### 1. Install the pruning function
@@ -67,11 +108,11 @@ Run it in Supabase Studio or include in a migration file:
 
 ```sql
 -- Schedule weekly pruning (every Sunday at 2 AM)
--- This keeps 28 days of data (adjust as needed)
+-- This keeps 90 days of data (adjust based on your needs)
 SELECT cron.schedule(
   'pgflow-prune-weekly',
   '0 2 * * 0', -- cron expression: minute hour day month weekday
-  $$SELECT pgflow.prune_data_older_than(make_interval(days => 28))$$
+  $$SELECT pgflow.prune_data_older_than(make_interval(days => 90))$$
 );
 ```
 


### PR DESCRIPTION
## Problem

The `pgflow.prune_data_older_than()` function failed with foreign key constraint violations when pruning old workflow data:

```
ERROR: update or delete on table "runs" violates foreign key constraint
"step_states_run_id_fkey" on table "step_states"
```

## Root Cause

The original implementation deleted records based on **individual step/task status**:

- Only deleted steps with `status='completed'` or `status='failed'`
- When a run failed, unexecuted steps remained in `status='created'` or `status='started'`
- These orphaned steps still referenced the run
- Deleting the run caused FK constraint violation

**Example**: Run fails at step1. Step2 and step3 never execute (remain `status='created'`). Prune deletes step1 but not step2/step3, then tries to delete the run → FK violation.

## Solution

Changed to delete **all children for runs that are completed/failed**, regardless of individual record status:

```
-- Delete ALL step_states/step_tasks for old runs
DELETE FROM pgflow.step_states
WHERE run_id IN (
  SELECT run_id FROM pgflow.runs
  WHERE (completed_at IS NOT NULL AND completed_at < cutoff) OR
        (failed_at IS NOT NULL AND failed_at < cutoff)
);
```

The run's completion/failure status is authoritative - when a run is old enough to prune, all associated records are deleted together.

## Changes

### Fixed Function

- `pkgs/core/supabase/tests/_shared/prune_data_older_than.sql.raw` - Corrected deletion logic

### Fixed Tests

- Fixed timestamp constraint violations in existing tests (3 files)
- All tests now properly maintain temporal ordering: `created_at <= started_at <= (completed_at | failed_at)`

### New Tests

- `prune_multiple_runs_same_flow.test.sql` - Tests multiple runs of same flow with different ages and statuses
- `prune_null_message_ids.test.sql` - Tests tasks with NULL message_ids

### Documentation

- `pkgs/website/src/content/docs/news/fixed-data-pruning-foreign-key-constraint-bug.mdx` - Bug fix announcement

## Test Coverage

**11 tests, 67 assertions** covering:

- ✅ Completed runs (old vs recent)
- ✅ Failed runs (old vs recent)
- ✅ Failed runs with unexecuted steps
- ✅ Multiple runs of same flow at different ages
- ✅ Mixed step statuses (completed/started/created)
- ✅ Still-running flows (never pruned regardless of age)
- ✅ NULL message_ids
- ✅ PGMQ message cleanup
- ✅ PGMQ archive pruning
- ✅ Worker pruning

All tests pass ✓

## Impact

- Function is not in default migrations yet (optional installation via docs)
- Only affects users who manually installed `prune_data_older_than()`
- Users should update by copying the fixed SQL from [docs](/how-to/prune-old-records/#the-pruning-function)