### PR TITLE
chore: add repository information to package.json files

### DIFF
--- a/pkgs/cli/package.json
+++ b/pkgs/cli/package.json
@@ -2,6 +2,11 @@
   "name": "pgflow",
   "version": "0.10.0",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pgflow-dev/pgflow",
+    "directory": "pkgs/cli"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/pkgs/client/package.json
+++ b/pkgs/client/package.json
@@ -2,6 +2,11 @@
   "name": "@pgflow/client",
   "version": "0.10.0",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pgflow-dev/pgflow",
+    "directory": "pkgs/client"
+  },
   "type": "module",
   "scripts": {
     "verify-exports": "node scripts/verify-exports.js"

--- a/pkgs/core/package.json
+++ b/pkgs/core/package.json
@@ -2,6 +2,11 @@
   "name": "@pgflow/core",
   "version": "0.10.0",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pgflow-dev/pgflow",
+    "directory": "pkgs/core"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/pkgs/dsl/package.json
+++ b/pkgs/dsl/package.json
@@ -2,6 +2,11 @@
   "name": "@pgflow/dsl",
   "version": "0.10.0",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pgflow-dev/pgflow",
+    "directory": "pkgs/dsl"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/pkgs/edge-worker/package.json
+++ b/pkgs/edge-worker/package.json
@@ -2,6 +2,11 @@
   "name": "@pgflow/edge-worker",
   "version": "0.10.0",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pgflow-dev/pgflow",
+    "directory": "pkgs/edge-worker"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Added repository information to package.json files

This PR adds the repository field to all package.json files in the monorepo, including:
- pgflow (CLI package)
- @pgflow/client
- @pgflow/core
- @pgflow/dsl
- @pgflow/edge-worker

Each repository field includes:
- type: git
- url: https://github.com/pgflow-dev/pgflow
- directory: pointing to the specific package location within the monorepo

This helps npm and other tools properly link to the source repository and specific package directory.