### PR TITLE
ci: add core pgtap tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,10 +177,44 @@ jobs:
         if: steps.check.outputs.affected == 'true'
         run: pnpm nx run client:e2e
 
+  # ─────────────────────────────────────── 2d. CORE PGTAP ──────────────────────────────────────
+  core-pgtap:
+    runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+
+      - name: Check if core is affected
+        id: check
+        run: |
+          if pnpm nx show projects --affected --base=origin/main --head=HEAD | grep -q "^core$"; then
+            echo "affected=true" >> $GITHUB_OUTPUT
+            echo "core is affected, running pgtap tests"
+          else
+            echo "affected=false" >> $GITHUB_OUTPUT
+            echo "core not affected, skipping pgtap tests"
+          fi
+
+      - name: Pre-start Supabase
+        if: steps.check.outputs.affected == 'true'
+        run: ./scripts/ci-prestart-supabase.sh core
+
+      - name: Run core pgtap tests
+        if: steps.check.outputs.affected == 'true'
+        run: pnpm nx run core:pgtap
+
   # ────────────────────────────────── 3. DEPLOY WEBSITE (PREVIEW) ───────────────────────────
   deploy-website:
     if: github.event_name == 'pull_request'
-    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e]
+    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e, core-pgtap]
     runs-on: ubuntu-latest
     environment: preview
     env:
@@ -222,7 +256,7 @@ jobs:
   # ────────────────────────────────── 4. DEPLOY DEMO ───────────────────────────
   deploy-demo:
     if: false # temporarily disabled
-    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e]
+    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e, core-pgtap]
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
     env:

--- a/pkgs/core/project.json
+++ b/pkgs/core/project.json
@@ -207,8 +207,12 @@
     },
     "test": {
       "executor": "nx:noop",
-      "inputs": ["default", "^production", "schemas", "migrations", "pgtapTests", "databaseTypes"],
-      "dependsOn": ["test:pgtap", "test:vitest", "test:types"]
+      "inputs": ["default", "^production", "databaseTypes"],
+      "dependsOn": ["test:vitest", "test:types"]
+    },
+    "pgtap": {
+      "executor": "nx:noop",
+      "dependsOn": ["test:pgtap"]
     },
     "test:pgtap": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# Add PGTap Tests for Core Package in CI Pipeline

This PR adds a dedicated CI job for running PGTap tests for the core package. The changes include:

1. Added a new `core-pgtap` job in the CI workflow that:
   - Checks if the core package is affected by changes
   - Runs PGTap tests only when core is affected
   - Uses a pre-start Supabase script for test setup

2. Updated the dependency chain to include the new `core-pgtap` job:
   - Made `deploy-website` depend on the new PGTap tests
   - Made `deploy-demo` depend on the new PGTap tests

3. Modified the core package's project.json:
   - Added a dedicated `pgtap` target that depends on `test:pgtap`
   - Updated the `test` target to no longer include PGTap tests in its dependencies
   - Removed unnecessary inputs from the test target

These changes ensure PGTap tests run in a separate CI job, improving test isolation and clarity.
