### PR TITLE
chore: use pnpm prefix for JSR commands and simplify snapshot release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "build": "nx run-many --target=build --all",
     "version": "pnpm changeset version && ./scripts/update-jsr-json-version.sh",
     "validate:publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm publish --dry-run --provenance --recursive --filter=!./pkgs/edge-worker",
-    "validate:publish:jsr": "cd ./pkgs/edge-worker && jsr publish --dry-run --allow-slow-types",
+    "validate:publish:jsr": "cd ./pkgs/edge-worker && pnpm jsr publish --dry-run --allow-slow-types",
     "validate:publish": "pnpm run validate:publish:npm && pnpm run validate:publish:jsr",
     "publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm publish --provenance --recursive --filter=!./pkgs/edge-worker",
-    "publish:jsr": "cd ./pkgs/edge-worker && jsr publish --allow-slow-types",
+    "publish:jsr": "cd ./pkgs/edge-worker && pnpm jsr publish --allow-slow-types",
     "changeset:tag": "pnpm changeset tag && git push --follow-tags",
     "release": "git status && pnpm run validate:publish && pnpm run publish:npm && pnpm run publish:jsr && pnpm run changeset:tag"
   },

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -326,10 +326,9 @@ NPM_SUCCESS=false
 JSR_SUCCESS=true  # Default true (only set false if JSR package exists and fails)
 JSR_PUBLISHED_VERSION=""  # Track JSR version if published
 
-# Publish to npm (token is read from NPM_TOKEN env var via .npmrc)
-# GITHUB_ACTIONS=true skips changeset's npm profile check which fails with automation tokens
+# Publish to npm (exclude edge-worker which goes to JSR only)
 echo -e "${BOLD}Publishing to npm...${NC}"
-if GITHUB_ACTIONS=true pnpm exec changeset publish --tag snapshot ; then
+if pnpm publish --recursive --tag snapshot --no-git-checks --filter='!./pkgs/edge-worker' ; then
   echo -e "${GREEN}✓ npm packages published${NC}"
   NPM_SUCCESS=true
 else
@@ -343,7 +342,6 @@ if [[ -f pkgs/edge-worker/jsr.json ]]; then
   echo ""
   echo -e "${BOLD}Publishing to JSR...${NC}"
   JSR_PUBLISH_CMD="pnpm jsr publish --allow-slow-types --allow-dirty"
-  # Pass token explicitly if set (pnpm jsr may not inherit JSR_TOKEN properly)
   if [[ -n "${JSR_TOKEN:-}" ]]; then
     JSR_PUBLISH_CMD="$JSR_PUBLISH_CMD --token $JSR_TOKEN"
   fi


### PR DESCRIPTION
# Use pnpm to invoke JSR commands and improve release process

This PR updates our publishing scripts to use `pnpm jsr` instead of directly calling `jsr` when publishing to the JSR registry. This ensures consistent dependency resolution through pnpm.

Additionally, the snapshot release script has been improved to:

1. Use `pnpm publish --recursive` directly instead of going through changeset for npm publishing
2. Properly exclude the edge-worker package from npm publishing (it's JSR-only)
3. Simplify the JSR publishing command with cleaner token handling

These changes make our release process more reliable and consistent across both npm and JSR registries.