### PR TITLE
chore: update npm for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
 
+      # npm 11.5.1+ required for OIDC trusted publishing
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 strict-peer-dependencies=false
 auto-install-peers=true
 @jsr:registry=https://npm.jsr.io
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Updates the release workflow to support OIDC trusted publishing by:

1. Adding a step to update npm to the latest version (11.5.1+) which is required for OIDC trusted publishing
2. Removing the NPM_TOKEN authentication line from .npmrc since it's no longer needed with OIDC

This change improves security by using OpenID Connect for npm publishing instead of long-lived access tokens.