### PR TITLE
refactor: simplify CLI install command with cleaner logs and single confirmation

### DIFF
--- a/pkgs/cli/src/commands/install/copy-migrations.ts
+++ b/pkgs/cli/src/commands/install/copy-migrations.ts
@@ -233,7 +233,7 @@ export async function copyMigrations({
 
   // If no files to copy, show message and return false (no changes made)
   if (filesToCopy.length === 0) {
-    log.success(`All ${skippedFiles.length} pgflow migrations are already in place`);
+    log.success('Migrations already up to date');
     return false;
   }
 
@@ -247,32 +247,28 @@ export async function copyMigrations({
     file.destination = `${baseTimestamp}_${file.source}`;
   });
 
-  // Build summary message with explanation - show all migrations
-  const migrationLines = filesToCopy.map((file) => {
-    return `    ${chalk.bold(file.source)}`;
-  });
-
-  const summaryMsg = [
-    `Add to ${chalk.cyan('migrations/')} ${chalk.dim('(database schema for workflow engine)')}:`,
-    '',
-    ...migrationLines,
-  ].join('\n');
-
-  log.info(summaryMsg);
-
-  let shouldContinue = autoConfirm;
-
+  // Show preview and ask for confirmation only when not auto-confirming
   if (!autoConfirm) {
+    const migrationLines = filesToCopy.map((file) => {
+      return `    ${chalk.bold(file.source)}`;
+    });
+
+    const summaryMsg = [
+      `Add to ${chalk.cyan('migrations/')} ${chalk.dim('(database schema for workflow engine)')}:`,
+      '',
+      ...migrationLines,
+    ].join('\n');
+
+    log.info(summaryMsg);
+
     const confirmResult = await confirm({
       message: `Add ${filesToCopy.length} migration${filesToCopy.length !== 1 ? 's' : ''}?`,
     });
 
-    shouldContinue = confirmResult === true;
-  }
-
-  if (!shouldContinue) {
-    log.warn('Migration installation skipped');
-    return false;
+    if (confirmResult !== true) {
+      log.warn('Migration installation skipped');
+      return false;
+    }
   }
 
   // Install migrations with new filenames
@@ -283,12 +279,7 @@ export async function copyMigrations({
     fs.copyFileSync(sourcePath1, destinationPath);
   }
 
-  const successMsg = [
-    `Installed ${filesToCopy.length} migration${filesToCopy.length !== 1 ? 's' : ''}`,
-    `  ${chalk.dim('Learn more:')} ${chalk.blue.underline('https://pgflow.dev/concepts/data-model/')}`,
-  ].join('\n');
-
-  log.success(successMsg);
+  log.success(`Installed ${filesToCopy.length} migration${filesToCopy.length !== 1 ? 's' : ''}`);
 
   return true; // Return true to indicate migrations were copied
 }

--- a/pkgs/cli/src/commands/install/create-edge-function.ts
+++ b/pkgs/cli/src/commands/install/create-edge-function.ts
@@ -59,40 +59,28 @@ export async function createEdgeFunction({
 
   // If all files exist, return success
   if (filesToCreate.length === 0) {
-    const detailedMsg = [
-      'ControlPlane edge function files are already in place:',
-      `  ${chalk.bold(relativeIndexPath)}`,
-      `  ${chalk.bold(relativeDenoJsonPath)}`,
-    ].join('\n');
-
-    log.success(detailedMsg);
-
+    log.success('Control Plane already up to date');
     return false;
   }
 
-  // Show what will be created with explanation
-  const summaryMsg = [
-    `Create ${chalk.cyan('functions/pgflow/')} ${chalk.dim('(Control Plane for flow registration and compilation)')}:`,
-    '',
-    ...filesToCreate.map((file) => `    ${chalk.bold(path.basename(file.relativePath))}`),
-  ].join('\n');
-
-  log.info(summaryMsg);
-
-  // Get confirmation
-  let shouldContinue = autoConfirm;
-
+  // Show preview and ask for confirmation only when not auto-confirming
   if (!autoConfirm) {
+    const summaryMsg = [
+      `Create ${chalk.cyan('functions/pgflow/')} ${chalk.dim('(Control Plane for flow registration and compilation)')}:`,
+      '',
+      ...filesToCreate.map((file) => `    ${chalk.bold(path.basename(file.relativePath))}`),
+    ].join('\n');
+
+    log.info(summaryMsg);
+
     const confirmResult = await confirm({
       message: `Create functions/pgflow/?`,
     });
 
-    shouldContinue = confirmResult === true;
-  }
-
-  if (!shouldContinue) {
-    log.warn('Control Plane installation skipped');
-    return false;
+    if (confirmResult !== true) {
+      log.warn('Control Plane installation skipped');
+      return false;
+    }
   }
 
   // Create the directory if it doesn't exist
@@ -109,12 +97,7 @@ export async function createEdgeFunction({
     fs.writeFileSync(denoJsonPath, DENO_JSON_TEMPLATE(getVersion()));
   }
 
-  const successMsg = [
-    `Control Plane installed`,
-    `  ${chalk.dim('Learn more:')} ${chalk.blue.underline('https://pgflow.dev/concepts/compilation/')}`,
-  ].join('\n');
-
-  log.success(successMsg);
+  log.success('Control Plane installed');
 
   return true;
 }

--- a/pkgs/cli/src/commands/install/update-env-file.ts
+++ b/pkgs/cli/src/commands/install/update-env-file.ts
@@ -58,35 +58,30 @@ export async function updateEnvFile({
 
   // If no changes needed, return early
   if (missingVars.length === 0) {
-    log.success('Environment variables are already set');
+    log.success('Environment variables already configured');
     return false;
   }
 
-  // Build summary message with explanation
-  const summaryParts = [
-    isNewFile
-      ? `Create ${chalk.cyan('functions/.env')} ${chalk.dim('(worker configuration)')}:`
-      : `Update ${chalk.cyan('functions/.env')} ${chalk.dim('(worker configuration)')}:`,
-    '',
-    ...missingVars.map(({ key, value }) => `    ${chalk.bold(key)}="${value}"`),
-  ];
-
-  log.info(summaryParts.join('\n'));
-
-  // Ask for confirmation if not auto-confirming
-  let shouldContinue = autoConfirm;
-
+  // Show preview and ask for confirmation only when not auto-confirming
   if (!autoConfirm) {
+    const summaryParts = [
+      isNewFile
+        ? `Create ${chalk.cyan('functions/.env')} ${chalk.dim('(worker configuration)')}:`
+        : `Update ${chalk.cyan('functions/.env')} ${chalk.dim('(worker configuration)')}:`,
+      '',
+      ...missingVars.map(({ key, value }) => `    ${chalk.bold(key)}="${value}"`),
+    ];
+
+    log.info(summaryParts.join('\n'));
+
     const confirmResult = await confirm({
       message: isNewFile ? `Create functions/.env?` : `Update functions/.env?`,
     });
 
-    shouldContinue = confirmResult === true;
-  }
-
-  if (!shouldContinue) {
-    log.warn('Environment variable update skipped');
-    return false;
+    if (confirmResult !== true) {
+      log.warn('Environment variable update skipped');
+      return false;
+    }
   }
 
   // Update environment variables


### PR DESCRIPTION
# Streamline CLI installation experience with simplified UI

This PR improves the installation command UX by:

1. Consolidating the installation process into a single confirmation step instead of multiple prompts
2. Simplifying success and status messages to be more concise
3. Restructuring the installation flow to show a clear preview of all changes upfront
4. Removing redundant documentation links from individual steps
5. Using consistent formatting and styling for status messages
6. Adding clearer visual indicators for completed steps

The installation now presents all planned changes at once with a single confirmation prompt when not using the `--yes` flag, making the process more efficient while still providing transparency about what will be modified.
