### PR TITLE
introduce prepush git hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -45,16 +45,19 @@ post-checkout:
         fi
     'claude-symlink':
       run: |
-        if [ -n "$CLAUDE_SYMLINK_SCRIPT" ] && [ -f "$CLAUDE_SYMLINK_SCRIPT" ]; then
-          "$CLAUDE_SYMLINK_SCRIPT" "$PWD"
-        elif [ -z "$CLAUDE_SYMLINK_SCRIPT" ]; then
-          echo "\033[33mWarning: CLAUDE_SYMLINK_SCRIPT not set. See LOCAL_DEV.md for setup instructions.\033[0m"
+        # Only run for branch checkouts (not file checkouts)
+        if [ "{3}" = "1" ]; then
+          if [ -n "$CLAUDE_SYMLINK_SCRIPT" ] && [ -f "$CLAUDE_SYMLINK_SCRIPT" ]; then
+            "$CLAUDE_SYMLINK_SCRIPT" --yes "$PWD"
+          elif [ -z "$CLAUDE_SYMLINK_SCRIPT" ]; then
+            echo "\033[33mWarning: CLAUDE_SYMLINK_SCRIPT not set. See LOCAL_DEV.md for setup instructions.\033[0m"
+          fi
         fi
 
 pre-push:
   commands:
     'nx-affected-checks':
-      run: pnpm nx affected --target=lint,build --base=origin/main --head=HEAD
+      run: pnpm nx affected --target=prepush --base=origin/main --head=HEAD --output-style=static
   scripts:
     'prevent-push-to-main.sh':
       runner: bash

--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -94,6 +94,10 @@
         "command": "./scripts/test-async-hang-issue-123",
         "cwd": "{projectRoot}"
       }
+    },
+    "prepush": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint", "build", "typecheck", "test:vitest"]
     }
   }
 }

--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -200,6 +200,8 @@
     },
     "test:types:vitest": {
       "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["production", "^production"],
       "dependsOn": ["^build"],
       "options": {
         "cwd": "{projectRoot}",
@@ -208,6 +210,8 @@
     },
     "test:types:strict": {
       "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["production", "^production"],
       "dependsOn": ["^build"],
       "options": {
         "cwd": "{projectRoot}",
@@ -217,6 +221,10 @@
     "test:types": {
       "executor": "nx:noop",
       "dependsOn": ["test:types:vitest", "test:types:strict"]
+    },
+    "prepush": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint", "build", "typecheck", "verify-exports", "test:types:vitest", "test:types:strict"]
     }
   }
 }

--- a/pkgs/core/project.json
+++ b/pkgs/core/project.json
@@ -273,6 +273,8 @@
     },
     "test:types:vitest": {
       "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["production", "^production"],
       "dependsOn": ["^build"],
       "options": {
         "cwd": "{projectRoot}",
@@ -281,6 +283,8 @@
     },
     "test:types:strict": {
       "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["production", "^production"],
       "dependsOn": ["^build"],
       "options": {
         "cwd": "{projectRoot}",
@@ -290,6 +294,10 @@
     "test:types": {
       "executor": "nx:noop",
       "dependsOn": ["test:types:vitest", "test:types:strict"]
+    },
+    "prepush": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint", "build", "test:types:vitest", "test:types:strict"]
     }
   }
 }

--- a/pkgs/dsl/project.json
+++ b/pkgs/dsl/project.json
@@ -38,6 +38,8 @@
     },
     "test:types:vitest": {
       "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["production"],
       "dependsOn": [],
       "options": {
         "cwd": "{projectRoot}",
@@ -46,6 +48,8 @@
     },
     "test:types:strict": {
       "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["production"],
       "dependsOn": [],
       "options": {
         "cwd": "{projectRoot}",
@@ -67,6 +71,10 @@
       "executor": "nx:noop",
       "inputs": ["default", "^production"],
       "dependsOn": ["test:vitest", "test:types"]
+    },
+    "prepush": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint", "build", "test:vitest", "test:types:vitest"]
     }
   }
 }

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -235,11 +235,15 @@
       "executor": "nx:run-commands",
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
+      "inputs": ["production", "^production"],
       "options": {
         "cwd": "{projectRoot}",
         "command": "deno check --config deno.test.json src/examples/*.example.ts tests/types/*.test-d.ts"
       }
+    },
+    "prepush": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint", "build", "test:types"]
     }
   },
   "tags": []


### PR DESCRIPTION
- Adds a 'prepush' target to multiple projects that includes fast-running checks
- Enables caching selectively in multiple prepush dependencies
- Adds a pre-push git hook to lefthook.yml that invokes prepush with nx affected
