### PR TITLE
chore: add .claude/settings.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ deno-dist/
 .nx-inputs
 .vscode
 
+.claude/settings.json
 **/.claude/settings.local.json
 
 # Claude config symlinks (actual content in ~/Code/pgflow-dev/claude/)


### PR DESCRIPTION
Added `.claude/settings.json` to .gitignore to prevent committing global Claude settings files, while maintaining the existing exclusion for local settings files.
