### PR TITLE
fix(client): exclude dist directory from TypeScript compilation to prevent TS6305 errors

### DIFF
--- a/pkgs/client/tsconfig.json
+++ b/pkgs/client/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {},
   "files": [],
   "include": ["src/**/*"],
+  "exclude": ["dist"],
   "references": [
     {
       "path": "../dsl"

--- a/pkgs/client/tsconfig.spec.json
+++ b/pkgs/client/tsconfig.spec.json
@@ -25,6 +25,7 @@
     "src/**/*.spec.jsx",
     "src/**/*.d.ts"
   ],
+  "exclude": ["dist"],
   "references": [
     {
       "path": "./tsconfig.lib.json"


### PR DESCRIPTION
Adds 'exclude: ["dist"]' to tsconfig.json and tsconfig.spec.json to prevent
intermittent test failures caused by stale declaration files in the dist directory.

Previously, when dist/ contained .d.ts files from previous builds, Vitest's
typecheck would fail with TS6305 errors about files not being built from source.
This happened because TypeScript was including both source files and generated
declaration files in compilation.

Fixes the 'sometimes it works, sometimes it doesn't' behavior when running
pnpm nx test client.