### PR TITLE
feat: add worker tracking and graceful shutdown for edge functions

### DIFF
--- a/pkgs/edge-worker/deno.lock
+++ b/pkgs/edge-worker/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@deno-library/progress@*": "1.5.1",
     "jsr:@henrygd/queue@^1.0.7": "1.2.0",
+    "jsr:@std/assert@*": "0.224.0",
     "jsr:@std/assert@0.224": "0.224.0",
     "jsr:@std/async@0.224": "0.224.2",
     "jsr:@std/crypto@*": "1.0.5",

--- a/pkgs/edge-worker/src/core/Queries.ts
+++ b/pkgs/edge-worker/src/core/Queries.ts
@@ -73,4 +73,25 @@ export class Queries {
     `;
     return result.result;
   }
+
+  /**
+   * Registers an edge function for monitoring by ensure_workers() cron.
+   * Called by workers on startup. Sets last_invoked_at to prevent cron from
+   * pinging during startup (debounce).
+   */
+  async trackWorkerFunction(functionName: string): Promise<void> {
+    await this.sql`
+      SELECT pgflow.track_worker_function(${functionName})
+    `;
+  }
+
+  /**
+   * Marks a worker as stopped for graceful shutdown signaling.
+   * Called by workers on beforeunload to allow ensure_workers() to detect death immediately.
+   */
+  async markWorkerStopped(workerId: string): Promise<void> {
+    await this.sql`
+      SELECT pgflow.mark_worker_stopped(${workerId}::uuid)
+    `;
+  }
 }

--- a/pkgs/edge-worker/src/core/WorkerLifecycle.ts
+++ b/pkgs/edge-worker/src/core/WorkerLifecycle.ts
@@ -29,6 +29,10 @@ export class WorkerLifecycle<IMessage extends Json> implements ILifecycle {
   async acknowledgeStart(workerBootstrap: WorkerBootstrap): Promise<void> {
     this.workerState.transitionTo(States.Starting);
 
+    // Register this edge function for monitoring by ensure_workers() cron.
+    // Must be called early to set last_invoked_at (debounce) before heartbeat timeout.
+    await this.queries.trackWorkerFunction(workerBootstrap.edgeFunctionName);
+
     this.logger.debug(`Ensuring queue '${this.queue.queueName}' exists...`);
     await this.queue.safeCreate();
 

--- a/pkgs/edge-worker/src/flow/FlowWorkerLifecycle.ts
+++ b/pkgs/edge-worker/src/flow/FlowWorkerLifecycle.ts
@@ -41,6 +41,10 @@ export class FlowWorkerLifecycle<TFlow extends AnyFlow> implements ILifecycle {
     // Store workerId for supplier pattern
     this._workerId = workerBootstrap.workerId;
 
+    // Register this edge function for monitoring by ensure_workers() cron.
+    // Must be called early to set last_invoked_at (debounce) before heartbeat timeout.
+    await this.queries.trackWorkerFunction(workerBootstrap.edgeFunctionName);
+
     // Compile/verify flow as part of Starting (before registering worker)
     if (this.ensureCompiledOnStartup) {
       await this.ensureFlowCompiled();

--- a/pkgs/edge-worker/supabase/functions/deno.lock
+++ b/pkgs/edge-worker/supabase/functions/deno.lock
@@ -1,0 +1,128 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@henrygd/queue@^1.0.7": "1.2.0",
+    "jsr:@std/async@0.224": "0.224.2",
+    "jsr:@std/crypto@*": "1.0.5",
+    "jsr:@supabase/supabase-js@^2.49.4": "2.58.0",
+    "npm:@supabase/auth-js@2.72.0": "2.72.0",
+    "npm:@supabase/functions-js@2.5.0": "2.5.0",
+    "npm:@supabase/node-fetch@2.6.15": "2.6.15",
+    "npm:@supabase/postgrest-js@1.21.4": "1.21.4",
+    "npm:@supabase/realtime-js@2.15.5": "2.15.5",
+    "npm:@supabase/storage-js@2.12.2": "2.12.2",
+    "npm:postgres@3.4.5": "3.4.5"
+  },
+  "jsr": {
+    "@henrygd/queue@1.2.0": {
+      "integrity": "3e6c968f9bd56e3e7dfbd9952d0b7173a4ecdb7d4df041b3a0f4dfc896efeede"
+    },
+    "@std/async@0.224.2": {
+      "integrity": "4d277d6e165df43d5e061ba0ef3edfddb8e8d558f5b920e3e6b1d2614b44d074"
+    },
+    "@std/crypto@1.0.5": {
+      "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
+    },
+    "@supabase/supabase-js@2.58.0": {
+      "integrity": "4d04e72e9f632b451ac7d1a84de0b85249c0097fdf06253f371c1f0a23e62c87",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js",
+        "npm:@supabase/node-fetch",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.72.0": {
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.5.0": {
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.21.4": {
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.15.5": {
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.12.2": {
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@types/node@22.5.4": {
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.6": {
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "postgres@3.4.5": {
+      "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg=="
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@6.19.8": {
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.18.3": {
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@henrygd/queue@^1.0.7",
+      "jsr:@std/assert@0.224",
+      "jsr:@std/async@0.224",
+      "jsr:@std/crypto@^1.0.5",
+      "jsr:@std/log@~0.224.13",
+      "jsr:@std/testing@0.224",
+      "jsr:@supabase/supabase-js@^2.49.4",
+      "npm:postgres@3.4.5"
+    ]
+  }
+}

--- a/pkgs/edge-worker/supabase/functions/stopped_at_test/index.ts
+++ b/pkgs/edge-worker/supabase/functions/stopped_at_test/index.ts
@@ -1,0 +1,28 @@
+import { EdgeWorker } from '@pgflow/edge-worker';
+import { crypto } from 'jsr:@std/crypto';
+import { sql } from '../utils.ts';
+
+async function cpuIntensiveTask(payload: { debug?: boolean }) {
+  let data = new TextEncoder().encode('burn');
+  const timeId = `stopped_at_test_${Math.random()}`;
+
+  if (payload.debug) {
+    console.time(timeId);
+  }
+
+  for (let i = 0; i < 10000; i++) {
+    data = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
+  }
+
+  if (payload.debug) {
+    console.timeEnd(timeId);
+    console.log(
+      '[stopped_at_test] last_val = ',
+      await sql`SELECT nextval('stopped_at_test_seq')`
+    );
+  } else {
+    await sql`SELECT nextval('stopped_at_test_seq')`;
+  }
+}
+
+EdgeWorker.start(cpuIntensiveTask, { queueName: 'stopped_at_test' });

--- a/pkgs/edge-worker/tests/e2e/stopped_at.test.ts
+++ b/pkgs/edge-worker/tests/e2e/stopped_at.test.ts
@@ -1,0 +1,136 @@
+import { withSql } from '../sql.ts';
+import { assertEquals, assertExists } from 'jsr:@std/assert';
+import {
+  fetchWorkers,
+  log,
+  sendBatch,
+  seqLastValue,
+  setupEnsureWorkersCron,
+  startWorker,
+  startWorkersMonitor,
+  waitFor,
+  waitForSeqToIncrementBy,
+} from './_helpers.ts';
+
+const WORKER_NAME = 'stopped_at_test';
+const SEQ_NAME = 'stopped_at_test_seq';
+
+// Send enough messages to make worker hit CPU clock limit and die
+// Must be enough to exhaust CPU clock (same as restarts.test.ts)
+const MESSAGES_TO_SEND = 30;
+// Wait for at least a few messages to be processed before worker dies
+const MIN_MESSAGES_PROCESSED = 5;
+
+Deno.test(
+  {
+    name: 'should set stopped_at when worker dies due to CPU clock limit',
+    sanitizeOps: false,
+    sanitizeResources: false,
+  },
+  async () => {
+    await withSql(async (sql) => {
+      // Setup: create sequence
+      await sql`CREATE SEQUENCE IF NOT EXISTS ${sql(SEQ_NAME)}`;
+      await sql`ALTER SEQUENCE ${sql(SEQ_NAME)} RESTART WITH 1`;
+
+      // Create queue if it doesn't exist (don't drop - workers might be polling)
+      const queues = await sql`SELECT queue_name FROM pgmq.list_queues() WHERE queue_name = ${WORKER_NAME}`;
+      if (queues.length === 0) {
+        await sql`SELECT pgmq.create(${WORKER_NAME})`;
+      } else {
+        // Purge existing messages
+        await sql`SELECT pgmq.purge_queue(${WORKER_NAME})`;
+      }
+
+      // Clean up old worker records (but workers may still be running)
+      await sql`
+        DELETE FROM pgflow.workers
+        WHERE function_name = ${WORKER_NAME}
+      `;
+
+      // Setup cron job for worker respawning
+      await setupEnsureWorkersCron(sql, '1 second');
+
+      // Start monitoring for debugging
+      const monitor = startWorkersMonitor(WORKER_NAME);
+
+      try {
+        // Start the worker
+        await startWorker(WORKER_NAME);
+
+        // Get the initial worker record
+        const initialWorkers = await fetchWorkers(WORKER_NAME);
+        assertEquals(initialWorkers.length, 1, 'Should have exactly 1 worker');
+        const workerId = initialWorkers[0].worker_id;
+
+        // Verify stopped_at is NULL initially
+        assertEquals(
+          initialWorkers[0].stopped_at,
+          null,
+          'Worker should have NULL stopped_at initially'
+        );
+
+        // Send CPU-intensive tasks that will cause the worker to die
+        await sendBatch(MESSAGES_TO_SEND, WORKER_NAME);
+
+        // Wait for at least some messages to be processed (worker was running)
+        await waitForSeqToIncrementBy(MIN_MESSAGES_PROCESSED, {
+          seqName: SEQ_NAME,
+          timeoutMs: 20000,
+          pollIntervalMs: 300,
+        });
+
+        // Wait for the original worker to have stopped_at set
+        const stoppedWorker = await waitFor(
+          async () => {
+            const [worker] = await sql`
+              SELECT worker_id, stopped_at, last_heartbeat_at
+              FROM pgflow.workers
+              WHERE worker_id = ${workerId}
+            `;
+
+            if (!worker) {
+              log('Worker not found in DB');
+              return false;
+            }
+
+            log(`Worker state: stopped_at=${worker.stopped_at}, last_hb=${worker.last_heartbeat_at}`);
+
+            // Return the worker once stopped_at is set
+            return worker.stopped_at !== null ? worker : false;
+          },
+          {
+            timeoutMs: 30000,
+            pollIntervalMs: 500,
+            description: 'worker to have stopped_at set',
+          }
+        );
+
+        // Assert stopped_at was set
+        assertExists(stoppedWorker.stopped_at, 'Worker should have stopped_at set after dying');
+
+        // Verify stopped_at is a valid timestamp (not too far in the past)
+        const stoppedAt = new Date(stoppedWorker.stopped_at);
+        const now = new Date();
+        const timeDiff = now.getTime() - stoppedAt.getTime();
+
+        // stopped_at should be within the last 60 seconds
+        assertEquals(
+          timeDiff < 60000,
+          true,
+          `stopped_at should be recent (within last 60s), but was ${timeDiff}ms ago`
+        );
+
+        // Verify all messages eventually get processed (by replacement worker)
+        const finalSeqValue = await seqLastValue(SEQ_NAME);
+        assertEquals(
+          finalSeqValue >= MIN_MESSAGES_PROCESSED,
+          true,
+          `At least ${MIN_MESSAGES_PROCESSED} messages should have been processed`
+        );
+      } finally {
+        await monitor.stop();
+      }
+    });
+  }
+);

--- a/pkgs/edge-worker/tests/helpers.ts
+++ b/pkgs/edge-worker/tests/helpers.ts
@@ -1,5 +1,25 @@
 import type { PgmqMessageRecord } from "../src/queue/types.ts";
 import type { postgres } from "./sql.ts";
+import { waitFor } from "./e2e/_helpers.ts";
+
+/**
+ * Waits for a pgmq queue to exist (created by worker startup)
+ */
+export async function waitForQueue(sql: postgres.Sql, queueName: string) {
+  return await waitFor(
+    async () => {
+      const result = await sql<{ queue_name: string }[]>`
+        SELECT queue_name FROM pgmq.list_queues() WHERE queue_name = ${queueName}
+      `;
+      return result.length > 0 || false;
+    },
+    {
+      description: `queue '${queueName}' to exist`,
+      timeoutMs: 5000,
+      pollIntervalMs: 50,
+    }
+  );
+}
 
 export async function sendBatch(count: number, queueName: string, sql: postgres.Sql) {
   return await sql`

--- a/pkgs/edge-worker/tests/integration/exponential_backoff.test.ts
+++ b/pkgs/edge-worker/tests/integration/exponential_backoff.test.ts
@@ -1,11 +1,12 @@
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertAlmostEquals } from '@std/assert';
 import { createQueueWorker } from '../../src/queue/createQueueWorker.ts';
 import { createTestPlatformAdapter } from './_helpers.ts';
 import { withTransaction } from '../db.ts';
 import { createFakeLogger } from '../fakes.ts';
 import { log, waitFor } from '../e2e/_helpers.ts';
-import { sendBatch } from '../helpers.ts';
-import type { postgres } from '../sql.ts';
+import { sendBatch, waitForQueue } from '../helpers.ts';
+import type { Json } from '../../src/core/types.ts';
+import type { MessageHandlerContext } from '../../src/core/context.ts';
 
 const workerConfig = {
   maxPollSeconds: 1,
@@ -18,34 +19,40 @@ const workerConfig = {
 } as const;
 
 /**
- * Helper to get message visibility time from pgmq queue table
- */
-async function getMessageVisibilityTime(
-  sql: postgres.Sql,
-  queueName: string,
-  msgId: number
-): Promise<number | null> {
-  const result = await sql<{ vt_seconds: number }[]>`
-    SELECT EXTRACT(EPOCH FROM (vt - now()))::int as vt_seconds
-    FROM pgmq.q_${sql.unsafe(queueName)}
-    WHERE msg_id = ${msgId}
-  `;
-  return result[0]?.vt_seconds ?? null;
-}
-
-/**
- * Creates a handler that always fails and tracks failure times
+ * Creates a handler that always fails and collects timing data from two sources:
+ * 1. JS timestamps (Date.now()) - when handler is invoked
+ * 2. DB visibility times (rawMessage.vt) - when message became visible
  */
 function createFailingHandler() {
-  const failureTimes: number[] = [];
+  const invocations: Array<{ jsTime: number; vt: string }> = [];
   return {
-    handler: () => {
-      failureTimes.push(Date.now());
-      log(`Failure #${failureTimes.length} at ${new Date().toISOString()}`);
+    handler: (_payload: Json, context: MessageHandlerContext) => {
+      invocations.push({
+        jsTime: Date.now(),
+        vt: context.rawMessage.vt,
+      });
+      log(`Invocation #${invocations.length} at ${new Date().toISOString()}`);
       throw new Error('Intentional failure for exponential backoff test');
     },
-    getFailureCount: () => failureTimes.length,
-    getFailureTimes: () => failureTimes,
+    getInvocationCount: () => invocations.length,
+    getJsDelays: () => {
+      // Delays in seconds from JS timestamps
+      const delays: number[] = [];
+      for (let i = 1; i < invocations.length; i++) {
+        delays.push((invocations[i].jsTime - invocations[i - 1].jsTime) / 1000);
+      }
+      return delays;
+    },
+    getVtDelays: () => {
+      // Delays in seconds from DB visibility times
+      const delays: number[] = [];
+      for (let i = 1; i < invocations.length; i++) {
+        const vt1 = new Date(invocations[i - 1].vt).getTime();
+        const vt2 = new Date(invocations[i].vt).getTime();
+        delays.push((vt2 - vt1) / 1000);
+      }
+      return delays;
+    },
   };
 }
 
@@ -53,12 +60,13 @@ function createFailingHandler() {
  * Test verifies that exponential backoff is applied correctly:
  * - 1st retry: baseDelay * 2^0 = 2 seconds
  * - 2nd retry: baseDelay * 2^1 = 4 seconds
- * - 3rd retry: baseDelay * 2^2 = 8 seconds
+ * Uses dual-source timing validation (JS timestamps + DB visibility times).
  */
 Deno.test(
   'queue worker applies exponential backoff on retries',
   withTransaction(async (sql) => {
-    const { handler, getFailureCount } = createFailingHandler();
+    const { handler, getInvocationCount, getJsDelays, getVtDelays } =
+      createFailingHandler();
     const worker = createQueueWorker(
       handler,
       {
@@ -70,11 +78,12 @@ Deno.test(
     );
 
     try {
-      // Start worker and send test message
+      // Start worker and wait for queue to be created
       worker.startOnlyOnce({
         edgeFunctionName: 'exponential-backoff-test',
         workerId: crypto.randomUUID(),
       });
+      await waitForQueue(sql, workerConfig.queueName);
 
       // Send a single message
       const [{ send_batch: msgIds }] = await sendBatch(
@@ -82,57 +91,58 @@ Deno.test(
         workerConfig.queueName,
         sql
       );
-      const msgId = msgIds[0];
-      log(`Sent message with ID: ${msgId}`);
+      log(`Sent message with ID: ${msgIds[0]}`);
 
-      // Collect visibility times after each failure
-      const visibilityTimes: number[] = [];
+      // Wait for all retries to complete
+      await waitFor(() => getInvocationCount() >= workerConfig.retry.limit, {
+        timeoutMs: 30000,
+      });
 
-      for (let i = 1; i <= workerConfig.retry.limit; i++) {
-        // Wait for failure
-        await waitFor(() => getFailureCount() >= i, {
-          timeoutMs: 15000,
-        });
+      // Get delays from both sources
+      const jsDelays = getJsDelays();
+      const vtDelays = getVtDelays();
 
-        // Get visibility time after failure
-        const vt = await getMessageVisibilityTime(
-          sql,
-          workerConfig.queueName,
-          msgId
-        );
-        if (vt !== null) {
-          visibilityTimes.push(vt);
-          log(`Visibility time after failure #${i}: ${vt}s`);
-        }
-      }
-
-      // Calculate individual retry delays from visibility times
-      const actualDelays: number[] = [];
-      for (let i = 0; i < visibilityTimes.length; i++) {
-        if (i === 0) {
-          actualDelays.push(visibilityTimes[i]);
-        } else {
-          actualDelays.push(visibilityTimes[i] - visibilityTimes[i - 1]);
-        }
-      }
+      log(`JS delays: ${JSON.stringify(jsDelays)}`);
+      log(`VT delays: ${JSON.stringify(vtDelays)}`);
 
       // Expected exponential backoff pattern: baseDelay * 2^(attempt-1)
-      const expectedDelays = [
-        2, // First retry: 2 * 2^0 = 2 seconds
-        4, // Second retry: 2 * 2^1 = 4 seconds
-        8, // Third retry: 2 * 2^2 = 8 seconds
-      ];
+      // - Delay 1->2: 2 * 2^0 = 2 seconds
+      // - Delay 2->3: 2 * 2^1 = 4 seconds
+      const expectedDelays = [2, 4];
 
-      // Compare actual vs expected delays
+      // Verify JS-based delays match expected pattern (within 200ms tolerance)
       assertEquals(
-        actualDelays,
-        expectedDelays,
-        'Retry delays should follow exponential backoff pattern'
+        jsDelays.length,
+        expectedDelays.length,
+        `Expected ${expectedDelays.length} delays, got ${jsDelays.length}`
       );
+      for (let i = 0; i < expectedDelays.length; i++) {
+        assertAlmostEquals(
+          jsDelays[i],
+          expectedDelays[i],
+          0.2,
+          `JS delay #${i + 1} should be ~${expectedDelays[i]}s`
+        );
+      }
 
-      // Verify total failure count
+      // Verify VT-based delays match expected pattern (within 200ms tolerance)
       assertEquals(
-        getFailureCount(),
+        vtDelays.length,
+        expectedDelays.length,
+        `Expected ${expectedDelays.length} VT delays, got ${vtDelays.length}`
+      );
+      for (let i = 0; i < expectedDelays.length; i++) {
+        assertAlmostEquals(
+          vtDelays[i],
+          expectedDelays[i],
+          0.2,
+          `VT delay #${i + 1} should be ~${expectedDelays[i]}s`
+        );
+      }
+
+      // Verify total invocation count
+      assertEquals(
+        getInvocationCount(),
         workerConfig.retry.limit,
         `Handler should be called ${workerConfig.retry.limit} times`
       );

--- a/pkgs/edge-worker/tests/integration/maxConcurrent.test.ts
+++ b/pkgs/edge-worker/tests/integration/maxConcurrent.test.ts
@@ -6,7 +6,7 @@ import { createFakeLogger } from '../fakes.ts';
 import { waitFor } from '../e2e/_helpers.ts';
 import type { PgmqMessageRecord } from '../../src/queue/types.ts';
 import { delay } from '@std/async';
-import { sendBatch } from '../helpers.ts';
+import { sendBatch, waitForQueue } from '../helpers.ts';
 
 const QUEUE_NAME = 'max_concurrent';
 const MESSAGES_TO_SEND = 3;
@@ -37,6 +37,7 @@ Deno.test(
         // random uuid
         workerId: crypto.randomUUID(),
       });
+      await waitForQueue(sql, QUEUE_NAME);
 
       await sendBatch(MESSAGES_TO_SEND, QUEUE_NAME, sql);
 

--- a/pkgs/edge-worker/tests/integration/retries.test.ts
+++ b/pkgs/edge-worker/tests/integration/retries.test.ts
@@ -4,7 +4,7 @@ import { createTestPlatformAdapter } from './_helpers.ts';
 import { withTransaction } from '../db.ts';
 import { createFakeLogger } from '../fakes.ts';
 import { log, waitFor } from '../e2e/_helpers.ts';
-import { getArchivedMessages, sendBatch } from '../helpers.ts';
+import { getArchivedMessages, sendBatch, waitForQueue } from '../helpers.ts';
 
 const workerConfig = {
   maxPollSeconds: 1,
@@ -45,11 +45,12 @@ Deno.test(
     );
 
     try {
-      // Start worker and send test message
+      // Start worker and wait for queue to be created
       worker.startOnlyOnce({
         edgeFunctionName: 'test',
         workerId: crypto.randomUUID(),
       });
+      await waitForQueue(sql, workerConfig.queueName);
       await sendBatch(1, workerConfig.queueName, sql);
 
       // Calculate expected processing time

--- a/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.deprecation.test.ts
+++ b/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.deprecation.test.ts
@@ -18,12 +18,12 @@ class MockQueries extends Queries {
   public sendHeartbeatCallCount = 0;
   public nextResult: { is_deprecated: boolean } = { is_deprecated: false };
   public workerStopped = false;
-  
+
   constructor() {
     // Pass null as sql since we'll override all methods
     super(null as unknown as postgres.Sql);
   }
-  
+
   override onWorkerStarted(params: { workerId: string; edgeFunctionName: string; queueName: string }): Promise<WorkerRow> {
     return Promise.resolve({
       worker_id: params.workerId,
@@ -50,6 +50,10 @@ class MockQueries extends Queries {
     _shape: FlowShape
   ): Promise<EnsureFlowCompiledResult> {
     return Promise.resolve({ status: 'verified', differences: [] });
+  }
+
+  override trackWorkerFunction(_functionName: string): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/pkgs/edge-worker/tests/unit/Queries.test.ts
+++ b/pkgs/edge-worker/tests/unit/Queries.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from '@std/assert';
+import { Queries } from '../../src/core/Queries.ts';
+import type { postgres } from '../sql.ts';
+
+// Mock SQL client that captures the SQL template string and values
+function createMockSql() {
+  const calls: { query: string; values: unknown[] }[] = [];
+
+  const mockSql = ((
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => {
+    const query = strings.join('?');
+    calls.push({ query, values });
+    return Promise.resolve([]);
+  }) as unknown as postgres.Sql;
+
+  return { mockSql, calls };
+}
+
+Deno.test('Queries.trackWorkerFunction - calls correct SQL function', async () => {
+  const { mockSql, calls } = createMockSql();
+  const queries = new Queries(mockSql);
+
+  await queries.trackWorkerFunction('my-edge-function');
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].values, ['my-edge-function']);
+  // Check that query references the correct function
+  assertEquals(calls[0].query.includes('pgflow.track_worker_function'), true);
+});
+
+Deno.test('Queries.trackWorkerFunction - handles special characters in function name', async () => {
+  const { mockSql, calls } = createMockSql();
+  const queries = new Queries(mockSql);
+
+  await queries.trackWorkerFunction('my_function-with-special_chars');
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].values, ['my_function-with-special_chars']);
+});
+
+Deno.test('Queries.markWorkerStopped - calls correct SQL function', async () => {
+  const { mockSql, calls } = createMockSql();
+  const queries = new Queries(mockSql);
+
+  const workerId = '550e8400-e29b-41d4-a716-446655440000';
+  await queries.markWorkerStopped(workerId);
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].values, [workerId]);
+  // Check that query references the correct function
+  assertEquals(calls[0].query.includes('pgflow.mark_worker_stopped'), true);
+});
+
+Deno.test('Queries.markWorkerStopped - handles different UUID formats', async () => {
+  const { mockSql, calls } = createMockSql();
+  const queries = new Queries(mockSql);
+
+  const workerId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+  await queries.markWorkerStopped(workerId);
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].values, [workerId]);
+});

--- a/pkgs/edge-worker/tests/unit/WorkerLifecycle.deprecation.test.ts
+++ b/pkgs/edge-worker/tests/unit/WorkerLifecycle.deprecation.test.ts
@@ -18,12 +18,12 @@ class MockQueries extends Queries {
   public sendHeartbeatCallCount = 0;
   public nextResult: { is_deprecated: boolean } = { is_deprecated: false };
   public workerStopped = false;
-  
+
   constructor() {
     // Pass null as sql since we'll override all methods
     super(null as unknown as postgres.Sql);
   }
-  
+
   override onWorkerStarted(params: {
     workerId: string;
     edgeFunctionName: string;
@@ -49,6 +49,14 @@ class MockQueries extends Queries {
   override onWorkerStopped(workerRow: WorkerRow): Promise<WorkerRow> {
     this.workerStopped = true;
     return Promise.resolve(workerRow);
+  }
+
+  override trackWorkerFunction(_functionName: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  override markWorkerStopped(_workerId: string): Promise<void> {
+    return Promise.resolve();
   }
 }
 


### PR DESCRIPTION
# Implement Worker Tracking for Improved Reliability

This PR adds functionality to track edge function workers more effectively, improving the reliability of worker management:

1. Added two new methods to the `Queries` class:
   - `trackWorkerFunction()` - Registers an edge function for monitoring by the `ensure_workers()` cron job
   - `markWorkerStopped()` - Marks a worker as stopped during graceful shutdown

2. Updated worker lifecycle implementations to call `trackWorkerFunction()` early in the startup process, which:
   - Sets `last_invoked_at` to prevent cron from pinging during startup (debounce)
   - Ensures proper monitoring of the worker by the cron job

3. Enhanced the shutdown process in `SupabasePlatformAdapter`:
   - Replaced the previous approach of spawning a new edge function
   - Now signals worker death to the cron job by setting `stopped_at`
   - Allows immediate detection of worker termination

4. Added comprehensive unit tests for the new functionality

These changes improve worker reliability by providing better signaling between workers and the monitoring system, ensuring faster recovery from failures and more efficient worker management.
