### PR TITLE
chore: add changeset validation to CI workflow and pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,32 @@ permissions:
   deployments: write # Netlify action needs it
 
 jobs:
+  # ─────────────────────────────────────── 0. VALIDATE CHANGESETS ──────────────────────────────────────
+  validate-changesets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Validate changesets
+        run: |
+          if find .changeset -name "*.md" -not -name "README.md" 2>/dev/null | grep -q .; then
+            echo "Found changeset files, validating..."
+            VERSION=$(jq -r '.devDependencies["@changesets/cli"]' package.json | tr -d '^~')
+            if ! pnpm dlx @changesets/cli@$VERSION status --since=origin/main; then
+              echo ""
+              echo "::error::Changeset validation failed. This usually means a changeset references a package that doesn't exist in the workspace."
+              echo "Check the package names in your .changeset/*.md files match the 'name' field in package.json files."
+              exit 1
+            fi
+            echo "✅ Changesets are valid"
+          else
+            echo "No changeset files found, skipping validation"
+          fi
+
   # ─────────────────────────────────────── 1. BUILD & TEST ──────────────────────────────────────
   build-and-test:
     runs-on: ubuntu-latest

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -61,5 +61,18 @@ pre-push:
       skip_output:
         - meta
   commands:
+    'validate-changesets':
+      run: |
+        if find .changeset -name "*.md" -not -name "README.md" 2>/dev/null | grep -q .; then
+          echo "🔍 Validating changesets..."
+          VERSION=$(jq -r '.devDependencies["@changesets/cli"]' package.json | tr -d '^~')
+          if ! pnpm dlx @changesets/cli@$VERSION status; then
+            echo ""
+            echo "❌ Changeset validation failed!"
+            echo "Check that package names in .changeset/*.md files match 'name' field in package.json files."
+            exit 1
+          fi
+          echo "✅ Changesets are valid"
+        fi
     'nx-affected-checks':
       run: CI=true NX_DAEMON=false pnpm nx affected --target=prepush --base=origin/main --head=HEAD --output-style=static --verbose --nx-bail


### PR DESCRIPTION
# Add changeset validation to CI and pre-push hooks

This PR adds validation for changesets to ensure they reference valid packages in the workspace. The validation is added in two places:

1. A new `validate-changesets` job in the GitHub Actions CI workflow that:
   - Checks for the presence of changeset files
   - Runs `@changesets/cli status` to validate them
   - Provides clear error messages if validation fails

2. A new `validate-changesets` command in the pre-push hook that:
   - Performs the same validation locally before code is pushed
   - Prevents pushing if changesets reference non-existent packages

This helps catch errors early when developers create changesets with incorrect package names.
