### PR TITLE
ci: add edge-worker integration tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,42 @@ jobs:
         if: steps.check.outputs.affected == 'true'
         run: pnpm nx run edge-worker:e2e
 
+  # ─────────────────────────────────────── 2a. EDGE-WORKER INTEGRATION ──────────────────────────────────────
+  edge-worker-integration:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+
+      - name: Check if edge-worker is affected
+        id: check
+        run: |
+          if pnpm nx show projects --affected --base=origin/main --head=HEAD | grep -q "^edge-worker$"; then
+            echo "affected=true" >> $GITHUB_OUTPUT
+            echo "edge-worker is affected, running integration tests"
+          else
+            echo "affected=false" >> $GITHUB_OUTPUT
+            echo "edge-worker not affected, skipping integration tests"
+          fi
+
+      - name: Pre-start Supabase
+        if: steps.check.outputs.affected == 'true'
+        run: ./scripts/ci-prestart-supabase.sh edge-worker
+
+      - name: Run edge-worker integration tests
+        if: steps.check.outputs.affected == 'true'
+        run: pnpm nx run edge-worker:test:integration
+
   # ─────────────────────────────────────── 2b. CLI E2E ──────────────────────────────────────
   cli-e2e:
     needs: pre_job
@@ -238,7 +274,7 @@ jobs:
   # ────────────────────────────────── 3. DEPLOY WEBSITE (PREVIEW) ───────────────────────────
   deploy-website:
     if: github.event_name == 'pull_request'
-    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e, core-pgtap]
+    needs: [build-and-test, edge-worker-e2e, edge-worker-integration, cli-e2e, client-e2e, core-pgtap]
     runs-on: ubuntu-latest
     environment: preview
     env:
@@ -280,7 +316,7 @@ jobs:
   # ────────────────────────────────── 4. DEPLOY DEMO ───────────────────────────
   deploy-demo:
     if: false # temporarily disabled
-    needs: [build-and-test, edge-worker-e2e, cli-e2e, client-e2e, core-pgtap]
+    needs: [build-and-test, edge-worker-e2e, edge-worker-integration, cli-e2e, client-e2e, core-pgtap]
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
     env:

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -188,7 +188,7 @@
     },
     "test": {
       "inputs": ["default", "^production"],
-      "dependsOn": ["test:types", "test:unit", "test:integration"]
+      "dependsOn": ["test:types", "test:unit"]
     },
     "test:types": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# Add Edge Worker Integration Tests to CI Pipeline

This PR adds a dedicated CI job for running integration tests for the Edge Worker package. The new job:

- Runs only when the edge-worker package is affected by changes
- Executes before the website and demo deployment steps
- Includes a pre-start Supabase script to prepare the testing environment

Additionally, the PR updates the Edge Worker's project configuration to no longer include integration tests in the default test command, allowing them to be run separately in CI.
