### PR TITLE
ci: add PAT token to release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
 
       - uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
Use PAT_TOKEN for checkout in release workflow to ensure proper permissions for subsequent operations.
