### PR TITLE
refactor: simplify environment detection for flow compilation mode

### DIFF
--- a/pkgs/edge-worker/src/flow/createFlowWorker.ts
+++ b/pkgs/edge-worker/src/flow/createFlowWorker.ts
@@ -90,7 +90,7 @@ export function createFlowWorker<TFlow extends AnyFlow, TResources extends Recor
     queries,
     flow,
     createLogger('FlowWorkerLifecycle'),
-    { env: platformAdapter.env }
+    { isLocalEnvironment: platformAdapter.isLocalEnvironment }
   );
 
   // Create frozen worker config ONCE for reuse across all task executions

--- a/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
+++ b/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
@@ -96,10 +96,10 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
   async stopWorker(): Promise<void> {
     // Trigger shutdown signal
     this.abortController.abort();
-    
+
     // Cleanup resources
     await this._platformResources.sql.end();
-    
+
     if (this.worker) {
       await this.worker.stop();
     }
@@ -262,7 +262,7 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
     ] as const;
 
     const missing: string[] = [];
-    
+
     for (const key of required) {
       if (!env[key]) {
         missing.push(key);

--- a/pkgs/edge-worker/src/platform/types.ts
+++ b/pkgs/edge-worker/src/platform/types.ts
@@ -57,4 +57,10 @@ export interface PlatformAdapter<TResources extends Record<string, unknown> = Re
    */
   get platformResources(): TResources;
 
+  /**
+   * Whether running in a local/development environment.
+   * Used by flow compilation to determine if recompilation is allowed.
+   */
+  get isLocalEnvironment(): boolean;
+
 }

--- a/pkgs/edge-worker/tests/integration/_helpers.ts
+++ b/pkgs/edge-worker/tests/integration/_helpers.ts
@@ -41,14 +41,15 @@ export function createTestPlatformAdapter(sql: postgres.Sql): PlatformAdapter<Su
     get shutdownSignal() { return abortController.signal; },
     get platformResources() { return platformResources; },
     get connectionString() { return integrationConfig.dbUrl; },
+    get isLocalEnvironment() { return false; },
     async startWorker(_createWorkerFn: CreateWorkerFn) {},
     async stopWorker() {},
   };
 }
 
 export function startWorker<TFlow extends AnyFlow>(
-  sql: postgres.Sql, 
-  flow: TFlow, 
+  sql: postgres.Sql,
+  flow: TFlow,
   options: FlowWorkerConfig
 ) {
   const defaultOptions = {


### PR DESCRIPTION
# Refactor Flow Compilation Environment Detection

This PR improves how we detect local/development environments for flow compilation by:

1. Adding an explicit `isLocalEnvironment` property to the `PlatformAdapter` interface
2. Replacing the environment variable-based detection with a cleaner approach that:
   - Removes direct access to environment variables in `FlowWorkerLifecycle`
   - Adds a new `isLocalSupabaseEnv()` function for checking environment records
   - Simplifies the flow compilation mode detection logic

The changes make the code more maintainable by:
- Adding a helpful comment about FlowShape JSON serialization
- Improving log messages during flow compilation
- Updating tests to use the new approach for environment detection
- Making the environment detection more explicit and testable

This refactoring maintains the same behavior while making the code more robust and easier to understand.
