### PR TITLE
build: exclude demo and website from npm publish build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "nx run-many --target=build --all",
     "version": "pnpm changeset version && ./scripts/update-jsr-json-version.sh",
-    "validate:publish:npm": "pnpm nx run-many -t build && pnpm publish --dry-run --recursive --filter=!./pkgs/edge-worker",
+    "validate:publish:npm": "pnpm nx run-many -t build --exclude=demo,website && pnpm publish --dry-run --recursive --filter=!./pkgs/edge-worker",
     "validate:publish:jsr": "cd ./pkgs/edge-worker && jsr publish --dry-run --allow-slow-types",
     "validate:publish": "pnpm run validate:publish:npm && pnpm run validate:publish:jsr",
-    "publish:npm": "pnpm nx run-many -t build && pnpm publish --recursive --filter=!./pkgs/edge-worker",
+    "publish:npm": "pnpm nx run-many -t build --exclude=demo,website && pnpm publish --recursive --filter=!./pkgs/edge-worker",
     "publish:jsr": "cd ./pkgs/edge-worker && jsr publish --allow-slow-types",
     "changeset:tag": "pnpm changeset tag && git push --follow-tags",
     "release": "git status && pnpm run validate:publish && pnpm run publish:npm && pnpm run publish:jsr && pnpm run changeset:tag"


### PR DESCRIPTION
Exclude demo and website packages from build during npm publishing

This PR modifies the npm publishing scripts to exclude the demo and website packages from the build process. The `validate:publish:npm` and `publish:npm` commands now include the `--exclude=demo,website` flag when running the build target, ensuring these packages are not built during the publishing workflow.