### PR TITLE
fix: update Deno compile command to use --config instead of --import-map

### DIFF
--- a/.changeset/fix-compile-config-flag.md
+++ b/.changeset/fix-compile-config-flag.md
@@ -1,0 +1,9 @@
+---
+'@pgflow/cli': patch
+---
+
+Fix: Use --config instead of --import-map for Deno compilation
+
+The compile command now uses Deno's --config flag instead of --import-map, enabling full deno.json support including nodeModulesDir, compilerOptions, unstable features, and other configuration options. Previously, these options would cause "Invalid top-level key" warnings.
+
+This is a backward-compatible bug fix. Existing deno.json files with only "imports" continue to work as before.

--- a/pkgs/cli/README.md
+++ b/pkgs/cli/README.md
@@ -70,7 +70,7 @@ npx pgflow@latest compile supabase/functions/_flows/my_flow.ts
 
 Options:
 
-- `--deno-json <path>` - Path to custom deno.json with import map
+- `--deno-json <path>` - Path to custom deno.json configuration file
 - `--supabase-path <path>` - Path to custom Supabase directory
 
 The compiler will:

--- a/pkgs/cli/examples/deno.json
+++ b/pkgs/cli/examples/deno.json
@@ -1,4 +1,5 @@
 {
+  "nodeModulesDir": true,
   "imports": {
     "@pgflow/dsl": "npm:@pgflow/dsl"
   }

--- a/pkgs/cli/src/commands/compile/README.md
+++ b/pkgs/cli/src/commands/compile/README.md
@@ -14,7 +14,7 @@ pgflow compile path/to/flow.ts --deno-json=path/to/deno.json
 
 ## Options
 
-- `--deno-json=path/to/deno.json`: (Required) Path to the deno.json file with a valid importMap that includes the pgflow DSL package.
+- `--deno-json=path/to/deno.json`: (Required) Path to the deno.json configuration file that includes the pgflow DSL package in its imports.
 
 ## Example
 
@@ -30,7 +30,7 @@ pgflow compile src/flows/analyze-website.ts --deno-json=deno.json
 
 - Deno must be installed on your system
 - The flow file must have a default export
-- The deno.json file must have a valid importMap that includes the pgflow DSL package
+- The deno.json file must include the pgflow DSL package in its imports
 
 ## Example deno.json
 

--- a/pkgs/cli/src/commands/compile/index.ts
+++ b/pkgs/cli/src/commands/compile/index.ts
@@ -17,8 +17,8 @@ const __dirname = path.dirname(__filename);
 function formatCommand(command: string, args: string[]): string {
   const cmd = chalk.cyan(command);
   const formattedArgs = args.map((arg) => {
-    // Highlight import map and file paths differently
-    if (arg.startsWith('--import-map=')) {
+    // Highlight config and file paths differently
+    if (arg.startsWith('--config=')) {
       const [flag, value] = arg.split('=');
       return `  ${chalk.yellow(flag)}=${chalk.green(value)}`;
     } else if (arg.startsWith('--')) {
@@ -56,7 +56,7 @@ export default (program: Command) => {
     .argument('<flowPath>', 'Path to the flow TypeScript file')
     .option(
       '--deno-json <denoJsonPath>',
-      'Path to deno.json with valid importMap'
+      'Path to deno.json configuration file'
     )
     .option('--supabase-path <supabasePath>', 'Path to the Supabase folder')
     .action(async (flowPath, options) => {
@@ -222,9 +222,9 @@ async function runDenoCompilation(
     // Build the command arguments array
     const args = ['run', '--allow-read', '--allow-net', '--allow-env'];
 
-    // Only add the import-map argument if denoJsonPath is provided and valid
+    // Only add the config argument if denoJsonPath is provided and valid
     if (denoJsonPath && typeof denoJsonPath === 'string') {
-      args.push(`--import-map=${denoJsonPath}`);
+      args.push(`--config=${denoJsonPath}`);
     }
 
     // Add the script path and flow path


### PR DESCRIPTION
- Changed CLI code to replace --import-map with --config for deno.json
- Updated README and examples to reflect the new --deno-json option
- Modified import path highlighting to recognize --config flag
- Ensured backward compatibility with existing deno.json files
- Improved documentation clarity for configuring Deno compilation