### PR TITLE
ci: add client e2e tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,44 @@ jobs:
         if: steps.check.outputs.affected == 'true'
         run: pnpm nx run cli:e2e
 
+  # ─────────────────────────────────────── 2c. CLIENT E2E ──────────────────────────────────────
+  client-e2e:
+    runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+
+      - name: Check if client is affected
+        id: check
+        run: |
+          if pnpm nx show projects --affected --base=origin/main --head=HEAD | grep -q "^client$"; then
+            echo "affected=true" >> $GITHUB_OUTPUT
+            echo "client is affected, running e2e tests"
+          else
+            echo "affected=false" >> $GITHUB_OUTPUT
+            echo "client not affected, skipping e2e tests"
+          fi
+
+      - name: Pre-start Supabase
+        if: steps.check.outputs.affected == 'true'
+        run: ./scripts/ci-prestart-supabase.sh client
+
+      - name: Run client e2e tests
+        if: steps.check.outputs.affected == 'true'
+        run: pnpm nx run client:e2e
+
   # ────────────────────────────────── 3. DEPLOY WEBSITE (PREVIEW) ───────────────────────────
   deploy-website:
     if: github.event_name == 'pull_request'
-    needs: [build-and-test, edge-worker-e2e, cli-e2e]
+    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e]
     runs-on: ubuntu-latest
     environment: preview
     env:
@@ -188,7 +222,7 @@ jobs:
   # ────────────────────────────────── 4. DEPLOY DEMO ───────────────────────────
   deploy-demo:
     if: false # temporarily disabled
-    needs: [build-and-test, edge-worker-e2e, cli-e2e]
+    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e]
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
     env:

--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -139,7 +139,7 @@
         "parallel": false
       }
     },
-    "test:integration": {
+    "e2e": {
       "executor": "nx:run-commands",
       "local": true,
       "cache": false,
@@ -164,25 +164,10 @@
         "parallel": false
       }
     },
-    "test:vitest": {
-      "executor": "nx:run-commands",
-      "local": true,
-      "cache": false,
-      "dependsOn": ["supabase:prepare", "build"],
-      "options": {
-        "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "psql 'postgresql://postgres:postgres@localhost:50522/postgres' -c 'SELECT pgflow_tests.reset_db()'",
-          "vitest run __tests__/ --config vitest.e2e.config.ts --poolOptions.threads.singleThread"
-        ],
-        "parallel": false
-      }
-    },
     "test": {
       "executor": "nx:noop",
       "inputs": ["default", "^production"],
-      "dependsOn": ["test:vitest", "test:types"]
+      "dependsOn": ["test:unit", "test:types"]
     },
     "benchmark": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# Add client e2e tests to CI workflow

This PR adds end-to-end tests for the client package to our CI workflow. The changes include:

1. Adding a new `client-e2e` job to the GitHub Actions workflow that:
   - Checks if the client package is affected by changes
   - Pre-starts Supabase for testing
   - Runs the client e2e tests when needed

2. Updating the dependency chain to include the new `client-e2e` job:
   - The `deploy-website` job now depends on `client-e2e`
   - The `deploy-demo` job now depends on `client-e2e`

3. Refactoring the client package's testing configuration:
   - Renamed `test:integration` to `e2e` for consistency
   - Removed the unused `test:vitest` command
   - Updated the `test` target to depend on `test:unit` instead of `test:vitest`

These changes ensure that client e2e tests are properly run as part of our CI process before deployments.
