### PR TITLE
fix: clear worker_functions table in reset and enhance worker credential tests

### DIFF
--- a/pkgs/core/supabase/seed.sql
+++ b/pkgs/core/supabase/seed.sql
@@ -13,6 +13,7 @@ BEGIN
   DELETE FROM pgflow.deps;
   DELETE FROM pgflow.steps;
   DELETE FROM pgflow.flows;
+  DELETE FROM pgflow.worker_functions;
 
   -- Also clear the realtime.messages table if it exists
   BEGIN


### PR DESCRIPTION
# Add worker_functions table to reset_db and enhance HTTP request tests

This PR improves the database reset functionality by adding the `worker_functions` table to the list of tables cleared during reset operations. 

It also enhances the test coverage for worker function HTTP requests by adding several new test cases that verify:

1. The correct construction of HTTP request URLs using base URLs from Vault
2. Proper inclusion of service role keys in Authorization headers when using Vault credentials
3. Appropriate fallback behavior for local development environments
4. Verification of the URL format pattern for function invocations

These changes ensure that worker functions are properly invoked with the correct credentials and endpoints in both production and local development environments.