### PR TITLE
chore: prevent direct commits and pushes to main branch

### DIFF
--- a/.lefthook/pre-push/prevent-push-to-main.sh
+++ b/.lefthook/pre-push/prevent-push-to-main.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check current branch
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "main" ]; then
+  echo "ERROR: Direct pushes from main branch are not allowed!"
+  exit 1
+fi
+
+# Check destination branch (handles: git push origin feature:main)
+# Git hook receives: <local_ref> <local_sha> <remote_ref> <remote_sha> per line
+# Note: Using timeout because lefthook's script execution may keep stdin open
+while read -r -t 0.5 local_ref local_sha remote_ref remote_sha || [ -n "$local_ref" ]; do
+  [ -z "$remote_ref" ] && break
+  remote_branch=$(echo "$remote_ref" | sed 's#^refs/heads/##')
+  if [ "$remote_branch" = "main" ]; then
+    echo "ERROR: Pushing to remote main branch is not allowed!"
+    echo "Attempted: $local_ref -> $remote_ref"
+    exit 1
+  fi
+done
+
+exit 0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,19 @@ prepare-commit-msg:
 
 pre-commit:
   commands:
+    'prevent-commit-on-main':
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+          echo "ERROR: Direct commits to main branch are not allowed!"
+          exit 1
+        fi
     'validate-json-files':
       glob: '*.{json,jsonc}'
       run: |
         ./scripts/validate-json-files.sh
+
+pre-push:
+  scripts:
+    'prevent-push-to-main.sh':
+      runner: bash


### PR DESCRIPTION
# Prevent direct commits and pushes to main branch

This PR adds git hooks to prevent accidental direct commits and pushes to the main branch, enforcing a workflow where changes must go through pull requests.

The implementation:
- Adds a pre-commit hook that checks if the current branch is main and blocks commits if it is
- Creates a pre-push hook script that prevents:
  - Pushing from the main branch
  - Pushing to the main branch (including cases like `git push origin feature:main`)

These hooks are configured in lefthook.yml and will help maintain code quality by ensuring all changes to main go through proper review.