### PR TITLE
fix: improve error handling for missing ControlPlane edge function

### DIFF
--- a/pkgs/edge-worker/tests/config.ts
+++ b/pkgs/edge-worker/tests/config.ts
@@ -19,6 +19,18 @@ export const e2eConfig = {
   get dbUrl() {
     return 'postgresql://postgres:postgres@127.0.0.1:50322/postgres';
   },
+
+  /** Max retries when waiting for server to be ready (default: 30) */
+  get serverReadyMaxRetries() {
+    const envValue = Deno.env.get('E2E_SERVER_READY_MAX_RETRIES');
+    return envValue ? parseInt(envValue, 10) : 30;
+  },
+
+  /** Delay between retries in ms (default: 1000) */
+  get serverReadyRetryDelayMs() {
+    const envValue = Deno.env.get('E2E_SERVER_READY_RETRY_DELAY_MS');
+    return envValue ? parseInt(envValue, 10) : 1000;
+  },
 };
 
 /**

--- a/pkgs/edge-worker/tests/e2e/control-plane.test.ts
+++ b/pkgs/edge-worker/tests/e2e/control-plane.test.ts
@@ -12,8 +12,8 @@ const BASE_URL = `${API_URL}/functions/v1/pgflow`;
 async function ensureServerReady() {
   log('Ensuring pgflow function is ready...');
 
-  const maxRetries = 15;
-  const retryDelayMs = 1000;
+  const maxRetries = e2eConfig.serverReadyMaxRetries;
+  const retryDelayMs = e2eConfig.serverReadyRetryDelayMs;
 
   for (let i = 0; i < maxRetries; i++) {
     try {


### PR DESCRIPTION
# Improve error handling for missing ControlPlane edge function

This PR enhances error handling in the CLI when the ControlPlane edge function is not found, distinguishing between two different 404 scenarios:

1. When the flow exists but isn't found in the ControlPlane (our existing error)
2. When the ControlPlane edge function itself doesn't exist (new error case)

The changes:
- Add specific error message when the Supabase gateway returns a 404 for the missing edge function
- Provide clear instructions to run `npx pgflow install` when the edge function is missing
- Handle non-JSON responses (like HTML error pages) that some gateways return
- Add tests for these new error handling cases

Additionally, the PR improves the Supabase startup script to:
- Better detect running services by using the project name from project.json
- Add configurable retry parameters for E2E tests when waiting for the server to be ready
