### PR TITLE
feat: return JSON response with status info from edge worker HTTP endpoint

### DIFF
--- a/.changeset/json-status-response.md
+++ b/.changeset/json-status-response.md
@@ -1,0 +1,5 @@
+---
+'@pgflow/edge-worker': patch
+---
+
+Return JSON response with status, workerId, and functionName from edge worker HTTP endpoint

--- a/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
+++ b/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
@@ -203,6 +203,8 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
     Deno.serve({}, (req: Request) => {
       this.logger.debug(`HTTP Request: ${this.edgeFunctionName}`);
 
+      const wasStarted = !this.worker;
+
       if (!this.worker) {
         this.edgeFunctionName = this.extractFunctionName(req);
 
@@ -218,7 +220,11 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
         });
       }
 
-      return new Response('ok', {
+      return new Response(JSON.stringify({
+        status: wasStarted ? 'started' : 'running',
+        workerId: this.validatedEnv.SB_EXECUTION_ID,
+        functionName: this.edgeFunctionName,
+      }), {
         headers: { 'Content-Type': 'application/json' },
       });
     });


### PR DESCRIPTION
This PR enhances the edge worker HTTP endpoint to return a more informative JSON response instead of just "ok". The response now includes:

- `status`: Indicates whether the worker was just "started" or was already "running"
- `workerId`: The Supabase execution ID from the validated environment
- `functionName`: The name of the edge function being executed

This change makes it easier to monitor and debug edge worker executions by providing more context about the worker's state.
