### PR TITLE
ci: run tests on changeset-release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['**', '!changeset-release/**']
   push:
     branches: [main]
   # TODO: Optimize - separate deployment workflow to avoid re-running tests on main
@@ -47,8 +46,6 @@ jobs:
   # ─────────────────────────────────────── 1. BUILD & TEST ──────────────────────────────────────
   build-and-test:
     runs-on: ubuntu-latest
-    # Skip for Version Packages PRs - code was already tested when original PRs merged
-    if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
@@ -93,8 +90,6 @@ jobs:
   # ─────────────────────────────────────── 2. EDGE-WORKER E2E ──────────────────────────────────────
   edge-worker-e2e:
     runs-on: ubuntu-latest
-    # Skip for Version Packages PRs - code was already tested when original PRs merged
-    if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
@@ -144,8 +139,6 @@ jobs:
   # ─────────────────────────────────────── 2b. CLI E2E ──────────────────────────────────────
   cli-e2e:
     runs-on: ubuntu-latest
-    # Skip for Version Packages PRs - code was already tested when original PRs merged
-    if: ${{ !startsWith(github.head_ref || '', 'changeset-release/') }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:


### PR DESCRIPTION
This PR removes the exclusion of `changeset-release/**` branches from the CI workflow. It also removes the conditional checks that were skipping the build-and-test, edge-worker-e2e, and cli-e2e jobs for Version Packages PRs. Now, all pull requests, including those created by the changeset release process, will trigger the full CI workflow.
