### PR TITLE
feat: add retry information display with exponential backoff in task logs

### DIFF
--- a/pkgs/edge-worker/src/flow/StepTaskExecutor.ts
+++ b/pkgs/edge-worker/src/flow/StepTaskExecutor.ts
@@ -61,6 +61,8 @@ export class StepTaskExecutor<TFlow extends AnyFlow, TContext extends StepTaskHa
     const stepDef = this.flow.getStepDefinition(this.stepTask.step_slug);
     // maxAttempts includes the initial attempt, so maxRetries = maxAttempts - 1
     const maxRetries = stepDef?.options?.maxAttempts ? stepDef.options.maxAttempts - 1 : undefined;
+    // baseDelay from step options for retry delay calculation
+    const baseDelay = stepDef?.options?.baseDelay;
 
     return {
       flowSlug: this.stepTask.flow_slug,
@@ -73,6 +75,7 @@ export class StepTaskExecutor<TFlow extends AnyFlow, TContext extends StepTaskHa
       queueName: this.workerIdentity.queueName,
       retryAttempt,
       maxRetries,
+      baseDelay,
     };
   }
 

--- a/pkgs/edge-worker/src/platform/types.ts
+++ b/pkgs/edge-worker/src/platform/types.ts
@@ -13,6 +13,8 @@ export interface TaskLogContext {
   queueName: string;
   retryAttempt?: number;
   maxRetries?: number;
+  /** Base delay in seconds for retry calculation (from step options) */
+  baseDelay?: number;
 }
 
 /**


### PR DESCRIPTION
# Enhanced Retry Information Display in Edge Worker Logs

This PR adds improved retry information to the Edge Worker logs when a task fails but has retries remaining. The changes include:

- Added `baseDelay` parameter to the task context to support exponential backoff calculations
- Enhanced the `FancyFormatter` to display retry information with a visual indicator (↻) showing:
  - Current retry attempt number
  - Maximum retries allowed
  - Calculated delay before the next retry attempt
- Updated the `SimpleFormatter` to include retry information in key-value format for structured logging
- Implemented exponential backoff calculation: `baseDelay * 2^(attempt-1)`
- Added comprehensive unit tests for both formatters to verify retry information display

These changes make it easier to understand retry behavior when tasks fail, providing clear visibility into when a task will be retried and with what delay.