### PR TITLE
refactor: add handler spy utilities for queue worker tests

### DIFF
--- a/pkgs/edge-worker/tests/integration/_helpers.ts
+++ b/pkgs/edge-worker/tests/integration/_helpers.ts
@@ -1,3 +1,4 @@
+import { assertEquals, assertAlmostEquals } from '@std/assert';
 import type { AnyFlow, ExtractFlowInput } from '@pgflow/dsl';
 import {
   createFlowWorker,
@@ -78,4 +79,97 @@ export function startWorker<TFlow extends AnyFlow>(
   });
 
   return worker;
+}
+
+// ============================================================================
+// Handler Spy & Delay Utilities
+// ============================================================================
+
+/**
+ * Represents a single invocation captured by the handler spy.
+ */
+export interface SpyInvocation<TInput, TContext> {
+  jsTime: number;
+  input: TInput;
+  context: TContext;
+}
+
+/**
+ * Creates a handler spy that captures invocations with timing data.
+ * @param onInvoke - Optional callback to execute on each invocation (throw to simulate failure)
+ */
+export function createHandlerSpy<TInput = unknown, TContext = unknown>(
+  onInvoke?: (input: TInput, context: TContext) => void
+) {
+  const invocations: SpyInvocation<TInput, TContext>[] = [];
+
+  return {
+    handler: (input: TInput, context: TContext) => {
+      invocations.push({ jsTime: Date.now(), input, context });
+      return onInvoke?.(input, context);
+    },
+    invocations,
+    count: () => invocations.length,
+  };
+}
+
+/**
+ * Calculates delays between invocations using JS timestamps.
+ * @returns Delays in seconds between consecutive invocations.
+ */
+export function calculateJsDelays<T, C>(
+  invocations: SpyInvocation<T, C>[]
+): number[] {
+  const delays: number[] = [];
+  for (let i = 1; i < invocations.length; i++) {
+    delays.push((invocations[i].jsTime - invocations[i - 1].jsTime) / 1000);
+  }
+  return delays;
+}
+
+/**
+ * Context type that includes rawMessage with visibility time.
+ */
+type WithRawMessage = { rawMessage: { vt: string } };
+
+/**
+ * Calculates delays between invocations using DB visibility times.
+ * @returns Delays in seconds between consecutive visibility times.
+ */
+export function calculateVtDelays<T, C extends WithRawMessage>(
+  invocations: SpyInvocation<T, C>[]
+): number[] {
+  const delays: number[] = [];
+  for (let i = 1; i < invocations.length; i++) {
+    const vt1 = new Date(invocations[i - 1].context.rawMessage.vt).getTime();
+    const vt2 = new Date(invocations[i].context.rawMessage.vt).getTime();
+    delays.push((vt2 - vt1) / 1000);
+  }
+  return delays;
+}
+
+/**
+ * Asserts that actual delays match expected delays within tolerance.
+ * @param actual - Actual measured delays in seconds
+ * @param expected - Expected delays in seconds
+ * @param toleranceSec - Tolerance in seconds for each comparison
+ */
+export function assertDelaysMatch(
+  actual: number[],
+  expected: number[],
+  toleranceSec: number
+): void {
+  assertEquals(
+    actual.length,
+    expected.length,
+    `Expected ${expected.length} delays, got ${actual.length}`
+  );
+  for (let i = 0; i < expected.length; i++) {
+    assertAlmostEquals(
+      actual[i],
+      expected[i],
+      toleranceSec,
+      `Delay #${i + 1} should be ~${expected[i]}s, got ${actual[i]}s`
+    );
+  }
 }

--- a/pkgs/edge-worker/tests/integration/fixed_retry.test.ts
+++ b/pkgs/edge-worker/tests/integration/fixed_retry.test.ts
@@ -1,6 +1,12 @@
-import { assertEquals, assertAlmostEquals } from '@std/assert';
+import { assertEquals } from '@std/assert';
 import { createQueueWorker } from '../../src/queue/createQueueWorker.ts';
-import { createTestPlatformAdapter } from './_helpers.ts';
+import {
+  createTestPlatformAdapter,
+  createHandlerSpy,
+  calculateJsDelays,
+  calculateVtDelays,
+  assertDelaysMatch,
+} from './_helpers.ts';
 import { withTransaction } from '../db.ts';
 import { createFakeLogger } from '../fakes.ts';
 import { log, waitFor } from '../e2e/_helpers.ts';
@@ -19,54 +25,20 @@ const workerConfig = {
 } as const;
 
 /**
- * Creates a handler that always fails and collects timing data from two sources:
- * 1. JS timestamps (Date.now()) - when handler is invoked
- * 2. DB visibility times (rawMessage.vt) - when message became visible
- */
-function createFailingHandler() {
-  const invocations: Array<{ jsTime: number; vt: string }> = [];
-  return {
-    handler: (_payload: Json, context: MessageHandlerContext) => {
-      invocations.push({
-        jsTime: Date.now(),
-        vt: context.rawMessage.vt,
-      });
-      log(`Invocation #${invocations.length} at ${new Date().toISOString()}`);
-      throw new Error('Intentional failure for fixed retry test');
-    },
-    getInvocationCount: () => invocations.length,
-    getJsDelays: () => {
-      // Delays in seconds from JS timestamps
-      const delays: number[] = [];
-      for (let i = 1; i < invocations.length; i++) {
-        delays.push((invocations[i].jsTime - invocations[i - 1].jsTime) / 1000);
-      }
-      return delays;
-    },
-    getVtDelays: () => {
-      // Delays in seconds from DB visibility times
-      const delays: number[] = [];
-      for (let i = 1; i < invocations.length; i++) {
-        const vt1 = new Date(invocations[i - 1].vt).getTime();
-        const vt2 = new Date(invocations[i].vt).getTime();
-        delays.push((vt2 - vt1) / 1000);
-      }
-      return delays;
-    },
-  };
-}
-
-/**
  * Test verifies that fixed retry strategy applies constant delay.
  * Uses dual-source timing validation (JS timestamps + DB visibility times).
  */
 Deno.test(
   'queue worker applies fixed delay on retries',
   withTransaction(async (sql) => {
-    const { handler, getInvocationCount, getJsDelays, getVtDelays } =
-      createFailingHandler();
+    const spy = createHandlerSpy<Json, MessageHandlerContext>(
+      (_input, _context) => {
+        log(`Invocation #${spy.count()} at ${new Date().toISOString()}`);
+        throw new Error('Intentional failure for fixed retry test');
+      }
+    );
     const worker = createQueueWorker(
-      handler,
+      spy.handler,
       {
         sql,
         ...workerConfig,
@@ -92,13 +64,13 @@ Deno.test(
       log(`Sent message with ID: ${msgIds[0]}`);
 
       // Wait for all retries to complete
-      await waitFor(() => getInvocationCount() >= workerConfig.retry.limit, {
+      await waitFor(() => spy.count() >= workerConfig.retry.limit, {
         timeoutMs: 30000,
       });
 
       // Get delays from both sources
-      const jsDelays = getJsDelays();
-      const vtDelays = getVtDelays();
+      const jsDelays = calculateJsDelays(spy.invocations);
+      const vtDelays = calculateVtDelays(spy.invocations);
 
       log(`JS delays: ${JSON.stringify(jsDelays)}`);
       log(`VT delays: ${JSON.stringify(vtDelays)}`);
@@ -108,38 +80,14 @@ Deno.test(
       const expectedDelays = [3, 3];
 
       // Verify JS-based delays match expected pattern (within 200ms tolerance)
-      assertEquals(
-        jsDelays.length,
-        expectedDelays.length,
-        `Expected ${expectedDelays.length} delays, got ${jsDelays.length}`
-      );
-      for (let i = 0; i < expectedDelays.length; i++) {
-        assertAlmostEquals(
-          jsDelays[i],
-          expectedDelays[i],
-          0.2,
-          `JS delay #${i + 1} should be ~${expectedDelays[i]}s`
-        );
-      }
+      assertDelaysMatch(jsDelays, expectedDelays, 0.2);
 
       // Verify VT-based delays match expected pattern (within 200ms tolerance)
-      assertEquals(
-        vtDelays.length,
-        expectedDelays.length,
-        `Expected ${expectedDelays.length} VT delays, got ${vtDelays.length}`
-      );
-      for (let i = 0; i < expectedDelays.length; i++) {
-        assertAlmostEquals(
-          vtDelays[i],
-          expectedDelays[i],
-          0.2,
-          `VT delay #${i + 1} should be ~${expectedDelays[i]}s`
-        );
-      }
+      assertDelaysMatch(vtDelays, expectedDelays, 0.2);
 
       // Verify total invocation count
       assertEquals(
-        getInvocationCount(),
+        spy.count(),
         workerConfig.retry.limit,
         `Handler should be called ${workerConfig.retry.limit} times`
       );

--- a/pkgs/edge-worker/tests/integration/legacy_retry_config.test.ts
+++ b/pkgs/edge-worker/tests/integration/legacy_retry_config.test.ts
@@ -1,53 +1,26 @@
 import { assertEquals } from '@std/assert';
 import { createQueueWorker } from '../../src/queue/createQueueWorker.ts';
-import { createTestPlatformAdapter } from './_helpers.ts';
+import {
+  createTestPlatformAdapter,
+  createHandlerSpy,
+  calculateJsDelays,
+  calculateVtDelays,
+  assertDelaysMatch,
+} from './_helpers.ts';
 import { withTransaction } from '../db.ts';
 import { createFakeLogger } from '../fakes.ts';
 import { log, waitFor } from '../e2e/_helpers.ts';
-import { sendBatch } from '../helpers.ts';
-import type { postgres } from '../sql.ts';
-import { delay } from '@std/async';
+import { sendBatch, waitForQueue } from '../helpers.ts';
+import type { Json } from '../../src/core/types.ts';
+import type { MessageHandlerContext } from '../../src/core/context.ts';
 
 /**
- * Helper to get message visibility time from pgmq queue table
- */
-async function getMessageVisibilityTime(
-  sql: postgres.Sql,
-  queueName: string,
-  msgId: number
-): Promise<number | null> {
-  const result = await sql<{ vt_seconds: number }[]>`
-    SELECT EXTRACT(EPOCH FROM (vt - now()))::int as vt_seconds
-    FROM pgmq.q_${sql.unsafe(queueName)}
-    WHERE msg_id = ${msgId}
-  `;
-  return result[0]?.vt_seconds ?? null;
-}
-
-/**
- * Creates a handler that always fails and tracks failure times
- */
-function createFailingHandler() {
-  const failureTimes: number[] = [];
-  return {
-    handler: () => {
-      failureTimes.push(Date.now());
-      log(`Failure #${failureTimes.length} at ${new Date().toISOString()}`);
-      throw new Error('Intentional failure for legacy config test');
-    },
-    getFailureCount: () => failureTimes.length,
-    getFailureTimes: () => failureTimes,
-  };
-}
-
-/**
- * Test verifies that legacy retryLimit and retryDelay still work (backwards compatibility)
+ * Test verifies that legacy retryLimit and retryDelay still work (backwards compatibility).
+ * Uses dual-source timing validation (JS timestamps + DB visibility times).
  */
 Deno.test(
   'queue worker supports legacy retryLimit and retryDelay config',
   withTransaction(async (sql) => {
-    const { handler, getFailureCount } = createFailingHandler();
-    
     // Track warning messages through logger
     const warnMessages: string[] = [];
     const customCreateLogger = (module: string) => ({
@@ -57,14 +30,21 @@ Deno.test(
         warnMessages.push(msg);
       },
     });
-    
+
+    const spy = createHandlerSpy<Json, MessageHandlerContext>(
+      (_input, _context) => {
+        log(`Invocation #${spy.count()} at ${new Date().toISOString()}`);
+        throw new Error('Intentional failure for legacy config test');
+      }
+    );
+
     const worker = createQueueWorker(
-      handler,
+      spy.handler,
       {
         sql,
         maxPollSeconds: 1,
-        retryLimit: 2,    // Legacy config
-        retryDelay: 5,    // Legacy config
+        retryLimit: 2, // Legacy config
+        retryDelay: 5, // Legacy config
         queueName: 'legacy_retry_test',
       },
       customCreateLogger,
@@ -74,19 +54,19 @@ Deno.test(
     try {
       // Verify deprecation warning was shown
       assertEquals(
-        warnMessages.some(msg => msg.includes('retryLimit and retryDelay are deprecated')),
+        warnMessages.some((msg) =>
+          msg.includes('retryLimit and retryDelay are deprecated')
+        ),
         true,
         'Should show deprecation warning for legacy config'
       );
 
-      // Start worker and send test message
+      // Start worker and wait for queue to be created
       worker.startOnlyOnce({
         edgeFunctionName: 'legacy-retry-test',
         workerId: crypto.randomUUID(),
       });
-      
-      // Wait for worker to be ready
-      await delay(100);
+      await waitForQueue(sql, 'legacy_retry_test');
 
       // Send a single message
       const [{ send_batch: msgIds }] = await sendBatch(
@@ -94,65 +74,32 @@ Deno.test(
         'legacy_retry_test',
         sql
       );
-      const msgId = msgIds[0];
-      log(`Sent message with ID: ${msgId}`);
+      log(`Sent message with ID: ${msgIds[0]}`);
 
-      // Collect visibility times after each failure
-      const visibilityTimes: number[] = [];
+      // Wait for all retries to complete
+      await waitFor(() => spy.count() >= 2, {
+        timeoutMs: 30000,
+      });
 
-      for (let i = 1; i <= 2; i++) {
-        // Wait for failure
-        await waitFor(() => getFailureCount() >= i, {
-          timeoutMs: 15000,
-        });
+      // Get delays from both sources
+      const jsDelays = calculateJsDelays(spy.invocations);
+      const vtDelays = calculateVtDelays(spy.invocations);
 
-        // Get visibility time after failure
-        const vt = await getMessageVisibilityTime(
-          sql,
-          'legacy_retry_test',
-          msgId
-        );
-        if (vt !== null) {
-          visibilityTimes.push(vt);
-          log(`Visibility time after failure #${i}: ${vt}s`);
-        }
-      }
+      log(`JS delays: ${JSON.stringify(jsDelays)}`);
+      log(`VT delays: ${JSON.stringify(vtDelays)}`);
 
-      // Calculate individual retry delays from visibility times
-      const actualDelays: number[] = [];
-      for (let i = 0; i < visibilityTimes.length; i++) {
-        if (i === 0) {
-          actualDelays.push(visibilityTimes[i]);
-        } else {
-          actualDelays.push(visibilityTimes[i] - visibilityTimes[i - 1]);
-        }
-      }
+      // Legacy config should result in fixed delays of 5 seconds
+      const expectedDelays = [5];
 
-      // Legacy config should result in fixed delays (with some tolerance for timing)
-      // First delay might have +1s due to processing time or pgmq internals
+      // Verify JS-based delays match expected pattern (within 200ms tolerance)
+      assertDelaysMatch(jsDelays, expectedDelays, 0.2);
+
+      // Verify VT-based delays match expected pattern (within 200ms tolerance)
+      assertDelaysMatch(vtDelays, expectedDelays, 0.2);
+
+      // Verify total invocation count
       assertEquals(
-        actualDelays.length,
-        2,
-        'Should have 2 retry delays'
-      );
-      
-      // First delay should be close to retryDelay (allowing 1s variance)
-      assertEquals(
-        Math.abs(actualDelays[0] - 5) <= 1,
-        true,
-        `First delay should be ~5s, got ${actualDelays[0]}s`
-      );
-      
-      // Second delay should be exactly retryDelay
-      assertEquals(
-        actualDelays[1],
-        5,
-        'Second delay should be exactly 5s'
-      );
-
-      // Verify total failure count
-      assertEquals(
-        getFailureCount(),
+        spy.count(),
         2, // retryLimit
         'Handler should be called 2 times (retryLimit)'
       );


### PR DESCRIPTION
# Add Handler Spy and Delay Utilities for Queue Worker Tests

This PR introduces a set of reusable testing utilities for queue worker tests:

- Added `createHandlerSpy()` to capture handler invocations with timing data
- Added utilities to calculate delays between invocations using both JS timestamps and DB visibility times
- Added `assertDelaysMatch()` to verify that actual delays match expected patterns within tolerance
- Refactored existing tests to use these new utilities:
  - `exponential_backoff.test.ts`
  - `fixed_retry.test.ts`
  - `legacy_retry_config.test.ts`

These changes improve test maintainability by eliminating duplicate code across test files and providing a consistent approach to timing validation.
