### PR TITLE
fix: update Supabase CLI version requirement from 2.34.3 to 2.50.3

### DIFF
--- a/.changeset/correct-cli-version-requirement.md
+++ b/.changeset/correct-cli-version-requirement.md
@@ -1,0 +1,9 @@
+---
+'pgflow': patch
+'@pgflow/client': patch
+'@pgflow/core': patch
+'@pgflow/edge-worker': patch
+'@pgflow/website': patch
+---
+
+Fix incorrect Supabase CLI version requirement from 2.34.3 to 2.50.3. CLI 2.50.3 is the first version to include pgmq 1.5.0+, which is required for pgflow 0.8.0+.

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -33,7 +33,7 @@
 		"postcss": "8.4.49",
 		"prettier": "^3.6.2",
 		"prettier-plugin-svelte": "^3.4.0",
-		"supabase": "^2.34.3",
+		"supabase": "^2.50.3",
 		"svelte": "^5.41.0",
 		"svelte-check": "^4.3.3",
 		"tailwind-merge": "^3.3.1",

--- a/pkgs/cli/README.md
+++ b/pkgs/cli/README.md
@@ -15,7 +15,7 @@ This package provides essential tools for setting up, managing, and deploying pg
 
 ## Prerequisites
 
-- Supabase CLI v2.34.3 or higher
+- Supabase CLI v2.50.3 or higher
 - Deno v2.1.x or higher (for flow compilation)
 - Local Supabase project initialized
 

--- a/pkgs/client/CHANGELOG.md
+++ b/pkgs/client/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 7380237: BREAKING CHANGE: pgflow 0.8.0 requires pgmq 1.5.0+, PostgreSQL 17, and Supabase CLI 2.34.3+
+- 7380237: BREAKING CHANGE: pgflow 0.8.0 requires pgmq 1.5.0+, PostgreSQL 17, and Supabase CLI 2.50.3+
 
   This version modernizes infrastructure dependencies and will NOT work with pgmq 1.4.x or earlier. The migration includes a compatibility check that aborts with a clear error message if requirements are not met.
 
@@ -12,9 +12,9 @@
 
   - pgmq 1.5.0 or higher (previously supported 1.4.x)
   - PostgreSQL 17 (from 15)
-  - Supabase CLI 2.34.3 or higher (includes pgmq 1.5.0+)
+  - Supabase CLI 2.50.3 or higher (includes pgmq 1.5.0+)
 
-  **For Supabase users:** Upgrade your Supabase CLI to 2.34.3+ which includes pgmq 1.5.0 by default.
+  **For Supabase users:** Upgrade your Supabase CLI to 2.50.3+ which includes pgmq 1.5.0 by default.
 
   **For self-hosted users:** Upgrade pgmq to 1.5.0+ and PostgreSQL to 17 before upgrading pgflow.
 

--- a/pkgs/client/package.json
+++ b/pkgs/client/package.json
@@ -44,7 +44,7 @@
     "@pgflow/dsl": "workspace:*",
     "@types/uuid": "^10.0.0",
     "postgres": "^3.4.5",
-    "supabase": "^2.34.3",
+    "supabase": "^2.50.3",
     "terser": "^5.43.0",
     "vite-plugin-dts": "~3.8.1",
     "vitest": "1.3.1"

--- a/pkgs/core/CHANGELOG.md
+++ b/pkgs/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 7380237: BREAKING CHANGE: pgflow 0.8.0 requires pgmq 1.5.0+, PostgreSQL 17, and Supabase CLI 2.34.3+
+- 7380237: BREAKING CHANGE: pgflow 0.8.0 requires pgmq 1.5.0+, PostgreSQL 17, and Supabase CLI 2.50.3+
 
   This version modernizes infrastructure dependencies and will NOT work with pgmq 1.4.x or earlier. The migration includes a compatibility check that aborts with a clear error message if requirements are not met.
 
@@ -12,9 +12,9 @@
 
   - pgmq 1.5.0 or higher (previously supported 1.4.x)
   - PostgreSQL 17 (from 15)
-  - Supabase CLI 2.34.3 or higher (includes pgmq 1.5.0+)
+  - Supabase CLI 2.50.3 or higher (includes pgmq 1.5.0+)
 
-  **For Supabase users:** Upgrade your Supabase CLI to 2.34.3+ which includes pgmq 1.5.0 by default.
+  **For Supabase users:** Upgrade your Supabase CLI to 2.50.3+ which includes pgmq 1.5.0 by default.
 
   **For self-hosted users:** Upgrade pgmq to 1.5.0+ and PostgreSQL to 17 before upgrading pgflow.
 

--- a/pkgs/core/package.json
+++ b/pkgs/core/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.1",
-    "supabase": "^2.34.3"
+    "supabase": "^2.50.3"
   },
   "dependencies": {
     "@pgflow/dsl": "workspace:*",

--- a/pkgs/core/supabase/migrations/20251104080523_pgflow_upgrade_pgmq_1_5_1.sql
+++ b/pkgs/core/supabase/migrations/20251104080523_pgflow_upgrade_pgmq_1_5_1.sql
@@ -1,5 +1,5 @@
 -- Migration tested 2025-11-02:
--- Successfully verified that this migration fails on pgmq 1.4.4 (Supabase CLI < 2.34.3)
+-- Successfully verified that this migration fails on pgmq 1.4.4 (Supabase CLI < 2.50.3)
 -- with clear error message guiding users to upgrade pgmq to 1.5.0+
 --
 -- Compatibility check: Ensure pgmq.message_record has headers column (pgmq 1.5.0+)

--- a/pkgs/core/supabase/migrations/atlas.sum
+++ b/pkgs/core/supabase/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GRevz5BG7qrdQxFbQ0XO9f21I5qaYocLc08bN3gVG50=
+h1:TiGfW/P3IHRUFlm9TwimGZLK/80Gh5RfQm+x21jBuic=
 20250429164909_pgflow_initial.sql h1:I3n/tQIg5Q5nLg7RDoU3BzqHvFVjmumQxVNbXTPG15s=
 20250517072017_pgflow_fix_poll_for_tasks_to_use_separate_statement_for_polling.sql h1:wTuXuwMxVniCr3ONCpodpVWJcHktoQZIbqMZ3sUHKMY=
 20250609105135_pgflow_add_start_tasks_and_started_status.sql h1:ggGanW4Wyt8Kv6TWjnZ00/qVb3sm+/eFVDjGfT8qyPg=
@@ -10,4 +10,4 @@ h1:GRevz5BG7qrdQxFbQ0XO9f21I5qaYocLc08bN3gVG50=
 20250719205006_pgflow_worker_deprecation.sql h1:pL5cR1/Oag993yWN6sUpE/U3LmVSzAlnoRXJRBtErU8=
 20251006073122_pgflow_add_map_step_type.sql h1:D/skgKpaVg5TM8bPovo9FUutQfg35/AzkxEcasYwytY=
 20251103222045_pgflow_fix_broadcast_order_and_timestamp_handling.sql h1:K/XnZpOmxfelsaNoJbR5HxhBrs/oW4aYja222h5cps4=
-20251104080523_pgflow_upgrade_pgmq_1_5_1.sql h1:t+Hu/rqP8b23S+JAjJ86Y8UlOTCfA+085/8RxD7gydA=
+20251104080523_pgflow_upgrade_pgmq_1_5_1.sql h1:Fw7zpMWnjhAHQ0qBJAprAvGl7dJMd8ExNHg8aKvkzTg=

--- a/pkgs/edge-worker/CHANGELOG.md
+++ b/pkgs/edge-worker/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 7380237: BREAKING CHANGE: pgflow 0.8.0 requires pgmq 1.5.0+, PostgreSQL 17, and Supabase CLI 2.34.3+
+- 7380237: BREAKING CHANGE: pgflow 0.8.0 requires pgmq 1.5.0+, PostgreSQL 17, and Supabase CLI 2.50.3+
 
   This version modernizes infrastructure dependencies and will NOT work with pgmq 1.4.x or earlier. The migration includes a compatibility check that aborts with a clear error message if requirements are not met.
 
@@ -12,9 +12,9 @@
 
   - pgmq 1.5.0 or higher (previously supported 1.4.x)
   - PostgreSQL 17 (from 15)
-  - Supabase CLI 2.34.3 or higher (includes pgmq 1.5.0+)
+  - Supabase CLI 2.50.3 or higher (includes pgmq 1.5.0+)
 
-  **For Supabase users:** Upgrade your Supabase CLI to 2.34.3+ which includes pgmq 1.5.0 by default.
+  **For Supabase users:** Upgrade your Supabase CLI to 2.50.3+ which includes pgmq 1.5.0 by default.
 
   **For self-hosted users:** Upgrade pgmq to 1.5.0+ and PostgreSQL to 17 before upgrading pgflow.
 

--- a/pkgs/edge-worker/package.json
+++ b/pkgs/edge-worker/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/deno": "^2.3.0",
     "@types/node": "~18.16.20",
-    "supabase": "^2.34.3"
+    "supabase": "^2.50.3"
   },
   "publishConfig": {
     "access": "public"

--- a/pkgs/website/package.json
+++ b/pkgs/website/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "prettier-plugin-astro": "^0.14.1",
-    "supabase": "^2.34.3",
+    "supabase": "^2.50.3",
     "wrangler": "^4.20.3"
   }
 }

--- a/pkgs/website/src/content/docs/get-started/installation.mdx
+++ b/pkgs/website/src/content/docs/get-started/installation.mdx
@@ -13,7 +13,7 @@ import { FileTree } from '@astrojs/starlight/components';
 Let's set up pgflow in your Supabase project. This setup needs to be done only once per project.
 
 <Aside type="caution" title="Prerequisites">
-- Supabase CLI version **2.34.3** or higher (check with `supabase -v`)
+- Supabase CLI version **2.50.3** or higher (check with `supabase -v`)
 - A local Supabase project set up
 - [Deno version **2.1.x or higher**](https://github.com/denoland/deno/releases) - required for flow compilation
 

--- a/pkgs/website/src/content/docs/news/pgflow-0-8-0-modernizing-dependencies-pgmq-1-5-0-and-postgresql-17.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-8-0-modernizing-dependencies-pgmq-1-5-0-and-postgresql-17.mdx
@@ -29,7 +29,7 @@ pgflow 0.8.0 introduces breaking dependency changes:
 
 1. **pgmq version**: Now requires 1.5.0 or higher (previously supported 1.4.x)
 2. **PostgreSQL version**: Upgrades to PostgreSQL 17 (from 15)
-3. **Supabase CLI**: Requires version 2.34.3 or higher (includes pgmq 1.5.0+)
+3. **Supabase CLI**: Requires version 2.50.3 or higher (includes pgmq 1.5.0+)
 4. **Deno version**: Now requires 2.1.x or higher (previously 1.45.x)
 
 The migration will fail safely if these requirements are not met - no partial upgrades or corrupted state.
@@ -86,12 +86,12 @@ This safety check prevents partial migrations and data corruption.
 
 ### Supabase Cloud Users
 
-Supabase CLI version 2.34.3 or higher includes pgmq 1.5.0 by default. To upgrade:
+Supabase CLI version 2.50.3 or higher includes pgmq 1.5.0 by default. To upgrade:
 
 1. Update your Supabase CLI if needed:
    ```bash
    supabase -v  # Check current version
-   npm install -g supabase  # Update if below 2.34.3
+   npm install -g supabase  # Update if below 2.50.3
    ```
 2. Verify your pgmq version using the SQL query above
 3. If you have pgmq 1.5.0+, run your migrations normally:

--- a/pkgs/website/src/content/docs/reference/manual-installation.mdx
+++ b/pkgs/website/src/content/docs/reference/manual-installation.mdx
@@ -15,7 +15,7 @@ This guide explains how to manually set up pgflow and Edge Worker without using 
 - When you want to understand what happens behind the scenes
 
 <Aside type="caution" title="Prerequisites">
-- Supabase CLI version **2.34.3** or higher (check with `supabase -v`)
+- Supabase CLI version **2.50.3** or higher (check with `supabase -v`)
 - A local Supabase project set up
 - Basic understanding of Supabase configuration
 </Aside>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,7 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0(prettier@3.6.2)(svelte@5.43.6)
       supabase:
-        specifier: ^2.34.3
+        specifier: ^2.50.3
         version: 2.54.11
       svelte:
         specifier: ^5.41.0
@@ -274,7 +274,7 @@ importers:
         specifier: ^3.4.5
         version: 3.4.5
       supabase:
-        specifier: ^2.34.3
+        specifier: ^2.50.3
         version: 2.54.11
       terser:
         specifier: ^5.43.0
@@ -299,7 +299,7 @@ importers:
         specifier: ^22.14.1
         version: 22.19.0
       supabase:
-        specifier: ^2.34.3
+        specifier: ^2.50.3
         version: 2.54.11
 
   pkgs/dsl:
@@ -339,7 +339,7 @@ importers:
         specifier: ~18.16.20
         version: 18.16.20
       supabase:
-        specifier: ^2.34.3
+        specifier: ^2.50.3
         version: 2.54.11
 
   pkgs/example-flows:
@@ -415,7 +415,7 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       supabase:
-        specifier: ^2.34.3
+        specifier: ^2.50.3
         version: 2.54.11
       wrangler:
         specifier: ^4.20.3


### PR DESCRIPTION
# Fix Supabase CLI version requirement from 2.34.3 to 2.50.3

This PR corrects the Supabase CLI version requirement across all documentation and package files from 2.34.3 to 2.50.3. This is an important fix because CLI version 2.50.3 is the first version that includes pgmq 1.5.0+, which is required for pgflow 0.8.0 and later.

The change affects:

- Package dependencies in package.json files
- Documentation in README files
- Changelog entries
- Migration comments
- Website documentation

This ensures consistent version requirements across the codebase and prevents users from encountering compatibility issues when using an insufficient CLI version.
