### PR TITLE
Fix: Improve pre-migration check clarity and accuracy

### DIFF
--- a/.changeset/add-map-step-type-infrastructure.md
+++ b/.changeset/add-map-step-type-infrastructure.md
@@ -4,37 +4,39 @@
 
 Add map step type infrastructure in SQL core
 
-> [!WARNING]
-> **This migration includes automatic data migration**
->
-> The migration will automatically update existing `step_states` rows to satisfy new constraints. This should complete without issues due to strict check constraints enforced in previous versions.
+⚠️ **This migration includes automatic data migration**
 
-> [!TIP]
-> **Optional: Verify before deploying to production**
->
-> If you have existing production data and want to verify the migration will succeed cleanly, run this **read-only check query** (does not modify data) in **Supabase Studio** against your **production database**:
->
-> 1. Open Supabase Studio → SQL Editor
-> 2. Copy contents of `pkgs/core/queries/PRE_MIGRATION_CHECK_20251006073122.sql`
-> 3. Execute against your production database (not local dev!)
-> 4. Review results
->
-> **Expected output for successful migration:**
-> ```
-> type                  | identifier                | details
-> ----------------------|---------------------------|---------------------------
-> ISSUE_1_AUTO_FIXED    | run=abc12345 step=load    | status=created remaining_tasks=1 → will set to NULL
-> ISSUE_2_AUTO_FIXED    | run=def67890 step=process | status=started → will set initial_tasks=1
-> INFO_SUMMARY          | total_step_states=42      | created=5 started=2 completed=30 failed=5
-> ```
->
-> **Interpretation:**
-> - ✅ Only `ISSUE_1_AUTO_FIXED`, `ISSUE_2_AUTO_FIXED`, and `INFO_SUMMARY` rows? **Safe to migrate**
-> - 🆘 Unexpected issues or errors? Copy output and share on Discord for help
->
-> **Note:** This check only returns results indicating correctness or problems - it does not modify any data. Only useful for production databases with existing runs.
+The migration will automatically update existing `step_states` rows to satisfy new constraints. This should complete without issues due to strict check constraints enforced in previous versions.
+
+💡 **Recommended: Verify before deploying to production**
+
+If you have existing production data and want to verify the migration will succeed cleanly, run this **read-only check query** (does not modify data) in **Supabase Studio** against your **production database**:
+
+1. Open Supabase Studio → SQL Editor
+2. Copy contents of `pkgs/core/queries/PRE_MIGRATION_CHECK_20251006073122.sql`
+3. Execute against your production database (not local dev!)
+4. Review results
+
+**Expected output for successful migration:**
+
+```
+type                       | identifier                | details
+---------------------------|---------------------------|------------------------------------------
+DATA_BACKFILL_STARTED      | run=def67890 step=process | initial_tasks will be set to 1 (...)
+DATA_BACKFILL_COMPLETED    | Found 100 completed steps | initial_tasks will be set to 1 (...)
+INFO_SUMMARY               | total_step_states=114     | created=0 started=1 completed=113 failed=0
+```
+
+**Interpretation:**
+
+- ✅ Only `DATA_BACKFILL_*` and `INFO_SUMMARY` rows? **Safe to migrate**
+- ⚠️ These are expected data migrations handled automatically by the migration
+- 🆘 Unexpected rows or errors? Copy output and share on Discord for help
+
+📝 **Note:** This check identifies data that needs migration but does not modify anything. Only useful for production databases with existing runs.
 
 **Automatic data updates:**
+
 - Sets `initial_tasks = 1` for all existing steps (correct for pre-map-step schema)
 - Sets `remaining_tasks = NULL` for 'created' status steps (new semantics)
 
@@ -47,6 +49,7 @@ No manual intervention required.
 This patch introduces the foundation for map step functionality in the SQL core layer:
 
 ### Schema Changes
+
 - Added `step_type` column to `steps` table with constraint allowing 'single' or 'map' values
 - Added `initial_tasks` column to `step_states` table (defaults to 1, stores planned task count)
 - Modified `remaining_tasks` column to be nullable (NULL = not started, >0 = active countdown)
@@ -54,11 +57,13 @@ This patch introduces the foundation for map step functionality in the SQL core 
 - Removed `only_single_task_per_step` constraint from `step_tasks` table to allow multiple tasks per step
 
 ### Function Updates
+
 - **`add_step()`**: Now accepts `step_type` parameter (defaults to 'single') with validation that map steps can have at most 1 dependency
 - **`start_flow()`**: Sets `initial_tasks = 1` for all steps (map step array handling will come in future phases)
 - **`start_ready_steps()`**: Copies `initial_tasks` to `remaining_tasks` when starting a step, maintaining proper task counting semantics
 
 ### Testing
+
 - Added comprehensive test coverage for map step creation and validation
 - All existing tests pass with the new schema changes
 - Tests validate the new step_type parameter and dependency constraints for map steps


### PR DESCRIPTION
## Summary

Updates the pre-migration check script (`PRE_MIGRATION_CHECK_20251006073122.sql`) to provide clearer, more accurate messaging about data migrations. Also updates the changeset documentation to match.

## Problem

The original pre-migration check output was misleading:
- Used vague labels like `ISSUE_1_AUTO_FIXED` and `ISSUE_2_AUTO_FIXED`
- Didn't clearly communicate that these are **expected** data migrations
- Missing reporting for completed steps that need backfilling
- Could give false confidence that everything is "auto-fixed" without explaining the criticality

## Changes

### Pre-migration Check Script
- ✅ Renamed output types from `ISSUE_*_AUTO_FIXED` to descriptive `DATA_*` labels
- ✅ Added `DATA_BACKFILL_COMPLETED` row to report completed steps needing backfill
- ✅ Improved detail messages to clearly state what will happen during migration
- ✅ Added critical warning about packaged migration version bug
- ✅ Better documentation explaining how to interpret results

**Before:**
```
type                  | identifier              | details
----------------------|-------------------------|---------------------------
ISSUE_2_AUTO_FIXED    | run=8805ef09 step=embed | status=started → will set initial_tasks=1
INFO_SUMMARY          | total_step_states=114   | created=0 started=1 completed=113 failed=0
```

**After:**
```
type                       | identifier                | details
---------------------------|---------------------------|------------------------------------------
DATA_BACKFILL_STARTED      | run=8805ef09 step=embed   | initial_tasks will be set to 1 (inferred from remaining_tasks=1)
DATA_BACKFILL_COMPLETED    | Found 113 completed steps | initial_tasks will be set to 1 (old schema enforced single-task)
INFO_SUMMARY               | total_step_states=114     | created=0 started=1 completed=113 failed=0
```

### Changeset Documentation
- ✅ Updated example output to match new check format
- ✅ Replaced markdown callouts with emojis (⚠️ 💡 📝)
- ✅ Clarified interpretation guidance

## Testing

Verified against real production-like data:
1. ✅ Created test database with pgmq extension
2. ✅ Imported schema and data dump (114 step_states: 1 started, 113 completed)
3. ✅ Ran pre-migration check - output is clear and accurate
4. ✅ Ran full migration - completed successfully
5. ✅ Verified all data properly migrated (initial_tasks backfilled correctly)
6. ✅ Verified constraints enforce correctness post-migration

## Migration Verification Note

During testing, we confirmed:
- **Local migration file** (`20251006073122_pgflow_add_map_step_type.sql`) is **CORRECT** ✅
  - Properly splits ALTER TABLE statements
  - Backfills data between schema changes
  - Handles started steps correctly

- **Packaged migration** (from published npm package) is **BROKEN** ❌
  - Combines column addition and constraint addition in single ALTER TABLE
  - Will FAIL on databases with started steps
  - Package needs rebuild before next release

## Files Changed

- `pkgs/core/queries/PRE_MIGRATION_CHECK_20251006073122.sql` - Improved clarity and accuracy
- `.changeset/add-map-step-type-infrastructure.md` - Updated documentation and examples

## Related

- Original migration PR: #234
- Issue: Misleading pre-migration check output
