### PR TITLE
chore: update release workflow and package configurations for npm publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,10 +2,18 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@pgflow/*", "pgflow"]],
+  "fixed": [
+    [
+      "@pgflow/core",
+      "@pgflow/dsl",
+      "@pgflow/client",
+      "@pgflow/edge-worker",
+      "pgflow"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@pgflow/demo", "@pgflow/website"]
+  "ignore": []
 }

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -36,6 +36,7 @@ runs:
         cache: 'pnpm'
         cache-dependency-path: |
           **/pnpm-lock.yaml
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'pkgs/website/**'
+      - 'pkgs/example-flows/**'
+      - 'apps/demo/**'
+      - '**/*.md'
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -35,4 +41,3 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "nx run-many --target=build --all",
     "version": "pnpm changeset version && ./scripts/update-jsr-json-version.sh",
-    "validate:publish:npm": "pnpm nx run-many -t build --exclude=demo,website && pnpm publish --dry-run --recursive --filter=!./pkgs/edge-worker",
+    "validate:publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm publish --dry-run --provenance --recursive --filter=!./pkgs/edge-worker",
     "validate:publish:jsr": "cd ./pkgs/edge-worker && jsr publish --dry-run --allow-slow-types",
     "validate:publish": "pnpm run validate:publish:npm && pnpm run validate:publish:jsr",
-    "publish:npm": "pnpm nx run-many -t build --exclude=demo,website && pnpm publish --recursive --filter=!./pkgs/edge-worker",
+    "publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm publish --provenance --recursive --filter=!./pkgs/edge-worker",
     "publish:jsr": "cd ./pkgs/edge-worker && jsr publish --allow-slow-types",
     "changeset:tag": "pnpm changeset tag && git push --follow-tags",
     "release": "git status && pnpm run validate:publish && pnpm run publish:npm && pnpm run publish:jsr && pnpm run changeset:tag"

--- a/pkgs/example-flows/package.json
+++ b/pkgs/example-flows/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pgflow/example-flows",
   "version": "0.10.0",
+  "private": true,
   "license": "Apache-2.0",
   "dependencies": {
     "@pgflow/core": "workspace:*",


### PR DESCRIPTION
# Improve Release Process and Package Configuration

This PR enhances our release workflow and package configuration:

- Updated the fixed packages list in `.changeset/config.json` to explicitly list all packages that should be versioned together
- Removed `@pgflow/demo` and `@pgflow/website` from the ignore list in changesets configuration
- Added registry URL configuration to the setup action
- Improved the release workflow by:
  - Adding path ignores to prevent unnecessary releases when only docs or examples change
  - Adding manual trigger capability with `workflow_dispatch`
  - Removing the NPM_TOKEN environment variable (likely using GitHub's built-in token)
- Added the `--provenance` flag to npm publish commands for better security
- Excluded `example-flows` from the build and publish process
- Marked the `@pgflow/example-flows` package as private to prevent accidental publishing

These changes will make our release process more reliable and secure.