### PR TITLE
chore: expand sharedGlobals pattern to include all YAML files in .github directory

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -11,7 +11,7 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"],
+    "sharedGlobals": ["{workspaceRoot}/.github/**/*.yml"],
     "sqruffConfig": ["{workspaceRoot}/.sqruff"]
   },
   "nxCloudId": "676490227393fa777407053a",


### PR DESCRIPTION
### TL;DR

Updated the `sharedGlobals` pattern in nx.json to include all YAML files in the .github directory.

### What changed?

Modified the `sharedGlobals` configuration in nx.json to use a more inclusive pattern. Changed from specifically targeting only the CI workflow file (`{workspaceRoot}/.github/workflows/ci.yml`) to including all YAML files in the .github directory and its subdirectories (`{workspaceRoot}/.github/**/*.yml`).

### How to test?

1. Verify that Nx correctly recognizes changes to any YAML file in the .github directory
2. Make a change to a YAML file outside the workflows directory and confirm it's properly detected
3. Run `nx affected` commands to ensure they correctly identify projects affected by changes to GitHub YAML files

### Why make this change?

This change ensures that modifications to any GitHub YAML configuration file (not just the CI workflow) are properly tracked by Nx's dependency graph. This provides better visibility into how GitHub configuration changes might affect projects in the workspace and ensures more accurate affected commands.