### PR TITLE
ci: skip tests for changeset-release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
   # ─────────────────────────────────────── 1. BUILD & TEST ──────────────────────────────────────
   build-and-test:
     runs-on: ubuntu-latest
+    # Skip for Version Packages PRs - code was already tested when original PRs merged
+    if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
@@ -90,6 +92,8 @@ jobs:
   # ─────────────────────────────────────── 2. EDGE-WORKER E2E ──────────────────────────────────────
   edge-worker-e2e:
     runs-on: ubuntu-latest
+    # Skip for Version Packages PRs - code was already tested when original PRs merged
+    if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
@@ -139,6 +143,8 @@ jobs:
   # ─────────────────────────────────────── 2b. CLI E2E ──────────────────────────────────────
   cli-e2e:
     runs-on: ubuntu-latest
+    # Skip for Version Packages PRs - code was already tested when original PRs merged
+    if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:


### PR DESCRIPTION
Skip CI tests for changeset-release PRs

This PR adds conditional checks to skip CI tests for PRs with branch names starting with "changeset-release/". Since the code in these version package PRs has already been tested when the original PRs were merged, running the tests again is redundant.

The condition `if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}` has been added to three jobs:
- build-and-test
- edge-worker-e2e
- cli-e2e

This change will improve CI efficiency by avoiding unnecessary test runs.
