### PR TITLE
docs: add Deno 2.1.x requirement to pgflow 0.8.0 release notes

### DIFF
--- a/pkgs/website/src/content/docs/news/pgflow-0-8-0-modernizing-dependencies-pgmq-1-5-0-and-postgresql-17.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-8-0-modernizing-dependencies-pgmq-1-5-0-and-postgresql-17.mdx
@@ -30,6 +30,7 @@ pgflow 0.8.0 introduces breaking dependency changes:
 1. **pgmq version**: Now requires 1.5.0 or higher (previously supported 1.4.x)
 2. **PostgreSQL version**: Upgrades to PostgreSQL 17 (from 15)
 3. **Supabase CLI**: Requires version 2.34.3 or higher (includes pgmq 1.5.0+)
+4. **Deno version**: Now requires 2.1.x or higher (previously 1.45.x)
 
 The migration will fail safely if these requirements are not met - no partial upgrades or corrupted state.
 
@@ -50,6 +51,16 @@ SELECT extversion FROM pg_extension WHERE extname = 'pgmq';
 ```
 
 You need version 1.5.0 or higher to upgrade to pgflow 0.8.0.
+
+### Check Your Deno Version
+
+Verify your Deno installation meets the minimum requirement:
+
+```bash frame="none"
+deno --version
+```
+
+You need Deno 2.1.x or higher (previously 1.45.x). If you need to upgrade, see the [Deno installation guide](https://docs.deno.com/runtime/getting_started/installation/).
 
 ### Compatibility Check Built-In
 


### PR DESCRIPTION
# Add Deno 2.1.x requirement to pgflow 0.8.0 documentation

This PR updates the pgflow 0.8.0 release documentation to include Deno 2.1.x as a new dependency requirement. The changes:

- Add Deno 2.1.x or higher as the fourth breaking dependency change in the list
- Include a new "Check Your Deno Version" section with instructions on how to verify the Deno version
- Add a reference to the Deno installation guide for users who need to upgrade

This ensures users are aware of all requirements before upgrading to pgflow 0.8.0.