### PR TITLE
feat: add pg_cron, pg_net, pgsodium, and supabase_vault extensions to Atlas database

### DIFF
--- a/pkgs/core/schemas/0010_extensions.sql
+++ b/pkgs/core/schemas/0010_extensions.sql
@@ -1,2 +1,12 @@
 -- Extensions must be created first
 create extension if not exists pgmq;
+
+-- Extensions for worker management
+-- pg_net: HTTP requests from SQL (for pinging edge functions)
+create extension if not exists pg_net;
+
+-- supabase_vault: Secure credential storage (service role key, base URL)
+create extension if not exists supabase_vault;
+
+-- pg_cron: Scheduled job execution (ensure_workers cron)
+create extension if not exists pg_cron;

--- a/pkgs/core/supabase/migrations/20251205103442_pgflow_temp_add_extensions.sql
+++ b/pkgs/core/supabase/migrations/20251205103442_pgflow_temp_add_extensions.sql
@@ -1,0 +1,4 @@
+-- Create extension "pg_net"
+CREATE EXTENSION IF NOT EXISTS "pg_net" WITH SCHEMA "public";
+-- Create extension "pg_cron"
+CREATE EXTENSION IF NOT EXISTS "pg_cron";

--- a/pkgs/core/supabase/migrations/atlas.sum
+++ b/pkgs/core/supabase/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:T5v0ssUXOiDF+iJT/GP9XN0ceXsT+9PnvHvkkRT3NT4=
+h1:ITAzSq+m8k27LdS5wU7dFgdolSQl5pHgOD5VgpL3zyU=
 20250429164909_pgflow_initial.sql h1:I3n/tQIg5Q5nLg7RDoU3BzqHvFVjmumQxVNbXTPG15s=
 20250517072017_pgflow_fix_poll_for_tasks_to_use_separate_statement_for_polling.sql h1:wTuXuwMxVniCr3ONCpodpVWJcHktoQZIbqMZ3sUHKMY=
 20250609105135_pgflow_add_start_tasks_and_started_status.sql h1:ggGanW4Wyt8Kv6TWjnZ00/qVb3sm+/eFVDjGfT8qyPg=
@@ -17,3 +17,4 @@ h1:T5v0ssUXOiDF+iJT/GP9XN0ceXsT+9PnvHvkkRT3NT4=
 20251204145037_pgflow_temp_worker_functions_schema.sql h1:mrLKtkM8aWHBY+LIxQrsXxE7aKuPJaQJO2qd0NnrJ74=
 20251204164612_pgflow_temp_track_worker_function.sql h1:3Ht8wUx3saKPo98osuTG/nxD/tKR48qe8jHNVwuu2lY=
 20251204165231_pgflow_temp_mark_worker_stopped.sql h1:zI2FijK429oae4OpLbjU4eSaZtYhlsbvN3buWH9FKLw=
+20251205103442_pgflow_temp_add_extensions.sql h1:IBHG1vBdXu8wDEJzqpJUFmuPhVaX0mAmDUkngLgdaMg=


### PR DESCRIPTION
# Add PostgreSQL extensions for pgflow worker management

This PR adds several PostgreSQL extensions to the Atlas development database to support pgflow worker management:

- Added `pg_cron` for scheduled job execution
- Added `pg_net` for making HTTP requests from SQL (needed for pinging edge functions)
- Added `pgsodium` and `supabase_vault` for secure credential storage

The changes include:
- Updated Dockerfile to install and configure these extensions
- Modified the schema dump script to include schemas from the new extensions
- Updated the baseline schema to include the new extensions
- Renamed the Docker image to `jumski/atlas-postgres-pgflow:latest` to better reflect its purpose
- Added proper configuration for shared preload libraries and other required settings

These extensions will enable pgflow to securely store credentials, make HTTP requests, and schedule recurring tasks for worker management.
