### PR TITLE
chore: simplify verify-exports dependency to single build task

### DIFF
--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -24,7 +24,7 @@
         "cwd": "{projectRoot}",
         "command": "pnpm run verify-exports"
       },
-      "dependsOn": ["build:lib", "build:browser"]
+      "dependsOn": ["build"]
     },
     "build:lib": {
       "executor": "@nx/vite:build",


### PR DESCRIPTION
Updated the `verify` target in `pkgs/client/project.json` to depend on the `build` target instead of both `build:lib` and `build:browser`. This simplifies the dependency chain for verification tasks.
