### PR TITLE
docs: improve Supabase worker cron job setup instructions

### DIFF
--- a/pkgs/website/src/content/docs/deploy/supabase/keep-workers-running.mdx
+++ b/pkgs/website/src/content/docs/deploy/supabase/keep-workers-running.mdx
@@ -27,15 +27,19 @@ This approach checks existing worker counts before spawning new ones:
 
 1. **Create the safety net cron job**
 
-   Remember to change `<your-worker-name>` to name of your worker's Edge Function and `<YOUR_ANON_KEY>` to match your project's ANON key.
+   Replace these placeholders with your values:
 
-   ```sql
+   - `<your-project-ref>` → your Supabase project reference (Dashboard → Project Settings → General → Project ID field)
+   - `<your-worker-name>` → your Edge Function name (e.g., `my-worker`)
+   - `<YOUR_ANON_KEY>` → your project's ANON key (from Dashboard → Settings → API)
+
+   ```sql "<your-project-ref>" "<your-worker-name>" "<YOUR_ANON_KEY>"
    SELECT cron.schedule(
      'watchdog--<your-worker-name>',
      '10 seconds',
      $$
      SELECT net.http_post(
-       url := 'https://your-project.supabase.co/functions/v1/<your-worker-name>',
+       url := 'https://<your-project-ref>.supabase.co/functions/v1/<your-worker-name>',
        headers := jsonb_build_object('Authorization', 'Bearer <YOUR_ANON_KEY>')
      ) AS request_id
      WHERE (
@@ -46,6 +50,10 @@ This approach checks existing worker counts before spawning new ones:
      $$
    );
    ```
+
+   <Aside type="note" title="One Cron Per Worker">
+   Create a separate cron job for each worker function you want to monitor. Each cron should have a unique name (e.g., `watchdog--worker-a`, `watchdog--worker-b`).
+   </Aside>
 
 </Steps>
 


### PR DESCRIPTION
# Improve Supabase Worker Monitoring Documentation

This PR enhances the documentation for keeping Supabase workers running by:

- Adding clear instructions for replacing all placeholders in the SQL example
- Including the project reference placeholder in the URL path
- Fixing the URL format to use the project reference instead of a generic "your-project" placeholder
- Adding a note about creating separate cron jobs for each worker function
- Highlighting code placeholders in the SQL example for better visibility

These changes make the setup process more explicit and help prevent common configuration errors when implementing worker monitoring.
