### PR TITLE
use PAT token for release workflow and enalble manual trigger for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   pull_request:
     branches: ['**', '!changeset-release/**']
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,5 @@ jobs:
           version: pnpm run version
           publish: pnpm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### TL;DR

Added manual workflow trigger capability and updated GitHub token for releases.

### What changed?

- Added `workflow_dispatch` trigger to the CI workflow, allowing manual execution of the CI pipeline
- Changed the GitHub token used in the release workflow from `GITHUB_TOKEN` to `PAT_TOKEN`

### How to test?

1. Verify that the CI workflow can be manually triggered from the GitHub Actions tab
2. Ensure the `PAT_TOKEN` secret is properly configured in the repository settings
3. Test the release workflow to confirm it can successfully authenticate using the new token

### Why make this change?

- Adding manual trigger capability provides more flexibility for running CI workflows on demand without requiring code changes
- Using a Personal Access Token (`PAT_TOKEN`) instead of the default `GITHUB_TOKEN` likely addresses permission limitations, as PATs can have broader scopes and capabilities for release operations