### PR TITLE
refactor: replace console.log with debug utility in tests

### DIFF
--- a/pkgs/client/__tests__/e2e/full-stack-dsl.test.ts
+++ b/pkgs/client/__tests__/e2e/full-stack-dsl.test.ts
@@ -9,6 +9,7 @@ import { Flow } from '@pgflow/dsl';
 import { compileFlow } from '@pgflow/dsl';
 import { readAndStart } from '../helpers/polling.js';
 import { cleanupFlow } from '../helpers/cleanup.js';
+import { log } from '../helpers/debug.js';
 
 describe('Full Stack DSL Integration', () => {
   it(
@@ -41,7 +42,7 @@ describe('Full Stack DSL Integration', () => {
 
       // 2. Compile to SQL
       const flowSql = compileFlow(SimpleFlow);
-      console.log('Generated SQL statements:', flowSql);
+      log('Generated SQL statements:', flowSql);
 
       // 3. Execute SQL to create flow definition
       for (const statement of flowSql) {
@@ -90,7 +91,7 @@ describe('Full Stack DSL Integration', () => {
       expect(run.input).toEqual(input);
 
       // 7. Execute the complete flow lifecycle
-      console.log('=== Step 1: Completing fetch step ===');
+      log('=== Step 1: Completing fetch step ===');
       let tasks = await readAndStart(sql, sqlClient, SimpleFlow.slug, 1, 5);
       expect(tasks).toHaveLength(1);
       expect(tasks[0].step_slug).toBe('fetch');
@@ -106,7 +107,7 @@ describe('Full Stack DSL Integration', () => {
       expect(fetchStep.status).toBe(FlowStepStatus.Completed);
       expect(fetchStep.output).toEqual(fetchOutput);
 
-      console.log('=== Step 2: Completing process step ===');
+      log('=== Step 2: Completing process step ===');
       tasks = await readAndStart(sql, sqlClient, SimpleFlow.slug, 1, 5);
       expect(tasks).toHaveLength(1);
       expect(tasks[0].step_slug).toBe('process');
@@ -127,7 +128,7 @@ describe('Full Stack DSL Integration', () => {
       expect(processStep.status).toBe(FlowStepStatus.Completed);
       expect(processStep.output).toEqual(processOutput);
 
-      console.log('=== Step 3: Completing save step ===');
+      log('=== Step 3: Completing save step ===');
       tasks = await readAndStart(sql, sqlClient, SimpleFlow.slug, 1, 5);
       expect(tasks).toHaveLength(1);
       expect(tasks[0].step_slug).toBe('save');
@@ -157,7 +158,7 @@ describe('Full Stack DSL Integration', () => {
       expect(run.status).toBe(FlowRunStatus.Completed);
       expect(run.remaining_steps).toBe(0);
 
-      console.log('=== Full Stack DSL Test Completed Successfully ===');
+      log('=== Full Stack DSL Test Completed Successfully ===');
       await supabaseClient.removeAllChannels();
     }),
     30000

--- a/pkgs/client/__tests__/e2e/network-resilience.test.ts
+++ b/pkgs/client/__tests__/e2e/network-resilience.test.ts
@@ -8,6 +8,7 @@ import { FlowStepStatus } from '../../src/lib/types.js';
 import { PgflowSqlClient } from '@pgflow/core';
 import { readAndStart } from '../helpers/polling.js';
 import { cleanupFlow } from '../helpers/cleanup.js';
+import { log } from '../helpers/debug.js';
 
 describe('Network Resilience Tests', () => {
   it(
@@ -61,7 +62,7 @@ describe('Network Resilience Tests', () => {
       expect(stepOne.status).toBe(FlowStepStatus.Completed);
 
       // Simulate network disconnection by unsubscribing from all channels
-      console.log('=== Simulating network disconnection ===');
+      log('=== Simulating network disconnection ===');
       await supabaseClient.removeAllChannels();
 
       // Wait a bit to ensure disconnection
@@ -76,7 +77,7 @@ describe('Network Resilience Tests', () => {
       await sqlClient.completeTask(tasks[0], stepTwoOutput);
 
       // Reconnect by creating a new run instance (simulates app restart/reconnection)
-      console.log('=== Simulating reconnection ===');
+      log('=== Simulating reconnection ===');
       const reconnectedRun = await pgflowClient.getRun(run.run_id);
       expect(reconnectedRun).toBeTruthy();
 
@@ -114,8 +115,8 @@ describe('Network Resilience Tests', () => {
       expect(dbState[1].status).toBe('completed');
       expect(dbState[1].output).toEqual(stepTwoOutput);
 
-      console.log('Events before disconnect:', eventsBeforeDisconnect.length);
-      console.log('Events after reconnect:', eventsAfterReconnect.length);
+      log('Events before disconnect:', eventsBeforeDisconnect.length);
+      log('Events after reconnect:', eventsAfterReconnect.length);
 
       await supabaseClient.removeAllChannels();
     }),
@@ -148,7 +149,7 @@ describe('Network Resilience Tests', () => {
       if (channel) {
         channel.subscribe((status: string) => {
           connectionEvents.push(status);
-          console.log('Channel status changed:', status);
+          log('Channel status changed:', status);
         });
       }
 
@@ -165,7 +166,7 @@ describe('Network Resilience Tests', () => {
       expect(step.status).toBe(FlowStepStatus.Completed);
       expect(step.output).toEqual(stepOutput);
 
-      console.log('Connection events recorded:', connectionEvents);
+      log('Connection events recorded:', connectionEvents);
 
       await supabaseClient.removeAllChannels();
     }),
@@ -195,7 +196,7 @@ describe('Network Resilience Tests', () => {
 
       // Simulate poor network by introducing delays and multiple reconnections
       for (let i = 0; i < 3; i++) {
-        console.log(`=== Connection cycle ${i + 1} ===`);
+        log(`=== Connection cycle ${i + 1} ===`);
 
         // Short connection period
         await new Promise((resolve) => setTimeout(resolve, 100));

--- a/pkgs/client/__tests__/helpers/debug.ts
+++ b/pkgs/client/__tests__/helpers/debug.ts
@@ -1,0 +1,11 @@
+/**
+ * Debug logging utility for e2e tests.
+ * Enable verbose output by setting DEBUG=1 or VERBOSE=1 environment variable.
+ */
+export const DEBUG = process.env.DEBUG === '1' || process.env.VERBOSE === '1';
+
+export const log = (...args: unknown[]) => {
+  if (DEBUG) {
+    console.log(...args);
+  }
+};

--- a/pkgs/client/vitest.e2e.global-setup.ts
+++ b/pkgs/client/vitest.e2e.global-setup.ts
@@ -1,6 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 import postgres from 'postgres';
 import { createHash } from 'crypto';
+import { log as debugLog } from './__tests__/helpers/debug';
+
+const log = (...args: unknown[]) => debugLog('[GLOBAL SETUP]', ...args);
 
 export async function setup() {
   // Create a hash-based channel name with only alphanumeric characters
@@ -8,27 +11,27 @@ export async function setup() {
   const random = Math.random().toString();
   const hash = createHash('sha1').update(timestamp + random).digest('hex');
   const channelName = `setup${hash.substring(0, 16)}`; // Use first 16 chars of hash
-  console.log(`[GLOBAL SETUP] Using random channel: ${channelName}`);
+  log(`Using random channel: ${channelName}`);
 
   const supabaseUrl = 'http://localhost:50521';
   const pgUrl = 'postgresql://postgres:postgres@localhost:50522/postgres';
 
-  console.log('[GLOBAL SETUP] Checking Supabase availability...');
+  log('Checking Supabase availability...');
 
   // Check if Supabase is reachable
   try {
     const response = await fetch(`${supabaseUrl}/rest/v1/`, { method: 'HEAD' });
-    console.log(`[GLOBAL SETUP] Supabase REST API response: ${response.status}`);
+    log(`Supabase REST API response: ${response.status}`);
   } catch (fetchError) {
     console.error('[GLOBAL SETUP] ❌ Failed to reach Supabase REST API:', fetchError instanceof Error ? fetchError.message : fetchError);
     console.error('[GLOBAL SETUP] Is Supabase running on port 50521?');
     process.exit(1);
   }
 
-  console.log('[GLOBAL SETUP] Creating Supabase client...');
+  log('Creating Supabase client...');
   const supabase = createClient(supabaseUrl, 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU');
 
-  console.log('[GLOBAL SETUP] Creating PostgreSQL connection...');
+  log('Creating PostgreSQL connection...');
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const sql = postgres(pgUrl, { prepare: false, onnotice: () => {} });
 
@@ -36,23 +39,23 @@ export async function setup() {
   const events: unknown[] = [];
 
   try {
-    console.log('[GLOBAL SETUP] Testing PostgreSQL connection...');
+    log('Testing PostgreSQL connection...');
     try {
       await sql`SELECT 1`;
-      console.log('[GLOBAL SETUP] ✓ PostgreSQL connection successful');
+      log('✓ PostgreSQL connection successful');
     } catch (pgError) {
       console.error('[GLOBAL SETUP] ❌ Failed to connect to PostgreSQL:', pgError instanceof Error ? pgError.message : pgError);
       console.error('[GLOBAL SETUP] Is PostgreSQL running on port 50522?');
       throw pgError;
     }
 
-    console.log('[GLOBAL SETUP] Setting up broadcast listener...');
+    log('Setting up broadcast listener...');
     channel.on('broadcast', { event: '*' }, (p) => {
-      console.log('[GLOBAL SETUP] Received broadcast event:', p);
+      log('Received broadcast event:', p);
       events.push(p);
     });
 
-    console.log('[GLOBAL SETUP] Subscribing to channel...');
+    log('Subscribing to channel...');
     await new Promise<void>((ok, fail) => {
       const t = setTimeout(() => {
         console.error('[GLOBAL SETUP] ❌ Channel subscription timed out after 10s');
@@ -60,9 +63,9 @@ export async function setup() {
       }, 10000);
 
       channel.subscribe((s) => {
-        console.log(`[GLOBAL SETUP] Channel status: ${s}`);
+        log(`Channel status: ${s}`);
         if (s === 'SUBSCRIBED') {
-          console.log('[GLOBAL SETUP] ✓ Channel subscribed successfully');
+          log('✓ Channel subscribed successfully');
           clearTimeout(t);
           ok();
         }
@@ -83,15 +86,15 @@ export async function setup() {
 
     // Add stabilization delay for cold channels to fully establish routing
     // Use 200ms instead of 75ms to ensure reliable routing in CI environments
-    console.log('[GLOBAL SETUP] Channel subscribed, waiting 200ms for stabilization...');
+    log('Channel subscribed, waiting 200ms for stabilization...');
     await new Promise(resolve => setTimeout(resolve, 200));
-    console.log('[GLOBAL SETUP] Stabilization complete');
+    log('Stabilization complete');
 
-    console.log('[GLOBAL SETUP] Sending test message via realtime.send()...');
+    log('Sending test message via realtime.send()...');
     await sql`SELECT realtime.send('{}', 'e', ${channelName}, false)`;
-    console.log('[GLOBAL SETUP] ✓ Message sent');
+    log('✓ Message sent');
 
-    console.log('[GLOBAL SETUP] Waiting for broadcast event (timeout: 10s)...');
+    log('Waiting for broadcast event (timeout: 10s)...');
     const start = Date.now();
     while (events.length === 0 && Date.now() - start < 10000) {
       await new Promise((ok) => setTimeout(ok, 100));
@@ -103,8 +106,8 @@ export async function setup() {
       throw new Error('realtime.send() failed - no events received');
     }
 
-    console.log(`[GLOBAL SETUP] ✓ Received ${events.length} event(s)`);
-    console.log('[GLOBAL SETUP] ✅ All connectivity checks passed');
+    log(`✓ Received ${events.length} event(s)`);
+    console.log('[GLOBAL SETUP] ✅ Connectivity check passed');
   } catch (e) {
     console.error('\n❌ Supabase connectivity check failed');
     console.error('Error:', e instanceof Error ? e.message : e);
@@ -115,10 +118,10 @@ export async function setup() {
     console.error('  4. Verify ports 50521 (API) and 50522 (PostgreSQL) are accessible\n');
     process.exit(1);
   } finally {
-    console.log('[GLOBAL SETUP] Cleaning up...');
+    log('Cleaning up...');
     await supabase.removeChannel(channel);
     await sql.end();
-    console.log('[GLOBAL SETUP] Cleanup complete');
+    log('Cleanup complete');
   }
 }
 


### PR DESCRIPTION
# Reduce Test Verbosity with Conditional Debug Logging

This PR introduces a debug logging utility to reduce console noise during test runs while preserving the ability to see detailed logs when needed. Key changes:

- Added a new `debug.ts` helper with a `log()` function that only outputs when `DEBUG=1` or `VERBOSE=1` environment variables are set
- Replaced all `console.log()` calls in E2E tests with the new `log()` function
- Updated the global setup script to use the same logging pattern
- Simplified the global setup output to show only essential information by default

This change makes test output cleaner and more focused on actual test results while maintaining the ability to see detailed logs when debugging by running tests with `DEBUG=1`.
