### PR TITLE
ci: remove e2e:install dependency and improve JSR authentication handling

### DIFF
--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -30,7 +30,7 @@
     "test": {
       "executor": "nx:noop",
       "inputs": ["default", "^production"],
-      "dependsOn": ["test:vitest", "e2e:install"],
+      "dependsOn": ["test:vitest"],
       "options": {
         "parallel": false
       }


### PR DESCRIPTION
This PR makes two changes to improve the release process:

1. Removes the `e2e:install` dependency from the CLI test task in `pkgs/cli/project.json`, simplifying the test execution flow.

2. Enhances the JSR publishing process in `snapshot-release.sh` by adding credential validation:
   - Checks for JSR authentication via environment variable or local credentials
   - Provides helpful guidance when credentials are missing
   - Gracefully skips JSR publishing instead of failing the entire release when credentials aren't available
   - Displays clear instructions for one-time authentication setup

These changes make the release process more robust and user-friendly, especially for contributors who may not have JSR credentials configured.
