### PR TITLE
chore: expand fixed packages list in changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,16 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@pgflow/*", "pgflow"]],
+  "fixed": [
+    [
+      "@pgflow/client",
+      "@pgflow/core",
+      "@pgflow/dsl",
+      "@pgflow/edge-worker",
+      "@pgflow/example-flows",
+      "pgflow"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
This PR updates the fixed packages configuration in the Changesets config file. Instead of using a wildcard pattern for all `@pgflow/*` packages, it now explicitly lists each package: `@pgflow/client`, `@pgflow/core`, `@pgflow/dsl`, `@pgflow/edge-worker`, and `@pgflow/example-flows`, along with the `pgflow` package. This ensures more precise version management for these specific packages.
