### PR TITLE
fix: exclude dist directory from package.json search in snapshot-release script

### DIFF
--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -197,7 +197,7 @@ while IFS= read -r -d '' file; do
     echo -e "  ${GREEN}✓${NC} ${BOLD}$NAME${NC}"
     echo -e "    ${VERSION}"
   fi
-done < <(find pkgs -name package.json -not -path "*/node_modules/*" -print0)
+done < <(find pkgs -name package.json -not -path "*/node_modules/*" -not -path "*/dist/*" -print0)
 
 # Check for JSR package (edge-worker)
 if [[ -f pkgs/edge-worker/jsr.json ]]; then


### PR DESCRIPTION
Exclude `dist` directories when finding package.json files in snapshot release script

This PR updates the `snapshot-release.sh` script to exclude `dist` directories when searching for package.json files. The script now uses `-not -path "*/dist/*"` in the find command to prevent processing package.json files that might exist in distribution directories.
