### PR TITLE
feat: add flow compilation verification at worker startup

### DIFF
--- a/pkgs/edge-worker/deno.lock
+++ b/pkgs/edge-worker/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@henrygd/queue@^1.0.7": "1.0.7",
     "jsr:@std/assert@*": "0.224.0",
     "jsr:@std/assert@0.224": "0.224.0",
+    "jsr:@std/async@*": "0.224.2",
     "jsr:@std/async@0.224": "0.224.2",
     "jsr:@std/crypto@*": "1.0.5",
     "jsr:@std/fmt@0.224": "0.224.0",

--- a/pkgs/edge-worker/src/flow/createFlowWorker.ts
+++ b/pkgs/edge-worker/src/flow/createFlowWorker.ts
@@ -89,7 +89,8 @@ export function createFlowWorker<TFlow extends AnyFlow, TResources extends Recor
   const lifecycle = new FlowWorkerLifecycle<TFlow>(
     queries,
     flow,
-    createLogger('FlowWorkerLifecycle')
+    createLogger('FlowWorkerLifecycle'),
+    { env: platformAdapter.env }
   );
 
   // Create frozen worker config ONCE for reuse across all task executions

--- a/pkgs/edge-worker/src/flow/errors.ts
+++ b/pkgs/edge-worker/src/flow/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Error thrown when flow shape in code doesn't match database schema in production mode.
+ * Worker should crash on this error - no recovery possible without migration.
+ */
+export class FlowShapeMismatchError extends Error {
+  constructor(
+    public readonly flowSlug: string,
+    public readonly differences: string[]
+  ) {
+    super(
+      `Flow '${flowSlug}' shape mismatch with database.\n` +
+      `Run migrations or use development mode to recompile.\n` +
+      `Differences:\n` +
+      differences.map(d => `  - ${d}`).join('\n')
+    );
+    this.name = 'FlowShapeMismatchError';
+  }
+}

--- a/pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
@@ -1,0 +1,261 @@
+import { assertEquals } from '@std/assert';
+import { withPgNoTransaction } from '../../db.ts';
+import { Flow } from '@pgflow/dsl';
+import { delay } from '@std/async';
+import { createFlowWorker } from '../../../src/flow/createFlowWorker.ts';
+import { createTestPlatformAdapter } from '../_helpers.ts';
+import {
+  KNOWN_LOCAL_ANON_KEY,
+  KNOWN_LOCAL_SERVICE_ROLE_KEY,
+} from '../../../src/shared/localDetection.ts';
+import type { postgres } from '../../sql.ts';
+
+// Define a minimal test flow
+const TestCompilationFlow = new Flow<{ value: number }>({ slug: 'test_compilation_flow' })
+  .step({ slug: 'double' }, async (input) => {
+    await delay(1);
+    return input.run.value * 2;
+  });
+
+function createLogger(module: string) {
+  return {
+    debug: console.log.bind(console, `[${module}]`),
+    info: console.log.bind(console, `[${module}]`),
+    warn: console.warn.bind(console, `[${module}]`),
+    error: console.error.bind(console, `[${module}]`),
+  };
+}
+
+function createPlatformAdapterWithEnv(
+  sql: postgres.Sql,
+  envOverrides: Record<string, string> = {}
+) {
+  const baseAdapter = createTestPlatformAdapter(sql);
+  const modifiedEnv = {
+    ...baseAdapter.env,
+    ...envOverrides,
+  };
+
+  return {
+    ...baseAdapter,
+    get env() { return modifiedEnv; },
+  };
+}
+
+Deno.test(
+  'compiles new flow on worker startup',
+  withPgNoTransaction(async (sql) => {
+    await sql`select pgflow_tests.reset_db();`;
+
+    // Verify flow doesn't exist
+    const [flowBefore] = await sql`
+      SELECT * FROM pgflow.flows WHERE flow_slug = 'test_compilation_flow'
+    `;
+    assertEquals(flowBefore, undefined, 'Flow should not exist before worker startup');
+
+    // Create worker (compilation happens during acknowledgeStart)
+    const worker = createFlowWorker(
+      TestCompilationFlow,
+      {
+        sql,
+        maxConcurrent: 1,
+        batchSize: 10,
+        maxPollSeconds: 1,
+        pollIntervalMs: 200,
+      },
+      createLogger,
+      createPlatformAdapterWithEnv(sql)
+    );
+
+    try {
+      // Start worker - this triggers compilation
+      worker.startOnlyOnce({
+        edgeFunctionName: 'test_compilation',
+        workerId: crypto.randomUUID(),
+      });
+
+      // Give time for startup to complete
+      await delay(100);
+
+      // Verify flow was created
+      const [flowAfter] = await sql`
+        SELECT * FROM pgflow.flows WHERE flow_slug = 'test_compilation_flow'
+      `;
+      assertEquals(flowAfter?.flow_slug, 'test_compilation_flow', 'Flow should be created');
+
+      // Verify step was created
+      const steps = await sql`
+        SELECT step_slug FROM pgflow.steps WHERE flow_slug = 'test_compilation_flow' ORDER BY step_slug
+      `;
+      assertEquals(steps.length, 1, 'Should have 1 step');
+      assertEquals(steps[0].step_slug, 'double', 'Step should be "double"');
+    } finally {
+      await worker.stop();
+    }
+  })
+);
+
+Deno.test(
+  'verifies existing matching flow on worker startup',
+  withPgNoTransaction(async (sql) => {
+    await sql`select pgflow_tests.reset_db();`;
+
+    // Pre-create the flow with matching structure
+    await sql`SELECT pgflow.create_flow('test_compilation_flow')`;
+    await sql`SELECT pgflow.add_step('test_compilation_flow', 'double')`;
+
+    // Verify flow exists
+    const [flowBefore] = await sql`
+      SELECT * FROM pgflow.flows WHERE flow_slug = 'test_compilation_flow'
+    `;
+    assertEquals(flowBefore?.flow_slug, 'test_compilation_flow', 'Flow should exist');
+
+    // Create and start worker
+    const worker = createFlowWorker(
+      TestCompilationFlow,
+      {
+        sql,
+        maxConcurrent: 1,
+        batchSize: 10,
+        maxPollSeconds: 1,
+        pollIntervalMs: 200,
+      },
+      createLogger,
+      createPlatformAdapterWithEnv(sql)
+    );
+
+    try {
+      // Start worker - should verify without error
+      worker.startOnlyOnce({
+        edgeFunctionName: 'test_compilation',
+        workerId: crypto.randomUUID(),
+      });
+
+      // Give time for startup to complete
+      await delay(100);
+
+      // Verify flow still exists (was not deleted/recreated)
+      const [flowAfter] = await sql`
+        SELECT * FROM pgflow.flows WHERE flow_slug = 'test_compilation_flow'
+      `;
+      assertEquals(flowAfter?.flow_slug, 'test_compilation_flow', 'Flow should still exist');
+    } finally {
+      await worker.stop();
+    }
+  })
+);
+
+Deno.test(
+  'throws FlowShapeMismatchError on mismatch in production mode',
+  withPgNoTransaction(async (sql) => {
+    await sql`select pgflow_tests.reset_db();`;
+
+    // Pre-create flow with DIFFERENT structure than what worker expects
+    await sql`SELECT pgflow.create_flow('test_compilation_flow')`;
+    await sql`SELECT pgflow.add_step('test_compilation_flow', 'double')`;
+    await sql`SELECT pgflow.add_step('test_compilation_flow', 'different_step', deps_slugs => ARRAY['double']::text[])`;
+
+    // Use non-local keys to simulate production mode
+    const platformAdapter = createPlatformAdapterWithEnv(sql, {
+      SUPABASE_ANON_KEY: 'prod-anon-key-not-local',
+      SUPABASE_SERVICE_ROLE_KEY: 'prod-service-key-not-local',
+    });
+
+    const worker = createFlowWorker(
+      TestCompilationFlow, // Has only 'double' step
+      {
+        sql,
+        maxConcurrent: 1,
+        batchSize: 10,
+        maxPollSeconds: 1,
+        pollIntervalMs: 200,
+      },
+      createLogger,
+      platformAdapter
+    );
+
+    // Set up unhandled rejection handler to capture the error
+    const caughtErrors: Error[] = [];
+    const errorHandler = (event: PromiseRejectionEvent) => {
+      event.preventDefault();
+      caughtErrors.push(event.reason as Error);
+    };
+    globalThis.addEventListener('unhandledrejection', errorHandler);
+
+    try {
+      worker.startOnlyOnce({
+        edgeFunctionName: 'test_compilation',
+        workerId: crypto.randomUUID(),
+      });
+
+      // Give time for startup to fail
+      await delay(200);
+
+      // Verify error was thrown
+      assertEquals(caughtErrors.length > 0, true, 'Should have caught an error');
+      const caughtError = caughtErrors[0];
+      assertEquals(caughtError.name, 'FlowShapeMismatchError', 'Error should be FlowShapeMismatchError');
+      assertEquals(
+        caughtError.message.includes('shape mismatch'),
+        true,
+        'Error message should mention mismatch'
+      );
+    } finally {
+      globalThis.removeEventListener('unhandledrejection', errorHandler);
+      try {
+        await worker.stop();
+      } catch {
+        // Ignore stop errors since worker may have failed to start
+      }
+    }
+  })
+);
+
+Deno.test(
+  'recompiles flow on mismatch in development mode (local Supabase)',
+  withPgNoTransaction(async (sql) => {
+    await sql`select pgflow_tests.reset_db();`;
+
+    // Pre-create flow with DIFFERENT structure
+    await sql`SELECT pgflow.create_flow('test_compilation_flow')`;
+    await sql`SELECT pgflow.add_step('test_compilation_flow', 'old_step')`;
+
+    // Use local keys to simulate development mode
+    const platformAdapter = createPlatformAdapterWithEnv(sql, {
+      SUPABASE_ANON_KEY: KNOWN_LOCAL_ANON_KEY,
+      SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SERVICE_ROLE_KEY,
+    });
+
+    const worker = createFlowWorker(
+      TestCompilationFlow, // Has 'double' step, not 'old_step'
+      {
+        sql,
+        maxConcurrent: 1,
+        batchSize: 10,
+        maxPollSeconds: 1,
+        pollIntervalMs: 200,
+      },
+      createLogger,
+      platformAdapter
+    );
+
+    try {
+      worker.startOnlyOnce({
+        edgeFunctionName: 'test_compilation',
+        workerId: crypto.randomUUID(),
+      });
+
+      // Give time for startup and recompilation
+      await delay(200);
+
+      // Verify flow was recompiled with new structure
+      const steps = await sql`
+        SELECT step_slug FROM pgflow.steps WHERE flow_slug = 'test_compilation_flow' ORDER BY step_slug
+      `;
+      assertEquals(steps.length, 1, 'Should have 1 step after recompilation');
+      assertEquals(steps[0].step_slug, 'double', 'Step should be "double" after recompilation');
+    } finally {
+      await worker.stop();
+    }
+  })
+);

--- a/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.deprecation.test.ts
+++ b/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.deprecation.test.ts
@@ -44,14 +44,21 @@ class MockQueries extends Queries {
     this.workerStopped = true;
     return Promise.resolve(workerRow);
   }
+
+  override ensureFlowCompiled(): Promise<{ status: 'compiled' | 'verified' | 'recompiled' | 'mismatch'; differences: string[] }> {
+    return Promise.resolve({ status: 'verified', differences: [] });
+  }
 }
 
 // Mock Flow
 const createMockFlow = (): AnyFlow => {
-  // Return a minimal flow structure that matches AnyFlow type
+  // Return a minimal flow structure needed for extractFlowShape
   return {
     slug: 'test-flow',
-  } as AnyFlow;
+    stepOrder: [],
+    options: {},
+    getStepDefinition: () => { throw new Error('No steps in mock flow'); },
+  } as unknown as AnyFlow;
 };
 
 


### PR DESCRIPTION
# Flow Compilation at Worker Startup

This PR adds automatic flow compilation and verification during worker startup. When a flow worker starts, it now ensures the flow is properly compiled in the database before processing any tasks.

Key features:
- Adds `ensureFlowCompiled` method to the Queries class to check flow compilation status
- Implements flow compilation during worker startup in the `FlowWorkerLifecycle` class
- Adds environment detection to determine compilation mode (development vs production)
- Introduces `FlowShapeMismatchError` for handling flow structure mismatches
- In development mode (local Supabase), mismatched flows are automatically recompiled
- In production mode, mismatches throw errors to prevent unexpected behavior

The PR includes comprehensive integration tests covering:
- Compiling new flows on worker startup
- Verifying existing flows with matching structure
- Handling mismatches in production mode (throws error)
- Recompiling mismatched flows in development mode

This ensures flows are always properly compiled before execution, preventing runtime errors from mismatched flow definitions.
