### PR TITLE
chore: remove Perplexity MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -19,14 +19,6 @@
       "name": "sequentialthinking",
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    },
-    "perplexity": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@perplexity-ai/mcp-server"],
-      "env": {
-        "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"
-      }
     }
   }
 }


### PR DESCRIPTION
Removed Perplexity AI model provider from MCP configuration

This PR removes the Perplexity AI model provider from the `.mcp.json` configuration file. The change eliminates the Perplexity stdio handler and its associated API key environment variable.