### PR TITLE
feat: enhance logging with environment-based configuration

### DIFF
--- a/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
+++ b/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
@@ -50,8 +50,8 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
   private queries: Queries;
   private deps: SupabasePlatformDeps;
 
-  // Logging factory with dynamic workerId support
-  private loggingFactory = createLoggingFactory();
+  // Logging factory with dynamic workerId support (initialized in constructor)
+  private loggingFactory!: ReturnType<typeof createLoggingFactory>;
 
   constructor(
     options?: { sql?: Sql; connectionString?: string },
@@ -73,9 +73,9 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
     // Create abort controller for shutdown signal
     this.abortController = new AbortController();
 
-    // Set initial log level
-    const logLevel = this.validatedEnv.EDGE_WORKER_LOG_LEVEL || 'info';
-    this.loggingFactory.setLogLevel(logLevel);
+    // Create logging factory with environment for auto-configuration
+    // (log level, format, and colors are determined from env)
+    this.loggingFactory = createLoggingFactory(env);
 
     // startWorker logger with a default module name
     this.logger = this.loggingFactory.createLogger('SupabasePlatformAdapter');


### PR DESCRIPTION
# Enhance logging system with environment-based configuration

This PR improves the edge worker logging system by adding environment-based auto-configuration:

- Added environment detection to automatically set appropriate log formats:
  - Local development: Uses 'fancy' format with colors and icons
  - Production: Uses 'simple' format with key=value pairs

- Implemented smart defaults for log levels:
  - Local development: 'verbose' level for detailed logs
  - Production: 'info' level for standard operational logs

- Added support for the NO_COLOR standard to disable colored output

- Created explicit configuration overrides:
  - `EDGE_WORKER_LOG_FORMAT`: Override the auto-detected format ('fancy'|'simple')
  - `EDGE_WORKER_LOG_LEVEL`: Override the environment-based log level

- Modified the SupabasePlatformAdapter to initialize the logging factory with environment variables

- Added comprehensive tests for all new configuration options