### PR TITLE
chore: move supabase dependency to root package.json

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -33,7 +33,6 @@
 		"postcss": "8.4.49",
 		"prettier": "^3.6.2",
 		"prettier-plugin-svelte": "^3.4.0",
-		"supabase": "^2.62.10",
 		"svelte": "^5.41.0",
 		"svelte-check": "^4.3.3",
 		"tailwind-merge": "^3.3.1",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,11 +55,11 @@ post-checkout:
         fi
 
 pre-push:
-  commands:
-    'nx-affected-checks':
-      run: CI=true NX_DAEMON=false pnpm nx affected --target=prepush --base=origin/main --head=HEAD --output-style=static --verbose --nx-bail
   scripts:
     'prevent-push-to-main.sh':
       runner: bash
       skip_output:
         - meta
+  commands:
+    'nx-affected-checks':
+      run: CI=true NX_DAEMON=false pnpm nx affected --target=prepush --base=origin/main --head=HEAD --output-style=static --verbose --nx-bail

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "private": true,
   "devDependencies": {
     "@axhxrx/nx-deno": "^1.0.2",
+    "supabase": "^2.62.10",
     "@changesets/cli": "^2.28.1",
     "@eslint/js": "^9.8.0",
     "@netlify/plugin-nextjs": "^5.11.4",

--- a/pkgs/client/package.json
+++ b/pkgs/client/package.json
@@ -44,7 +44,6 @@
     "@pgflow/dsl": "workspace:*",
     "@types/uuid": "^10.0.0",
     "postgres": "^3.4.5",
-    "supabase": "^2.62.10",
     "terser": "^5.43.0",
     "vite-plugin-dts": "~3.8.1",
     "vitest": "1.3.1"

--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -68,9 +68,7 @@
       "dependsOn": ["supabase:prepare"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh ."
-        ],
+        "commands": ["../../scripts/supabase-start-locked.sh ."],
         "parallel": false
       }
     },
@@ -227,7 +225,13 @@
     },
     "prepush": {
       "executor": "nx:noop",
-      "dependsOn": ["lint", "build", "typecheck", "verify-exports", "test:types:vitest", "test:types:strict"]
+      "dependsOn": [
+        "lint",
+        "build",
+        "typecheck",
+        "test:types:vitest",
+        "test:types:strict"
+      ]
     }
   }
 }

--- a/pkgs/core/package.json
+++ b/pkgs/core/package.json
@@ -19,8 +19,7 @@
     }
   },
   "devDependencies": {
-    "@types/node": "^22.14.1",
-    "supabase": "^2.62.10"
+    "@types/node": "^22.14.1"
   },
   "dependencies": {
     "@pgflow/dsl": "workspace:*",

--- a/pkgs/edge-worker/package.json
+++ b/pkgs/edge-worker/package.json
@@ -29,8 +29,7 @@
   },
   "devDependencies": {
     "@types/deno": "^2.3.0",
-    "@types/node": "~18.16.20",
-    "supabase": "^2.50.3"
+    "@types/node": "~18.16.20"
   },
   "publishConfig": {
     "access": "public"

--- a/pkgs/website/package.json
+++ b/pkgs/website/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "prettier-plugin-astro": "^0.14.1",
-    "supabase": "^2.62.10",
     "wrangler": "^4.20.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       prettier:
         specifier: ^2.6.2
         version: 2.8.8
+      supabase:
+        specifier: ^2.62.10
+        version: 2.62.10
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -187,9 +190,6 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.4.0
         version: 3.4.0(prettier@3.6.2)(svelte@5.43.6)
-      supabase:
-        specifier: ^2.62.10
-        version: 2.62.10
       svelte:
         specifier: ^5.41.0
         version: 5.43.6
@@ -273,9 +273,6 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.5
-      supabase:
-        specifier: ^2.62.10
-        version: 2.62.10
       terser:
         specifier: ^5.43.0
         version: 5.43.1
@@ -298,9 +295,6 @@ importers:
       '@types/node':
         specifier: ^22.14.1
         version: 22.19.0
-      supabase:
-        specifier: ^2.62.10
-        version: 2.62.10
 
   pkgs/dsl:
     devDependencies:
@@ -338,9 +332,6 @@ importers:
       '@types/node':
         specifier: ~18.16.20
         version: 18.16.20
-      supabase:
-        specifier: ^2.50.3
-        version: 2.54.11
 
   pkgs/example-flows:
     dependencies:
@@ -414,9 +405,6 @@ importers:
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
-      supabase:
-        specifier: ^2.62.10
-        version: 2.62.10
       wrangler:
         specifier: ^4.20.3
         version: 4.46.0(@cloudflare/workers-types@4.20251109.0)
@@ -11125,11 +11113,6 @@ packages:
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
-  supabase@2.54.11:
-    resolution: {integrity: sha512-KuDDVi1s2fhfun81LNPaCLpW4/LFsP3G2LKUQimzEoj64sP1DtZ/d97uw6GFYbNMPW9JC2Ruuei53qHInOwJLA==}
-    engines: {npm: '>=8'}
-    hasBin: true
-
   supabase@2.62.10:
     resolution: {integrity: sha512-Zw5vDl+3KGU8VWSChLQqJ0IYfeLwLNnmW32iS54GVx52VEnOxtDBZylMx/GRGRtv5z6RtU3/Eal7H2B0S1kDcQ==}
     engines: {npm: '>=8'}
@@ -11230,10 +11213,6 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  tar@7.5.1:
-    resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
-    engines: {node: '>=18'}
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
@@ -25802,15 +25781,6 @@ snapshots:
     dependencies:
       s.color: 0.0.15
 
-  supabase@2.54.11:
-    dependencies:
-      bin-links: 6.0.0
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
-      node-fetch: 3.3.2
-      tar: 7.5.1
-    transitivePeerDependencies:
-      - supports-color
-
   supabase@2.62.10:
     dependencies:
       bin-links: 6.0.0
@@ -25937,14 +25907,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  tar@7.5.1:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.2:
     dependencies:


### PR DESCRIPTION
# Move Supabase dependency to root package.json

This PR relocates the `supabase` dependency from multiple package.json files to the root package.json. The dependency was previously duplicated across several packages:

- apps/demo
- pkgs/client
- pkgs/core
- pkgs/edge-worker
- pkgs/website

Now it's defined only once at the workspace root level, allowing all packages to share the same version.

Additionally, this PR reorders the pre-push hooks in lefthook.yml to place the script section before the commands section, improving the organization of the configuration file.
