### PR TITLE
chore: rename test:vitest to test:unit in project configs

### DIFF
--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -30,12 +30,12 @@
     "test": {
       "executor": "nx:noop",
       "inputs": ["default", "^production"],
-      "dependsOn": ["test:vitest"],
+      "dependsOn": ["test:unit"],
       "options": {
         "parallel": false
       }
     },
-    "test:vitest": {
+    "test:unit": {
       "executor": "nx:run-commands",
       "inputs": ["default", "^production"],
       "options": {

--- a/pkgs/core/project.json
+++ b/pkgs/core/project.json
@@ -208,7 +208,7 @@
     "test": {
       "executor": "nx:noop",
       "inputs": ["default", "^production", "databaseTypes"],
-      "dependsOn": ["test:vitest", "test:types"]
+      "dependsOn": ["test:unit", "test:types"]
     },
     "pgtap": {
       "executor": "nx:noop",
@@ -229,7 +229,7 @@
         "parallel": false
       }
     },
-    "test:vitest": {
+    "test:unit": {
       "executor": "@nx/vite:test",
       "dependsOn": ["build", "verify-gen-types"],
       "inputs": ["default", "databaseTypes", "^production"],

--- a/pkgs/dsl/project.json
+++ b/pkgs/dsl/project.json
@@ -26,7 +26,7 @@
         "parallel": false
       }
     },
-    "test:vitest": {
+    "test:unit": {
       "executor": "@nx/vite:test",
       "dependsOn": ["build"],
       "inputs": ["default", "^production"],
@@ -70,11 +70,11 @@
     "test": {
       "executor": "nx:noop",
       "inputs": ["default", "^production"],
-      "dependsOn": ["test:vitest", "test:types"]
+      "dependsOn": ["test:unit", "test:types"]
     },
     "prepush": {
       "executor": "nx:noop",
-      "dependsOn": ["lint", "build", "test:vitest", "test:types:vitest"]
+      "dependsOn": ["lint", "build", "test:unit", "test:types:vitest"]
     }
   }
 }


### PR DESCRIPTION
Renamed test task from `test:vitest` to `test:unit` across project configuration files for better clarity and consistency. This change affects the CLI, Core, and DSL packages, updating both the task names and their dependencies to reflect the new naming convention.
