### PR TITLE
ci: refine release workflow path filters to include changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'pkgs/website/**'
-      - 'pkgs/example-flows/**'
-      - 'apps/demo/**'
-      - '**/*.md'
+    paths:
+      - '**'                        # Include all files
+      - '!pkgs/website/**'          # Exclude website
+      - '!pkgs/example-flows/**'    # Exclude example-flows
+      - '!apps/demo/**'             # Exclude demo
+      - '!**/*.md'                  # Exclude all markdown
+      - '.changeset/*.md'           # Re-include changeset files
+      - '!.changeset/README.md'     # Exclude changeset README
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Improved GitHub workflow path filtering for releases

This PR updates the release workflow to use a more explicit path filtering approach. Instead of using `paths-ignore`, it now uses a combination of include and exclude patterns to better control which files trigger the workflow:

- Includes all files by default
- Excludes website, example-flows, demo, and markdown files
- Re-includes changeset markdown files (except the README)

This approach provides more precise control over which files trigger the release workflow, ensuring changesets are properly processed.