### PR TITLE
Fix CLI config.toml corruption with minimal configs

### DIFF
--- a/.changeset/fix-minimal-config.md
+++ b/.changeset/fix-minimal-config.md
@@ -1,0 +1,5 @@
+---
+'pgflow': patch
+---
+
+Fix config.toml corruption when updating minimal configurations (issue #143)

--- a/pkgs/cli/__tests__/commands/install/update-config-toml.test.ts
+++ b/pkgs/cli/__tests__/commands/install/update-config-toml.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { parse as parseTOML, stringify as stringifyTOML } from 'smol-toml';
+import { updateConfigToml } from '../../../src/commands/install/update-config-toml';
+
+describe('updateConfigToml', () => {
+  let tempDir: string;
+  let supabasePath: string;
+
+  beforeEach(() => {
+    // Create a temporary directory for testing
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgflow-test-'));
+    supabasePath = path.join(tempDir, 'supabase');
+    fs.mkdirSync(supabasePath, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Clean up the temporary directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should handle minimal config without [db] section (issue #143)', async () => {
+    // This is the minimal config from issue #143
+    const minimalConfig = `project_id = "xxxxxxxxxxx"
+
+[auth]
+enabled = true
+site_url = "https://siteurl.com"
+additional_redirect_urls = ["http://127.0.0.1:8080", "https://127.0.0.1:8080", "http://localhost:8080", "https://localhost:8080"]
+
+[auth.external.github]
+enabled = true
+client_id = "env(GITHUB_OAUTH_CLIENT_ID)"
+secret = "env(GITHUB_OAUTH_CLIENT_SECRET)"
+redirect_uri = "http://localhost:54321/auth/v1/callback"
+`;
+
+    const configPath = path.join(supabasePath, 'config.toml');
+    fs.writeFileSync(configPath, minimalConfig);
+
+    // Call updateConfigToml - this should not hang or corrupt the file
+    const result = await updateConfigToml({
+      supabasePath,
+      autoConfirm: true,
+    });
+
+    // Verify the function completed successfully
+    expect(result).toBe(true);
+
+    // Verify the file exists and is readable
+    expect(fs.existsSync(configPath)).toBe(true);
+    const updatedContent = fs.readFileSync(configPath, 'utf8');
+
+    // Debug: log the actual output
+    console.log('Updated config.toml content:');
+    console.log(updatedContent);
+    console.log('---');
+
+    // First, verify the output is valid TOML that can be parsed
+    let parsedConfig;
+    expect(() => {
+      parsedConfig = parseTOML(updatedContent);
+    }).not.toThrow();
+
+    // Then verify it can be round-tripped (parse -> stringify -> parse)
+    // This catches cases where the TOML is "parseable" but malformed
+    let roundTrippedConfig;
+    expect(() => {
+      const stringified = stringifyTOML(parsedConfig);
+      roundTrippedConfig = parseTOML(stringified);
+    }).not.toThrow();
+
+    // Verify original content is preserved (check this FIRST to fail clearly if TOML is invalid)
+    expect(parsedConfig.project_id, 'project_id should be preserved in parsed config').toBe('xxxxxxxxxxx');
+    expect(parsedConfig.auth?.enabled).toBe(true);
+    expect(parsedConfig.auth?.site_url).toBe('https://siteurl.com');
+    expect(parsedConfig.auth?.external?.github?.enabled).toBe(true);
+
+    // Verify required sections were added
+    expect(parsedConfig.db?.pooler?.enabled).toBe(true);
+    expect(parsedConfig.db?.pooler?.pool_mode).toBe('transaction');
+    expect(parsedConfig.edge_runtime?.policy).toBe('per_worker');
+
+    // Verify backup was created
+    const backupPath = `${configPath}.backup`;
+    expect(fs.existsSync(backupPath)).toBe(true);
+  });
+
+  it('should handle config with existing [db] section but no pooler', async () => {
+    const configWithDb = `project_id = "test123"
+
+[db]
+# Some other db config
+major_version = 15
+
+[auth]
+enabled = true
+`;
+
+    const configPath = path.join(supabasePath, 'config.toml');
+    fs.writeFileSync(configPath, configWithDb);
+
+    const result = await updateConfigToml({
+      supabasePath,
+      autoConfirm: true,
+    });
+
+    expect(result).toBe(true);
+
+    const updatedContent = fs.readFileSync(configPath, 'utf8');
+    const parsedConfig = parseTOML(updatedContent);
+
+    expect(parsedConfig.db?.pooler?.enabled).toBe(true);
+    expect(parsedConfig.db?.pooler?.pool_mode).toBe('transaction');
+    expect(parsedConfig.db?.major_version).toBe(15);
+  });
+
+  it('should handle completely empty sections', async () => {
+    const minimalConfig = `project_id = "test123"
+`;
+
+    const configPath = path.join(supabasePath, 'config.toml');
+    fs.writeFileSync(configPath, minimalConfig);
+
+    const result = await updateConfigToml({
+      supabasePath,
+      autoConfirm: true,
+    });
+
+    expect(result).toBe(true);
+
+    const updatedContent = fs.readFileSync(configPath, 'utf8');
+
+    // First verify the TOML is valid and parseable
+    let parsedConfig;
+    expect(() => {
+      parsedConfig = parseTOML(updatedContent);
+    }).not.toThrow();
+
+    // Verify it can be round-tripped
+    expect(() => {
+      const stringified = stringifyTOML(parsedConfig);
+      parseTOML(stringified);
+    }).not.toThrow();
+
+    // Verify original content is preserved
+    expect(parsedConfig.project_id, 'project_id should be preserved in parsed config').toBe('test123');
+
+    // Verify required sections were added
+    expect(parsedConfig.db?.pooler?.enabled).toBe(true);
+    expect(parsedConfig.db?.pooler?.pool_mode).toBe('transaction');
+    expect(parsedConfig.edge_runtime?.policy).toBe('per_worker');
+  });
+
+  it('should not make changes if config is already correct', async () => {
+    const correctConfig = `project_id = "test123"
+
+[db.pooler]
+enabled = true
+pool_mode = "transaction"
+
+[edge_runtime]
+policy = "per_worker"
+`;
+
+    const configPath = path.join(supabasePath, 'config.toml');
+    fs.writeFileSync(configPath, correctConfig);
+
+    const result = await updateConfigToml({
+      supabasePath,
+      autoConfirm: true,
+    });
+
+    // Should return false because no changes were needed
+    expect(result).toBe(false);
+
+    // Verify backup was NOT created
+    const backupPath = `${configPath}.backup`;
+    expect(fs.existsSync(backupPath)).toBe(false);
+  });
+
+  it('should throw clear error for invalid TOML syntax', async () => {
+    const invalidToml = `project_id = "test123"
+
+[db.pooler]
+enabled = this is not valid toml syntax
+`;
+
+    const configPath = path.join(supabasePath, 'config.toml');
+    fs.writeFileSync(configPath, invalidToml);
+
+    // Should throw with clear error message
+    await expect(
+      updateConfigToml({
+        supabasePath,
+        autoConfirm: true,
+      })
+    ).rejects.toThrow(/Invalid TOML syntax/);
+
+    // Verify the error message includes the file path
+    await expect(
+      updateConfigToml({
+        supabasePath,
+        autoConfirm: true,
+      })
+    ).rejects.toThrow(/config\.toml/);
+  });
+
+  it('should handle full real-world config without losing any data', async () => {
+    // Read the full config fixture (348 lines with all Supabase settings)
+    const fixtureContent = fs.readFileSync(
+      path.join(__dirname, '../../fixtures/full-config.toml'),
+      'utf8'
+    );
+
+    const configPath = path.join(supabasePath, 'config.toml');
+    fs.writeFileSync(configPath, fixtureContent);
+
+    // Parse the original config to get "before" state
+    const beforeConfig = parseTOML(fixtureContent);
+
+    // Verify the fixture has the expected starting state (all 3 fields need updating)
+    expect(beforeConfig.db?.pooler?.enabled).toBe(false);
+    expect(beforeConfig.db?.pooler?.pool_mode).toBe('session');
+    expect(beforeConfig.edge_runtime?.policy).toBe('oneshot');
+
+    // Call updateConfigToml
+    const result = await updateConfigToml({
+      supabasePath,
+      autoConfirm: true,
+    });
+
+    expect(result).toBe(true);
+
+    // Read and parse the updated config
+    const updatedContent = fs.readFileSync(configPath, 'utf8');
+    const afterConfig = parseTOML(updatedContent);
+
+    // Verify it's valid TOML that can round-trip
+    expect(() => {
+      const stringified = stringifyTOML(afterConfig);
+      parseTOML(stringified);
+    }).not.toThrow();
+
+    // Create expected config: clone before and modify all 3 required fields
+    const expectedConfig = JSON.parse(JSON.stringify(beforeConfig));
+    expectedConfig.db.pooler.enabled = true;
+    expectedConfig.db.pooler.pool_mode = 'transaction';
+    expectedConfig.edge_runtime.policy = 'per_worker';
+
+    // Deep equality check: verify ONLY the 3 required fields changed
+    // If this fails, vitest will show a detailed diff of the objects
+    expect(afterConfig).toEqual(expectedConfig);
+
+    // Also compare as formatted JSON strings for an alternate view if needed
+    // This will show line-by-line diffs in test output if objects don't match
+    const afterJSON = JSON.stringify(afterConfig, null, 2);
+    const expectedJSON = JSON.stringify(expectedConfig, null, 2);
+    expect(afterJSON, 'Config objects should match when serialized to JSON').toBe(expectedJSON);
+
+    // Verify backup was created
+    const backupPath = `${configPath}.backup`;
+    expect(fs.existsSync(backupPath)).toBe(true);
+  });
+});

--- a/pkgs/cli/__tests__/fixtures/full-config.toml
+++ b/pkgs/cli/__tests__/fixtures/full-config.toml
@@ -1,0 +1,347 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "fix-cli-hanging-on-minimal-config"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "session"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "oneshot"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/pkgs/cli/package.json
+++ b/pkgs/cli/package.json
@@ -24,7 +24,7 @@
     "@pgflow/core": "workspace:*",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
-    "toml-patch": "^0.2.3"
+    "smol-toml": "^1.4.2"
   },
   "publishConfig": {
     "access": "public"

--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -34,12 +34,20 @@
     "test": {
       "executor": "nx:noop",
       "dependsOn": [
+        "test:vitest",
         "test:e2e:install",
         "test:e2e:install:duplicates",
         "test:e2e:compile"
       ],
       "options": {
         "parallel": false
+      }
+    },
+    "test:vitest": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "vitest run",
+        "cwd": "{projectRoot}"
       }
     },
     "test:e2e:install": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,9 +231,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
-      toml-patch:
-        specifier: ^0.2.3
-        version: 0.2.3
+      smol-toml:
+        specifier: ^1.4.2
+        version: 1.4.2
     devDependencies:
       '@types/node':
         specifier: ^22.14.1
@@ -20303,6 +20303,11 @@ packages:
     engines: {node: '>= 18'}
     dev: false
 
+  /smol-toml@1.4.2:
+    resolution: {integrity: sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==}
+    engines: {node: '>= 18'}
+    dev: false
+
   /snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
@@ -21278,10 +21283,6 @@ packages:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
     dev: true
-
-  /toml-patch@0.2.3:
-    resolution: {integrity: sha512-SQI/j7f2S/iQZmoWBWNUMTfVmPbhP3+YCqxB/q8iOjdnXBk29HDARHzjCazmwftZaylYuMSrTTrvJiESVyzJzw==}
-    dev: false
 
   /toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}


### PR DESCRIPTION
Fixes #143

## Problem

The `pgflow install` command corrupts `config.toml` when the file has minimal configuration without a `[db]` section. Top-level fields like `project_id` get placed inline with new section headers, creating invalid TOML that loses data.

## Root Cause

The `toml-patch` library (v0.2.3, unmaintained since 2019) incorrectly handles adding new sections to minimal configs, placing top-level fields inline with section headers instead of preserving them at the top level.

## Solution

Replaced `toml-patch` with `smol-toml` (v1.4.2, actively maintained). Simplified from complex `TOML.patch()` + regex post-processing to straightforward `parse()` → modify → `stringify()`.

**Tradeoff:** Comments in `config.toml` won't be preserved (no Node.js TOML library supports this properly). A backup is always created before modification.

## Changes

**Core Fix:**
- Replaced `toml-patch` dependency with `smol-toml`
- Simplified `update-config-toml.ts` implementation
- Removed complex regex post-processing

**Tests:**
- Added comprehensive unit tests (5 test cases)
- Created fixture with full 348-line real-world config
- Tests validate data preservation using dual comparison (object equality + JSON string diff)
- Added `test:vitest` target to run unit tests with `pnpm nx test cli`

## Test Coverage

1. Minimal config without `[db]` - Reproduces issue #143
2. Config with `[db]` but no `pooler` - Tests section augmentation
3. Completely minimal config - Tests full section creation
4. Already correct config - Tests no-op behavior
5. Full real-world config - Validates no data loss with 348-line fixture

Each test validates valid TOML output, round-trip capability, correct field updates, and data preservation.