### PR TITLE
add ensureCompiledOnStartup config flag to opt-out of auto-compilation

### DIFF
--- a/.changeset/auto-compile-on-startup.md
+++ b/.changeset/auto-compile-on-startup.md
@@ -1,0 +1,7 @@
+---
+'@pgflow/core': patch
+'@pgflow/dsl': patch
+'@pgflow/edge-worker': patch
+---
+
+Add automatic flow compilation at worker startup. Workers now call ensure_flow_compiled to verify flows are up-to-date. In development, mismatched flows are recompiled automatically. In production, mismatches cause errors. Use ensureCompiledOnStartup: false to opt-out.

--- a/pkgs/edge-worker/src/core/workerConfigTypes.ts
+++ b/pkgs/edge-worker/src/core/workerConfigTypes.ts
@@ -145,6 +145,14 @@ export type ResolvedQueueWorkerConfig = Required<Omit<QueueWorkerConfig, 'retryD
  */
 export type FlowWorkerConfig = {
   /**
+   * Whether to verify/compile flow at worker startup.
+   * When true (default), worker calls pgflow.ensure_flow_compiled() before polling.
+   * Set to false to skip compilation check (useful if flows are pre-compiled via CLI).
+   * @default true
+   */
+  ensureCompiledOnStartup?: boolean;
+
+  /**
    * How many tasks are processed at the same time
    * @default 10
    */
@@ -201,7 +209,7 @@ export type FlowWorkerConfig = {
 /**
  * Resolved flow configuration with all defaults applied
  */
-export type ResolvedFlowWorkerConfig = Required<Omit<FlowWorkerConfig, 'connectionString' | 'env'>> & {
+export type ResolvedFlowWorkerConfig = Required<Omit<FlowWorkerConfig, 'connectionString' | 'env' | 'ensureCompiledOnStartup'>> & {
   connectionString: string | undefined;
   env: Record<string, string | undefined>;
 };

--- a/pkgs/edge-worker/src/flow/createFlowWorker.ts
+++ b/pkgs/edge-worker/src/flow/createFlowWorker.ts
@@ -90,7 +90,10 @@ export function createFlowWorker<TFlow extends AnyFlow, TResources extends Recor
     queries,
     flow,
     createLogger('FlowWorkerLifecycle'),
-    { isLocalEnvironment: platformAdapter.isLocalEnvironment }
+    {
+      isLocalEnvironment: platformAdapter.isLocalEnvironment,
+      ensureCompiledOnStartup: config.ensureCompiledOnStartup ?? true
+    }
   );
 
   // Create frozen worker config ONCE for reuse across all task executions

--- a/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.compilation.test.ts
+++ b/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.compilation.test.ts
@@ -1,0 +1,169 @@
+import { assertEquals } from '@std/assert';
+import { FlowWorkerLifecycle } from '../../src/flow/FlowWorkerLifecycle.ts';
+import { Queries, type EnsureFlowCompiledResult } from '../../src/core/Queries.ts';
+import type { WorkerRow } from '../../src/core/types.ts';
+import { Flow, type FlowShape } from '@pgflow/dsl';
+import type { Logger } from '../../src/platform/types.ts';
+import type { postgres } from '../sql.ts';
+
+// Mock Queries
+class MockQueries extends Queries {
+  public ensureFlowCompiledCallCount = 0;
+
+  constructor() {
+    // Pass null as sql since we'll override all methods
+    super(null as unknown as postgres.Sql);
+  }
+
+  override onWorkerStarted(params: { workerId: string; edgeFunctionName: string; queueName: string }): Promise<WorkerRow> {
+    return Promise.resolve({
+      worker_id: params.workerId,
+      queue_name: params.queueName,
+      function_name: params.edgeFunctionName,
+      started_at: new Date().toISOString(),
+      deprecated_at: null,
+      last_heartbeat_at: new Date().toISOString(),
+    });
+  }
+
+  override sendHeartbeat(_workerRow: WorkerRow): Promise<{ is_deprecated: boolean }> {
+    return Promise.resolve({ is_deprecated: false });
+  }
+
+  override ensureFlowCompiled(
+    _flowSlug: string,
+    _shape: FlowShape,
+    _mode: 'development' | 'production'
+  ): Promise<EnsureFlowCompiledResult> {
+    this.ensureFlowCompiledCallCount++;
+    return Promise.resolve({ status: 'verified', differences: [] });
+  }
+}
+
+// Real Flow for testing - using the DSL to create a valid flow
+const TestFlow = new Flow<{ value: number }>({ slug: 'test_flow' })
+  .step({ slug: 'step1' }, (input) => input.run.value);
+
+const createMockFlow = () => TestFlow;
+
+const createLogger = (): Logger => ({
+  debug: () => {},
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+});
+
+Deno.test('FlowWorkerLifecycle - calls ensureFlowCompiled when ensureCompiledOnStartup is true', async () => {
+  const mockQueries = new MockQueries();
+  const mockFlow = createMockFlow();
+  const logger = createLogger();
+
+  const lifecycle = new FlowWorkerLifecycle(mockQueries, mockFlow, logger, {
+    ensureCompiledOnStartup: true
+  });
+
+  await lifecycle.acknowledgeStart({
+    workerId: 'test-worker-id',
+    edgeFunctionName: 'test-function',
+  });
+
+  assertEquals(mockQueries.ensureFlowCompiledCallCount, 1, 'ensureFlowCompiled should be called once');
+});
+
+Deno.test('FlowWorkerLifecycle - skips ensureFlowCompiled when ensureCompiledOnStartup is false', async () => {
+  const mockQueries = new MockQueries();
+  const mockFlow = createMockFlow();
+  const logger = createLogger();
+
+  const lifecycle = new FlowWorkerLifecycle(mockQueries, mockFlow, logger, {
+    ensureCompiledOnStartup: false
+  });
+
+  await lifecycle.acknowledgeStart({
+    workerId: 'test-worker-id',
+    edgeFunctionName: 'test-function',
+  });
+
+  assertEquals(mockQueries.ensureFlowCompiledCallCount, 0, 'ensureFlowCompiled should NOT be called');
+});
+
+Deno.test('FlowWorkerLifecycle - calls ensureFlowCompiled by default (no config)', async () => {
+  const mockQueries = new MockQueries();
+  const mockFlow = createMockFlow();
+  const logger = createLogger();
+
+  const lifecycle = new FlowWorkerLifecycle(mockQueries, mockFlow, logger);
+
+  await lifecycle.acknowledgeStart({
+    workerId: 'test-worker-id',
+    edgeFunctionName: 'test-function',
+  });
+
+  assertEquals(mockQueries.ensureFlowCompiledCallCount, 1, 'ensureFlowCompiled should be called by default');
+});
+
+Deno.test('FlowWorkerLifecycle - calls ensureFlowCompiled by default (empty config)', async () => {
+  const mockQueries = new MockQueries();
+  const mockFlow = createMockFlow();
+  const logger = createLogger();
+
+  const lifecycle = new FlowWorkerLifecycle(mockQueries, mockFlow, logger, {});
+
+  await lifecycle.acknowledgeStart({
+    workerId: 'test-worker-id',
+    edgeFunctionName: 'test-function',
+  });
+
+  assertEquals(mockQueries.ensureFlowCompiledCallCount, 1, 'ensureFlowCompiled should be called with empty config');
+});
+
+Deno.test('FlowWorkerLifecycle - logs skip message when ensureCompiledOnStartup is false', async () => {
+  const logs: string[] = [];
+  const testLogger: Logger = {
+    debug: () => {},
+    info: (msg: string) => logs.push(msg),
+    error: () => {},
+    warn: () => {},
+  };
+
+  const mockQueries = new MockQueries();
+  const mockFlow = createMockFlow();
+
+  const lifecycle = new FlowWorkerLifecycle(mockQueries, mockFlow, testLogger, {
+    ensureCompiledOnStartup: false
+  });
+
+  await lifecycle.acknowledgeStart({
+    workerId: 'test-worker-id',
+    edgeFunctionName: 'test-function',
+  });
+
+  const skipLog = logs.find(log => log.includes('Skipping compilation'));
+  assertEquals(skipLog !== undefined, true, 'Should log skip message');
+  assertEquals(skipLog?.includes('ensureCompiledOnStartup=false'), true, 'Skip message should mention the config flag');
+});
+
+Deno.test('FlowWorkerLifecycle - does not log skip message when ensureCompiledOnStartup is true', async () => {
+  const logs: string[] = [];
+  const testLogger: Logger = {
+    debug: () => {},
+    info: (msg: string) => logs.push(msg),
+    error: () => {},
+    warn: () => {},
+  };
+
+  const mockQueries = new MockQueries();
+  const mockFlow = createMockFlow();
+
+  const lifecycle = new FlowWorkerLifecycle(mockQueries, mockFlow, testLogger, {
+    ensureCompiledOnStartup: true
+  });
+
+  await lifecycle.acknowledgeStart({
+    workerId: 'test-worker-id',
+    edgeFunctionName: 'test-function',
+  });
+
+  const skipLog = logs.find(log => log.includes('Skipping compilation'));
+  assertEquals(skipLog, undefined, 'Should NOT log skip message when compilation is enabled');
+});


### PR DESCRIPTION
### TL;DR

Add automatic flow compilation at worker startup with the ability to opt-out.

### What changed?

- Added a new `ensureCompiledOnStartup` configuration option to `FlowWorkerConfig` (defaults to `true`)
- When enabled (default), workers call `pgflow.ensure_flow_compiled()` at startup to verify flows are up-to-date
- In development mode, mismatched flows are automatically recompiled
- In production mode, mismatches cause errors
- Added comprehensive tests for the new configuration option

### How to test?

1. Create a flow worker with default settings to see automatic compilation:
   ```typescript
   const worker = createFlowWorker(MyFlow, { /* config */ });
   ```

2. Opt-out of automatic compilation:
   ```typescript
   const worker = createFlowWorker(MyFlow, {
     ensureCompiledOnStartup: false,
     // other config
   });
   ```

3. Run tests to verify behavior:
   ```
   deno test pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
   deno test pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.compilation.test.ts
   ```

### Why make this change?

This change improves the developer experience by ensuring flows are properly compiled at worker startup. It helps catch flow definition mismatches early, automatically recompiling in development environments while failing fast in production. The opt-out option provides flexibility for environments where flows are pre-compiled via CLI or other means.