### PR TITLE
chore: simplify fixed packages list in changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,16 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [
-    [
-      "@pgflow/client",
-      "@pgflow/core",
-      "@pgflow/dsl",
-      "@pgflow/edge-worker",
-      "@pgflow/example-flows",
-      "pgflow"
-    ]
-  ],
+  "fixed": [["@pgflow/*", "pgflow"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/correct-cli-version-requirement.md
+++ b/.changeset/correct-cli-version-requirement.md
@@ -3,7 +3,6 @@
 '@pgflow/client': patch
 '@pgflow/core': patch
 '@pgflow/edge-worker': patch
-'@pgflow/website': patch
 ---
 
 Fix incorrect Supabase CLI version requirement from 2.34.3 to 2.50.3. CLI 2.50.3 is the first version to include pgmq 1.5.0+, which is required for pgflow 0.8.0+.


### PR DESCRIPTION
# Use wildcard pattern for fixed packages in changesets config

This PR updates the `.changeset/config.json` file to use a wildcard pattern `@pgflow/*` for fixed packages instead of listing them individually. This simplifies the configuration and ensures any new packages under the `@pgflow` namespace will automatically be included in the fixed versioning group.

Also removes `@pgflow/website` from the changeset that fixes the Supabase CLI version requirement, as the website package doesn't need this change.
