### PR TITLE
refactor: remove last_invoked_at from track_worker_function to fix debounce handling

### DIFF
--- a/pkgs/core/schemas/0057_function_track_worker_function.sql
+++ b/pkgs/core/schemas/0057_function_track_worker_function.sql
@@ -6,14 +6,12 @@ create or replace function pgflow.track_worker_function(
 ) returns void
 language sql
 as $$
-  insert into pgflow.worker_functions (function_name, updated_at, last_invoked_at)
-  values (track_worker_function.function_name, clock_timestamp(), clock_timestamp())
+  insert into pgflow.worker_functions (function_name, updated_at)
+  values (track_worker_function.function_name, clock_timestamp())
   on conflict (function_name)
   do update set
-    updated_at = clock_timestamp(),
-    last_invoked_at = clock_timestamp();
+    updated_at = clock_timestamp();
 $$;
 
 comment on function pgflow.track_worker_function(text) is
-'Registers an edge function for monitoring. Called by workers on startup.
-Sets last_invoked_at to prevent cron from pinging during startup (debounce).';
+'Registers an edge function for monitoring. Called by workers on startup.';

--- a/pkgs/core/supabase/migrations/atlas.sum
+++ b/pkgs/core/supabase/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GOF4slSDF67Y0jRat+hxKnNE1MIRJy/Z8pJog3iEuVk=
+h1:VgOpcmBfLwSXeC+q/2hT/Quc8P7YRzKa3x4cZ1z+ZRM=
 20250429164909_pgflow_initial.sql h1:I3n/tQIg5Q5nLg7RDoU3BzqHvFVjmumQxVNbXTPG15s=
 20250517072017_pgflow_fix_poll_for_tasks_to_use_separate_statement_for_polling.sql h1:wTuXuwMxVniCr3ONCpodpVWJcHktoQZIbqMZ3sUHKMY=
 20250609105135_pgflow_add_start_tasks_and_started_status.sql h1:ggGanW4Wyt8Kv6TWjnZ00/qVb3sm+/eFVDjGfT8qyPg=
@@ -12,4 +12,4 @@ h1:GOF4slSDF67Y0jRat+hxKnNE1MIRJy/Z8pJog3iEuVk=
 20251103222045_pgflow_fix_broadcast_order_and_timestamp_handling.sql h1:K/XnZpOmxfelsaNoJbR5HxhBrs/oW4aYja222h5cps4=
 20251104080523_pgflow_upgrade_pgmq_1_5_1.sql h1:Fw7zpMWnjhAHQ0qBJAprAvGl7dJMd8ExNHg8aKvkzTg=
 20251130000000_pgflow_auto_compilation.sql h1:qs+3qq1Vsyo0ETzbxDnmkVtSUa6XHkd/K9wF/3W46jM=
-20251207185658_pgflow_worker_management.sql h1:nPudzivCuG1bwmxnNzSvvcpMjjINKXP6ypzBajzhWqY=
+20251208045933_pgflow_worker_management.sql h1:B9LcYfhZQ5hyoTmXLl6pd/kPik9EJOuPdGI/9THmrks=

--- a/pkgs/core/supabase/tests/ensure_workers/debounce.test.sql
+++ b/pkgs/core/supabase/tests/ensure_workers/debounce.test.sql
@@ -7,7 +7,11 @@ select pgflow_tests.reset_db();
 select pgflow.track_worker_function('my-function');
 
 -- TEST: Function with recent last_invoked_at is NOT returned (debounce active)
--- Note: track_worker_function sets last_invoked_at to now()
+-- Manually set last_invoked_at to now() to simulate recent invocation
+update pgflow.worker_functions
+set last_invoked_at = now()
+where function_name = 'my-function';
+
 set local app.settings.jwt_secret = 'super-secret-jwt-token-with-at-least-32-characters-long';
 select is(
   (select count(*) from pgflow.ensure_workers()),

--- a/pkgs/edge-worker/src/core/Worker.ts
+++ b/pkgs/edge-worker/src/core/Worker.ts
@@ -24,14 +24,11 @@ export class Worker {
   }
 
   startOnlyOnce(workerBootstrap: WorkerBootstrap) {
-    if (this.lifecycle.isRunning) {
-      this.logger.debug('Worker already running, ignoring start request');
+    if (!this.lifecycle.isCreated) {
+      this.logger.debug('Worker not in Created state, ignoring start request');
       return;
     }
-
-    if (!this.mainLoopPromise) {
-      this.mainLoopPromise = this.start(workerBootstrap);
-    }
+    this.mainLoopPromise = this.start(workerBootstrap);
   }
 
   private async start(workerBootstrap: WorkerBootstrap) {

--- a/pkgs/edge-worker/src/core/WorkerLifecycle.ts
+++ b/pkgs/edge-worker/src/core/WorkerLifecycle.ts
@@ -30,7 +30,6 @@ export class WorkerLifecycle<IMessage extends Json> implements ILifecycle {
     this.workerState.transitionTo(States.Starting);
 
     // Register this edge function for monitoring by ensure_workers() cron.
-    // Must be called early to set last_invoked_at (debounce) before heartbeat timeout.
     await this.queries.trackWorkerFunction(workerBootstrap.edgeFunctionName);
 
     this.logger.debug(`Ensuring queue '${this.queue.queueName}' exists...`);
@@ -93,6 +92,10 @@ export class WorkerLifecycle<IMessage extends Json> implements ILifecycle {
         this.transitionToDeprecated();
       }
     }
+  }
+
+  get isCreated() {
+    return this.workerState.isCreated;
   }
 
   get isRunning() {

--- a/pkgs/edge-worker/src/core/types.ts
+++ b/pkgs/edge-worker/src/core/types.ts
@@ -26,6 +26,7 @@ export interface ILifecycle {
 
   get edgeFunctionName(): string | undefined;
   get queueName(): string;
+  get isCreated(): boolean;
   get isRunning(): boolean;
   get isStopping(): boolean;
   get isStopped(): boolean;

--- a/pkgs/edge-worker/src/flow/FlowWorkerLifecycle.ts
+++ b/pkgs/edge-worker/src/flow/FlowWorkerLifecycle.ts
@@ -42,7 +42,6 @@ export class FlowWorkerLifecycle<TFlow extends AnyFlow> implements ILifecycle {
     this._workerId = workerBootstrap.workerId;
 
     // Register this edge function for monitoring by ensure_workers() cron.
-    // Must be called early to set last_invoked_at (debounce) before heartbeat timeout.
     await this.queries.trackWorkerFunction(workerBootstrap.edgeFunctionName);
 
     // Compile/verify flow as part of Starting (before registering worker)
@@ -127,6 +126,10 @@ export class FlowWorkerLifecycle<TFlow extends AnyFlow> implements ILifecycle {
         this.transitionToDeprecated();
       }
     }
+  }
+
+  get isCreated() {
+    return this.workerState.isCreated;
   }
 
   get isRunning() {

--- a/pkgs/edge-worker/tests/unit/Worker.startOnlyOnce.test.ts
+++ b/pkgs/edge-worker/tests/unit/Worker.startOnlyOnce.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals } from '@std/assert';
+import { Worker } from '../../src/core/Worker.ts';
+import type {
+  IBatchProcessor,
+  ILifecycle,
+  WorkerBootstrap,
+} from '../../src/core/types.ts';
+import { createLoggingFactory } from '../../src/platform/logging.ts';
+
+const loggingFactory = createLoggingFactory();
+loggingFactory.setLogLevel('error'); // Suppress debug output during tests
+const logger = loggingFactory.createLogger('Worker.startOnlyOnce.test');
+
+// Mock ILifecycle that tracks calls and allows controlling state
+function createMockLifecycle(
+  state: 'created' | 'starting' | 'running' | 'stopping' | 'stopped'
+): ILifecycle & { acknowledgeStartCalled: boolean } {
+  return {
+    acknowledgeStartCalled: false,
+    acknowledgeStart: function () {
+      this.acknowledgeStartCalled = true;
+      return Promise.resolve();
+    },
+    acknowledgeStop: () => {},
+    sendHeartbeat: async () => {},
+    edgeFunctionName: 'test-function',
+    queueName: 'test-queue',
+    isCreated: state === 'created',
+    isRunning: state === 'running',
+    isStopping: state === 'stopping',
+    isStopped: state === 'stopped',
+    transitionToStopping: () => {},
+  };
+}
+
+// Mock IBatchProcessor
+function createMockBatchProcessor(): IBatchProcessor {
+  return {
+    processBatch: async () => {},
+    awaitCompletion: async () => {},
+  };
+}
+
+// Mock SQL connection
+const mockSql = {
+  end: async () => {},
+} as never;
+
+const workerBootstrap: WorkerBootstrap = {
+  edgeFunctionName: 'test-function',
+  workerId: 'test-worker-id',
+};
+
+Deno.test('Worker.startOnlyOnce - starts worker when in Created state', async () => {
+  const lifecycle = createMockLifecycle('created');
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, mockSql as never, logger);
+
+  worker.startOnlyOnce(workerBootstrap);
+
+  // Give the async start() a moment to call acknowledgeStart
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(
+    lifecycle.acknowledgeStartCalled,
+    true,
+    'Worker should start when in Created state'
+  );
+});
+
+Deno.test('Worker.startOnlyOnce - ignores request when in Starting state', async () => {
+  const lifecycle = createMockLifecycle('starting');
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, mockSql as never, logger);
+
+  worker.startOnlyOnce(workerBootstrap);
+
+  // Give any async operations a moment
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(
+    lifecycle.acknowledgeStartCalled,
+    false,
+    'Worker should NOT start when in Starting state'
+  );
+});
+
+Deno.test('Worker.startOnlyOnce - ignores request when in Running state', async () => {
+  const lifecycle = createMockLifecycle('running');
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, mockSql as never, logger);
+
+  worker.startOnlyOnce(workerBootstrap);
+
+  // Give any async operations a moment
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(
+    lifecycle.acknowledgeStartCalled,
+    false,
+    'Worker should NOT start when in Running state'
+  );
+});
+
+Deno.test('Worker.startOnlyOnce - ignores request when in Stopping state', async () => {
+  const lifecycle = createMockLifecycle('stopping');
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, mockSql as never, logger);
+
+  worker.startOnlyOnce(workerBootstrap);
+
+  // Give any async operations a moment
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(
+    lifecycle.acknowledgeStartCalled,
+    false,
+    'Worker should NOT start when in Stopping state'
+  );
+});
+
+Deno.test('Worker.startOnlyOnce - ignores request when in Stopped state', async () => {
+  const lifecycle = createMockLifecycle('stopped');
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, mockSql as never, logger);
+
+  worker.startOnlyOnce(workerBootstrap);
+
+  // Give any async operations a moment
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(
+    lifecycle.acknowledgeStartCalled,
+    false,
+    'Worker should NOT start when in Stopped state'
+  );
+});


### PR DESCRIPTION
# Improve worker function tracking and lifecycle management

This PR refines the worker function tracking mechanism and improves worker lifecycle management:

1. Removed `last_invoked_at` from `track_worker_function()` to separate concerns:
   - Worker registration is now handled by `track_worker_function()`
   - Debounce protection is managed by `ensure_workers()` setting `last_invoked_at`

2. Enhanced worker lifecycle management:
   - Workers now only start when in the "Created" state
   - Added `isCreated` getter to lifecycle interfaces
   - Added comprehensive unit tests for `Worker.startOnlyOnce()`

3. Updated migration file with clearer extension creation comments

4. Fixed tests to reflect the new behavior:
   - Updated debounce tests to manually set `last_invoked_at`
   - Adjusted worker function tracking tests

These changes improve separation of concerns and make the worker startup process more robust.