### PR TITLE
ci: refactor setup action to include Deno, Sqruff and Atlas

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,14 @@
 name: 'Setup pgflow workspace'
 description: 'Common setup steps for pgflow CI workflow (run after checkout)'
 
+inputs:
+  github-token:
+    description: 'GitHub token for API requests (used by sqruff)'
+    required: true
+  atlas-cloud-token:
+    description: 'Atlas Cloud token for schema management'
+    required: true
+
 runs:
   using: 'composite'
   steps:
@@ -36,3 +44,18 @@ runs:
     - name: Rebuild packages that need postinstall (onlyBuiltDependencies)
       shell: bash
       run: pnpm rebuild supabase sharp
+
+    # Deno setup
+    - uses: denoland/setup-deno@v2
+      with:
+        deno-version: '2.1.4'
+
+    # Sqruff SQL linter
+    - uses: ./.github/actions/setup-sqruff
+      with:
+        github-token: ${{ inputs.github-token }}
+
+    # Atlas schema management
+    - uses: ariga/setup-atlas@master
+      with:
+        cloud-token: ${{ inputs.atlas-cloud-token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Validate changesets
         run: |
@@ -54,21 +57,9 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: '2.1.4'
-
-      - name: Install sqruff
-        uses: ./.github/actions/setup-sqruff
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Atlas
-        uses: ariga/setup-atlas@master
-        with:
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Set Nx base for affected commands
         run: |
@@ -98,6 +89,9 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Check if edge-worker is affected
         id: check
@@ -109,24 +103,6 @@ jobs:
             echo "affected=false" >> $GITHUB_OUTPUT
             echo "edge-worker not affected, skipping e2e tests"
           fi
-
-      - name: Setup Deno
-        if: steps.check.outputs.affected == 'true'
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: '2.1.4'
-
-      - name: Install sqruff
-        if: steps.check.outputs.affected == 'true'
-        uses: ./.github/actions/setup-sqruff
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Atlas
-        if: steps.check.outputs.affected == 'true'
-        uses: ariga/setup-atlas@master
-        with:
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Pre-start Supabase
         if: steps.check.outputs.affected == 'true'
@@ -147,6 +123,9 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Check if cli is affected
         id: check
@@ -158,24 +137,6 @@ jobs:
             echo "affected=false" >> $GITHUB_OUTPUT
             echo "cli not affected, skipping e2e tests"
           fi
-
-      - name: Setup Deno
-        if: steps.check.outputs.affected == 'true'
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: '2.1.4'
-
-      - name: Install sqruff
-        if: steps.check.outputs.affected == 'true'
-        uses: ./.github/actions/setup-sqruff
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Atlas
-        if: steps.check.outputs.affected == 'true'
-        uses: ariga/setup-atlas@master
-        with:
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Pre-start Supabase
         if: steps.check.outputs.affected == 'true'
@@ -204,6 +165,9 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Set Nx base for affected commands
         run: |
@@ -283,6 +247,9 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Set Nx base for affected commands
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Atlas
-        uses: ariga/setup-atlas@master
-        with:
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-
       - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
       - name: Create Release Pull Request
         uses: changesets/action@v1

--- a/nx.json
+++ b/nx.json
@@ -11,7 +11,12 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/**/*.yml"],
+    "sharedGlobals": [
+      "{workspaceRoot}/.github/actions/setup/action.yml",
+      "{workspaceRoot}/.github/actions/setup-sqruff/action.yml",
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/tsconfig.base.json"
+    ],
     "sqruffConfig": ["{workspaceRoot}/.sqruff"]
   },
   "nxCloudId": "676490227393fa777407053a",
@@ -117,6 +122,9 @@
     },
     "e2e:*": {
       "local": true
+    },
+    "test:types:strict": {
+      "inputs": ["{workspaceRoot}/scripts/typecheck-ts2578.sh"]
     }
   }
 }


### PR DESCRIPTION
# Refactor CI setup to centralize tool installation

This PR refactors our CI setup by moving the installation of Deno, Sqruff, and Atlas into the shared setup action. This eliminates redundant tool installations across multiple workflow jobs.

Key changes:
- Added input parameters to the setup action for GitHub token and Atlas Cloud token
- Integrated Deno, Sqruff, and Atlas installation directly in the setup action
- Updated all workflow jobs to pass the required tokens to the setup action
- Removed duplicate tool installation steps from individual workflow jobs
- Refined the shared globals configuration in nx.json to be more specific
- Added test:types:strict to the nx.json task runner configuration

This change improves CI efficiency by ensuring tools are installed only once per job and simplifies workflow maintenance by centralizing setup logic.
