### PR TITLE
Restore toml-patch using @decimalturn/toml-patch

### DIFF
--- a/.changeset/preserve-toml-comments.md
+++ b/.changeset/preserve-toml-comments.md
@@ -1,0 +1,5 @@
+---
+'pgflow': patch
+---
+
+Fix config.toml corruption with minimal configs while preserving comments. Switch to @decimalturn/toml-patch 0.3.7 (maintained fork) which fixes issue #143 and preserves TOML comments and formatting. Thanks to @DecimalTurn for maintaining the fork and contributing this fix.

--- a/pkgs/cli/__tests__/commands/install/update-config-toml.test.ts
+++ b/pkgs/cli/__tests__/commands/install/update-config-toml.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { parse as parseTOML, stringify as stringifyTOML } from 'smol-toml';
+import { parse as parseTOML, stringify as stringifyTOML } from '@decimalturn/toml-patch';
 import { updateConfigToml } from '../../../src/commands/install/update-config-toml';
 
 describe('updateConfigToml', () => {
@@ -59,7 +59,7 @@ redirect_uri = "http://localhost:54321/auth/v1/callback"
     console.log('---');
 
     // First, verify the output is valid TOML that can be parsed
-    let parsedConfig;
+    let parsedConfig: any;
     expect(() => {
       parsedConfig = parseTOML(updatedContent);
     }).not.toThrow();
@@ -134,7 +134,7 @@ enabled = true
     const updatedContent = fs.readFileSync(configPath, 'utf8');
 
     // First verify the TOML is valid and parseable
-    let parsedConfig;
+    let parsedConfig: any;
     expect(() => {
       parsedConfig = parseTOML(updatedContent);
     }).not.toThrow();

--- a/pkgs/cli/package.json
+++ b/pkgs/cli/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "@clack/prompts": "^0.10.1",
     "@commander-js/extra-typings": "^13.1.0",
+    "@decimalturn/toml-patch": "0.3.7",
     "@pgflow/core": "workspace:*",
     "chalk": "^5.4.1",
-    "commander": "^13.1.0",
-    "smol-toml": "^1.4.2"
+    "commander": "^13.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       '@commander-js/extra-typings':
         specifier: ^13.1.0
         version: 13.1.0(commander@13.1.0)
+      '@decimalturn/toml-patch':
+        specifier: 0.3.7
+        version: 0.3.7
       '@pgflow/core':
         specifier: workspace:*
         version: link:../core
@@ -231,9 +234,6 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
-      smol-toml:
-        specifier: ^1.4.2
-        version: 1.4.2
     devDependencies:
       '@types/node':
         specifier: ^22.14.1
@@ -2416,6 +2416,10 @@ packages:
       enabled: 2.0.0
       kuler: 2.0.0
     dev: true
+
+  /@decimalturn/toml-patch@0.3.7:
+    resolution: {integrity: sha512-AzBw8XGOfTASzpypq3E0M/jW9/XGz9h879SuEYvzsB8f3xSUvYLABkoDgbLq7jsLCNrxqyRd10Ffxu/ndkMZaw==}
+    dev: false
 
   /@dependents/detective-less@5.0.1:
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
@@ -20302,11 +20306,6 @@ packages:
 
   /smol-toml@1.4.1:
     resolution: {integrity: sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==}
-    engines: {node: '>= 18'}
-    dev: false
-
-  /smol-toml@1.4.2:
-    resolution: {integrity: sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==}
     engines: {node: '>= 18'}
     dev: false
 


### PR DESCRIPTION
> [!NOTE] This work is originally by @DecimalTurn (PR #229). This PR is a resubmission because CI requires repository secrets that GitHub does not provide for fork builds.

## Original Description

This change still resolves #143 like in #227, but it retains comments preservation when editing TOML config files.

## Additional Context from Original PR

- The maintained fork (@decimalturn/toml-patch) has been verified to not have the same problem described in #143
- A new test was added to ensure the issue is caught: https://github.com/DecimalTurn/toml-patch/commit/5c139ca0ff26c269deca8f8ee112c79e017940ff
- The maintainer is committed to maintaining this fork for the foreseeable future
- The scoped package name (@decimalturn/toml-patch) will be maintained

## Changes

1. Replaced `smol-toml` with `@decimalturn/toml-patch` in package dependencies
2. Updated `updateConfigToml` function to use TOML.patch() instead of stringify()
3. Removed the note about losing comments and formatting from documentation
4. Updated tests to use the new package
5. Added proper typing for parsed config variables

## Benefits

- Preserves comments and formatting in config.toml files
- Resolves the issue with missing sections (from #143)
- Maintains comment preservation capability (from original toml-patch)

---

Credit: @DecimalTurn for the original implementation and maintaining the toml-patch fork
