### PR TITLE
feat: add service role auth validation to edge worker requests

### DIFF
--- a/pkgs/cli/supabase/functions/pgflow/deno.json
+++ b/pkgs/cli/supabase/functions/pgflow/deno.json
@@ -15,6 +15,7 @@
     "@pgflow/edge-worker/_internal": "../_vendor/@pgflow/edge-worker/_internal.ts",
     "@henrygd/queue": "jsr:@henrygd/queue@^1.0.7",
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@^2.49.4",
-    "postgres": "npm:postgres@3.4.5"
+    "postgres": "npm:postgres@3.4.5",
+    "@std/crypto": "jsr:@std/crypto"
   }
 }

--- a/pkgs/edge-worker/deno.lock
+++ b/pkgs/edge-worker/deno.lock
@@ -7,6 +7,7 @@
     "jsr:@std/assert@0.224": "0.224.0",
     "jsr:@std/async@0.224": "0.224.2",
     "jsr:@std/crypto@*": "1.0.5",
+    "jsr:@std/crypto@0.224": "0.224.0",
     "jsr:@std/fmt@0.224": "0.224.0",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/internal@0.224": "0.224.0",
@@ -35,6 +36,12 @@
     },
     "@std/async@0.224.2": {
       "integrity": "4d277d6e165df43d5e061ba0ef3edfddb8e8d558f5b920e3e6b1d2614b44d074"
+    },
+    "@std/crypto@0.224.0": {
+      "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
+      "dependencies": [
+        "jsr:@std/assert@0.224"
+      ]
     },
     "@std/crypto@1.0.5": {
       "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
@@ -414,6 +421,7 @@
       "jsr:@henrygd/queue@^1.0.7",
       "jsr:@std/assert@0.224",
       "jsr:@std/async@0.224",
+      "jsr:@std/crypto@0.224",
       "jsr:@std/log@~0.224.13",
       "jsr:@std/testing@0.224",
       "npm:@supabase/supabase-js@^2.39.0",

--- a/pkgs/edge-worker/deno.test.json
+++ b/pkgs/edge-worker/deno.test.json
@@ -8,6 +8,7 @@
     "@henrygd/queue": "jsr:@henrygd/queue@^1.0.7",
     "@std/assert": "jsr:@std/assert@^0.224.0",
     "@std/async": "jsr:@std/async@^0.224.0",
+    "@std/crypto/timing-safe-equal": "jsr:@std/crypto@^0.224.0/timing-safe-equal",
     "@std/log": "jsr:@std/log@^0.224.13",
     "@std/testing/mock": "jsr:@std/testing@^0.224.0/mock",
     "postgres": "npm:postgres@3.4.5",

--- a/pkgs/edge-worker/jsr.json
+++ b/pkgs/edge-worker/jsr.json
@@ -8,6 +8,7 @@
   },
   "imports": {
     "@henrygd/queue": "jsr:@henrygd/queue@^1.0.7",
+    "@std/crypto": "jsr:@std/crypto@^1.0.5",
     "postgres": "npm:postgres@3.4.5",
     "@pgflow/core": "npm:@pgflow/core@0.9.1",
     "@pgflow/dsl": "npm:@pgflow/dsl@0.9.1"

--- a/pkgs/edge-worker/src/shared/authValidation.ts
+++ b/pkgs/edge-worker/src/shared/authValidation.ts
@@ -1,0 +1,60 @@
+import { timingSafeEqual } from '@std/crypto/timing-safe-equal';
+import { isLocalSupabaseEnv } from './localDetection.ts';
+
+export interface AuthValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function validateServiceRoleAuth(
+  request: Request,
+  env: Record<string, string | undefined>
+): AuthValidationResult {
+  // Skip validation in local mode
+  if (isLocalSupabaseEnv(env)) {
+    return { valid: true };
+  }
+
+  const authHeader = request.headers.get('Authorization');
+  const expectedKey = env['SUPABASE_SERVICE_ROLE_KEY'];
+
+  if (!authHeader) {
+    return { valid: false, error: 'Missing Authorization header' };
+  }
+
+  if (!expectedKey) {
+    return { valid: false, error: 'Server misconfigured: missing service role key' };
+  }
+
+  const expected = `Bearer ${expectedKey}`;
+
+  // Use constant-time comparison to prevent timing attacks
+  const encoder = new TextEncoder();
+  const authBytes = encoder.encode(authHeader);
+  const expectedBytes = encoder.encode(expected);
+
+  // Length check first (timingSafeEqual requires same length)
+  if (authBytes.length !== expectedBytes.length) {
+    return { valid: false, error: 'Invalid Authorization header' };
+  }
+
+  if (!timingSafeEqual(authBytes, expectedBytes)) {
+    return { valid: false, error: 'Invalid Authorization header' };
+  }
+
+  return { valid: true };
+}
+
+export function createUnauthorizedResponse(): Response {
+  return new Response(
+    JSON.stringify({ error: 'Unauthorized', message: 'Unauthorized' }),
+    { status: 401, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+export function createServerErrorResponse(): Response {
+  return new Response(
+    JSON.stringify({ error: 'Internal Server Error', message: 'Internal Server Error' }),
+    { status: 500, headers: { 'Content-Type': 'application/json' } }
+  );
+}

--- a/pkgs/edge-worker/tests/unit/shared/authValidation.test.ts
+++ b/pkgs/edge-worker/tests/unit/shared/authValidation.test.ts
@@ -1,0 +1,146 @@
+import { assertEquals } from '@std/assert';
+import {
+  validateServiceRoleAuth,
+  createUnauthorizedResponse,
+  createServerErrorResponse,
+} from '../../../src/shared/authValidation.ts';
+import {
+  KNOWN_LOCAL_ANON_KEY,
+  KNOWN_LOCAL_SERVICE_ROLE_KEY,
+} from '../../../src/shared/localDetection.ts';
+
+// ============================================================
+// Helper functions
+// ============================================================
+
+function createRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) {
+    headers.set('Authorization', authHeader);
+  }
+  return new Request('http://localhost/test', { headers });
+}
+
+function localEnv(): Record<string, string | undefined> {
+  return {
+    SUPABASE_ANON_KEY: KNOWN_LOCAL_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SERVICE_ROLE_KEY,
+  };
+}
+
+function productionEnv(serviceRoleKey?: string): Record<string, string | undefined> {
+  return {
+    SUPABASE_ANON_KEY: 'production-anon-key-abc',
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+  };
+}
+
+const PRODUCTION_SERVICE_ROLE_KEY = 'production-service-role-key-xyz';
+
+// ============================================================
+// validateServiceRoleAuth() - Local mode tests
+// ============================================================
+
+Deno.test('validateServiceRoleAuth - local mode: allows request without auth header', () => {
+  const request = createRequest();
+  const result = validateServiceRoleAuth(request, localEnv());
+  assertEquals(result, { valid: true });
+});
+
+Deno.test('validateServiceRoleAuth - local mode: allows request with wrong auth header', () => {
+  const request = createRequest('Bearer wrong-key');
+  const result = validateServiceRoleAuth(request, localEnv());
+  assertEquals(result, { valid: true });
+});
+
+Deno.test('validateServiceRoleAuth - local mode: allows request with correct auth header', () => {
+  const request = createRequest(`Bearer ${KNOWN_LOCAL_SERVICE_ROLE_KEY}`);
+  const result = validateServiceRoleAuth(request, localEnv());
+  assertEquals(result, { valid: true });
+});
+
+// ============================================================
+// validateServiceRoleAuth() - Production mode tests
+// ============================================================
+
+Deno.test('validateServiceRoleAuth - production: rejects request without auth header', () => {
+  const request = createRequest();
+  const result = validateServiceRoleAuth(request, productionEnv(PRODUCTION_SERVICE_ROLE_KEY));
+  assertEquals(result, { valid: false, error: 'Missing Authorization header' });
+});
+
+Deno.test('validateServiceRoleAuth - production: rejects request with wrong auth header', () => {
+  const request = createRequest('Bearer wrong-key');
+  const result = validateServiceRoleAuth(request, productionEnv(PRODUCTION_SERVICE_ROLE_KEY));
+  assertEquals(result, { valid: false, error: 'Invalid Authorization header' });
+});
+
+Deno.test('validateServiceRoleAuth - production: accepts request with correct auth header', () => {
+  const request = createRequest(`Bearer ${PRODUCTION_SERVICE_ROLE_KEY}`);
+  const result = validateServiceRoleAuth(request, productionEnv(PRODUCTION_SERVICE_ROLE_KEY));
+  assertEquals(result, { valid: true });
+});
+
+Deno.test('validateServiceRoleAuth - production: rejects when service role key not configured', () => {
+  const request = createRequest('Bearer any-key');
+  const result = validateServiceRoleAuth(request, productionEnv(undefined));
+  assertEquals(result, { valid: false, error: 'Server misconfigured: missing service role key' });
+});
+
+Deno.test('validateServiceRoleAuth - production: rejects Basic auth scheme', () => {
+  const request = createRequest(`Basic ${PRODUCTION_SERVICE_ROLE_KEY}`);
+  const result = validateServiceRoleAuth(request, productionEnv(PRODUCTION_SERVICE_ROLE_KEY));
+  assertEquals(result, { valid: false, error: 'Invalid Authorization header' });
+});
+
+Deno.test('validateServiceRoleAuth - production: rejects malformed Bearer token', () => {
+  const request = createRequest('Bearer');
+  const result = validateServiceRoleAuth(request, productionEnv(PRODUCTION_SERVICE_ROLE_KEY));
+  assertEquals(result, { valid: false, error: 'Invalid Authorization header' });
+});
+
+Deno.test('validateServiceRoleAuth - production: rejects auth header without scheme', () => {
+  const request = createRequest(PRODUCTION_SERVICE_ROLE_KEY);
+  const result = validateServiceRoleAuth(request, productionEnv(PRODUCTION_SERVICE_ROLE_KEY));
+  assertEquals(result, { valid: false, error: 'Invalid Authorization header' });
+});
+
+// ============================================================
+// createUnauthorizedResponse() tests
+// ============================================================
+
+Deno.test('createUnauthorizedResponse - returns 401 status', () => {
+  const response = createUnauthorizedResponse();
+  assertEquals(response.status, 401);
+});
+
+Deno.test('createUnauthorizedResponse - returns JSON content type', () => {
+  const response = createUnauthorizedResponse();
+  assertEquals(response.headers.get('Content-Type'), 'application/json');
+});
+
+Deno.test('createUnauthorizedResponse - returns error body', async () => {
+  const response = createUnauthorizedResponse();
+  const body = await response.json();
+  assertEquals(body, { error: 'Unauthorized', message: 'Unauthorized' });
+});
+
+// ============================================================
+// createServerErrorResponse() tests
+// ============================================================
+
+Deno.test('createServerErrorResponse - returns 500 status', () => {
+  const response = createServerErrorResponse();
+  assertEquals(response.status, 500);
+});
+
+Deno.test('createServerErrorResponse - returns JSON content type', () => {
+  const response = createServerErrorResponse();
+  assertEquals(response.headers.get('Content-Type'), 'application/json');
+});
+
+Deno.test('createServerErrorResponse - returns error body', async () => {
+  const response = createServerErrorResponse();
+  const body = await response.json();
+  assertEquals(body, { error: 'Internal Server Error', message: 'Internal Server Error' });
+});


### PR DESCRIPTION
# Add service role authentication for edge worker requests

This PR adds authentication validation for edge worker requests in production environments. It implements a secure mechanism to verify that incoming requests to the edge worker are authorized using the Supabase service role key.

Key changes:
- Added authentication validation in the `SupabasePlatformAdapter` to verify requests
- Implemented `validateServiceRoleAuth()` function using timing-safe comparison to prevent timing attacks
- Created `createUnauthorizedResponse()` helper to generate standardized 401 responses
- Authentication is automatically bypassed in local development environments
- Added comprehensive unit tests for all authentication scenarios

The implementation uses the `@std/crypto/timing-safe-equal` module to perform constant-time comparison of authentication tokens, which helps prevent timing-based attacks.