### PR TITLE
feat: add unblock skill to diagnose and resolve analysis paralysis

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,8 @@
       "Skill(scratch-review)",
       "Skill(idea-refine)",
       "Skill(notes-sync)",
+      "Skill(unblock)",
+      "AskUserQuestion",
       "WebSearch",
       "mcp__context7__get-library-docs",
       "mcp__context7__resolve-library-id",

--- a/.claude/skills/unblock/SKILL.md
+++ b/.claude/skills/unblock/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: unblock
+description: Use when user says "unblock", "am I overthinking", "help me ship", "ship check". Diagnostic tool using Yes/No questions to identify if caution is justified or paranoia. Provides actionable prescriptions.
+allowed-tools: AskUserQuestion
+---
+
+# unblock
+
+Break analysis paralysis by diagnosing if caution is justified or paranoia.
+
+## Process
+
+### 1. Context (via AskUserQuestion tool)
+
+Analyze recent session to infer what's happening, then use AskUserQuestion to confirm:
+
+**Step 1**: Review last 10-20 messages for patterns:
+- Repeated refactoring/rewrites
+- Long research/planning without implementation
+- Working on meta-tools instead of core features
+- Multiple "what if" or "should I" questions
+
+**Step 2**: Use AskUserQuestion with inferred context:
+```
+question: "What are you stuck on?"
+options:
+  - [Inferred from session, e.g. "Perfecting the unblock skill for 1+ hour"]
+  - [Alternative inference if applicable]
+  - "Something else entirely"
+```
+
+If time unclear, follow with:
+```
+question: "How long on this without shipping?"
+options: ["< 30 mins", "30m - 2h", "2h - 1 day", "> 1 day"]
+```
+
+### 2. Diagnostic (15-20 questions via AskUserQuestion tool)
+
+<critical>
+ALL questions MUST use AskUserQuestion tool - including initial context.
+Interactive buttons prevent overthinking and force decisions.
+</critical>
+
+Ask in 3-4 batches of 4-5 questions. Adapt based on context.
+
+**Batch 1: Risk & Velocity**
+- Can users lose data/money? (Stakes)
+- Shipped last 2 weeks? (Velocity)
+- >2 hours researching? (Analysis)
+- Reputation damage worry? (Fear)
+
+**Batch 2: Users & Demand**
+- Anyone asked for this? (Demand)
+- Users complain if nothing ships? (Pressure)
+- Solving real problem? (Validation)
+- Rewritten without feedback? (Iteration)
+
+**Batch 3: Complexity & Focus**
+- Ship with half the code? (Scope)
+- >3 active blockers? (Focus)
+- Complexity for "professionalism"? (Theater)
+- More thinking than coding? (Action)
+
+**Batch 4: pgflow & Momentum**
+- Critical onboarding path? (Priority)
+- Treating MVP like enterprise? (Scale)
+- Fear from actual feedback? (Reality)
+- Know NOT shipping kills projects? (Truth)
+
+### 3. Score
+
+Count flags:
+- **RED**: Low stakes + high fear + no users = Paranoia
+- **YELLOW**: Mixed signals
+- **GREEN**: Real stakes + users waiting = Justified
+
+### 4. Diagnose
+
+```
+## Diagnosis: [Paranoia/Mixed/Justified]
+
+### Evidence:
+- RED: [specific findings]
+- GREEN: [what works]
+
+### Problem: [1 paragraph root cause]
+
+### Cost: [Quantified loss]
+
+### Prescription: [See prescriptions.md]
+```
+
+### 5. Follow-up
+"Want help shipping the blocked thing now?"
+
+## Resources
+
+- [patterns.md](patterns.md) - Pattern detection
+- [prescriptions.md](prescriptions.md) - Treatments by type

--- a/.claude/skills/unblock/patterns.md
+++ b/.claude/skills/unblock/patterns.md
@@ -1,0 +1,19 @@
+# Patterns
+
+## Red Flags (Paranoia)
+- **Analysis Paralysis**: >2h research, multiple rewrites, >5 blockers
+- **Impostor Syndrome**: Fear of exposure, zero complaints but worried
+- **Momentum Paranoia**: "One bug kills project", no actual negative feedback
+- **Complexity Theater**: Over-engineering to appear professional
+- **Scope Creep**: "While I'm at it" additions
+
+## Green Flags (Justified)
+- **Real Stakes**: Paying customers, data loss risk, financial transactions
+- **Active Users**: Users asked for it, complaints about delays
+- **pgflow Critical Path**: Install/compile/onboarding must work
+
+## Quick Detection
+- No paying customers + high fear = Paranoia
+- <50 users + scale worries = Premature optimization
+- Zero complaints + embarrassment = Impostor syndrome
+- Rewriting without shipping = Perfectionism

--- a/.claude/skills/unblock/prescriptions.md
+++ b/.claude/skills/unblock/prescriptions.md
@@ -1,0 +1,45 @@
+# Prescriptions
+
+## High Paranoia → Radical Action
+1. Ship in 2 hours max (set timer)
+2. Delete 4 of 5 blockers
+3. 30-min research cap
+4. Can't research what users didn't ask for
+
+*Ship the thing. Fix what breaks. Repeat daily.*
+
+## Impostor Syndrome → Build in Public
+1. Ship with "🚧 Experimental" prefix
+2. Add "Known Limitations" to README
+3. Ask for feedback explicitly
+4. Make reporting issues easy
+
+*Your 177 stars want to help shape, not judge.*
+
+## Complexity Theater → Aggressive Simplification
+1. Delete 50% of code
+2. Remove ALL future abstractions
+3. Ship simplest solution that works
+
+*Complexity is debt. Ship simple.*
+
+## pgflow Onboarding → First Experience Priority
+```bash
+npx pgflow install  # MUST work
+npx pgflow compile  # MUST work
+```
+*Silent abandonment is real. Protect onboarding.*
+
+## Justified Caution → Controlled Risk
+1. Ship behind feature flag
+2. Test with friendlies first
+3. Progressive rollout over 2 weeks
+
+*Real stakes need real process.*
+
+## Mixed Signals → Time-boxed Polish
+1. List concerns (10 min)
+2. Fix top 2 user-affecting (4h max)
+3. Ship with "Beta" label
+
+*Good enough beats perfect later.*


### PR DESCRIPTION
# Add "unblock" skill to help users overcome analysis paralysis

This PR introduces a new "unblock" skill designed to help users who are stuck in analysis paralysis and need assistance to ship faster. The skill acts as a diagnostic tool that:

1. Triggers when users express being blocked or overthinking
2. Gathers context about what they're stuck on
3. Runs a diagnostic with targeted yes/no questions across 5 key areas:
   - Stakes Assessment
   - Velocity Check
   - Fear Patterns
   - User Pressure
   - Time Allocation

Based on the responses, the skill provides a clear diagnosis of whether the user is:
- Wasting time on paranoia
- Showing mixed signals
- Exercising justified caution

The skill then delivers a concrete prescription with time-bound actions to help the user move forward, quantifies the cost of delay, and offers immediate assistance to ship the blocked work.

This skill follows key principles like being direct, using the user's own words, quantifying waste, and providing action-oriented advice with memorable punch lines.