### PR TITLE
chore: add build:lib dependency to client build:browser task

### DIFF
--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -39,7 +39,7 @@
     "build:browser": {
       "executor": "@nx/vite:build",
       "outputs": ["{options.outputPath}"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "build:lib"],
       "inputs": ["production", "^production"],
       "options": {
         "outputPath": "pkgs/client/dist",


### PR DESCRIPTION
Added dependency on `build:lib` for the `build:browser` task in the client package to ensure the library is built before the browser build.
