### PR TITLE
refactor: move setup steps into deploy-website action

### DIFF
--- a/.github/actions/deploy-website/action.yml
+++ b/.github/actions/deploy-website/action.yml
@@ -2,6 +2,12 @@ name: 'Deploy Website'
 description: 'Deploy website to Cloudflare Pages (preview or production)'
 
 inputs:
+  github-token:
+    description: 'GitHub token for setup'
+    required: true
+  atlas-cloud-token:
+    description: 'Atlas Cloud token for setup'
+    required: true
   environment:
     description: 'Deployment environment (preview or production)'
     required: true
@@ -37,6 +43,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: ./.github/actions/setup
+      with:
+        github-token: ${{ inputs.github-token }}
+        atlas-cloud-token: ${{ inputs.atlas-cloud-token }}
+
+    - name: Install D2 diagramming tool
+      uses: ./.github/actions/setup-d2
+
     - name: Validate Supabase environment variables
       shell: bash
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,8 +306,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
-      - uses: ./.github/actions/setup-d2
-
       - name: Check if website is affected
         id: check-affected
         run: |
@@ -323,6 +321,8 @@ jobs:
         if: steps.check-affected.outputs.affected == 'true'
         uses: ./.github/actions/deploy-website
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
           environment: preview
           supabase-url: ${{ secrets.WEBSITE_PREVIEW_SUPABASE_URL }}
           supabase-anon-key: ${{ secrets.WEBSITE_PREVIEW_SUPABASE_ANON_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,14 +24,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-
       - name: Deploy website to production
         uses: ./.github/actions/deploy-website
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
           environment: production
           supabase-url: ${{ secrets.WEBSITE_PRODUCTION_SUPABASE_URL }}
           supabase-anon-key: ${{ secrets.WEBSITE_PRODUCTION_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
# Refactor website deployment workflow

This PR refactors the website deployment workflow by moving the setup steps into the deploy-website action itself. The changes:

1. Add required inputs to the deploy-website action:
   - `github-token`
   - `atlas-cloud-token`

2. Incorporate setup steps directly in the deploy-website action:
   - Call the setup action
   - Install the D2 diagramming tool

3. Update workflow files to pass the required tokens to the deploy-website action

This approach simplifies the deployment workflows by encapsulating all necessary setup within the deploy-website action, making it more self-contained and reusable.