### PR TITLE
feat: add allowDataLoss option and remove ensureCompiledOnStartup

### DIFF
--- a/.changeset/compilation-config-allow-data-loss.md
+++ b/.changeset/compilation-config-allow-data-loss.md
@@ -1,0 +1,6 @@
+---
+'@pgflow/core': minor
+'@pgflow/edge-worker': minor
+---
+
+New compilation config with allowDataLoss option for rapid iteration platforms. Breaking: ensureCompiledOnStartup removed in favor of compilation option.


### PR DESCRIPTION
Introduces a new compilation configuration with an `allowDataLoss` option designed for rapid iteration platforms. This change also removes the `ensureCompiledOnStartup` option, replacing it with a compilation option, which is a breaking change. The update affects both `@pgflow/core` and `@pgflow/edge-worker` packages.