### PR TITLE
feat: add flow_input to StepTaskRecord and context objects

### DIFF
--- a/pkgs/core/src/types.ts
+++ b/pkgs/core/src/types.ts
@@ -25,6 +25,7 @@ export type StepTaskRecord<TFlow extends AnyFlow> = {
     task_index: number;
     input: Simplify<StepInput<TFlow, StepSlug>>;
     msg_id: number;
+    flow_input: ExtractFlowInput<TFlow>;
   };
 }[Extract<keyof ExtractFlowSteps<TFlow>, string>];
 

--- a/pkgs/edge-worker/deno.lock
+++ b/pkgs/edge-worker/deno.lock
@@ -1,17 +1,28 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@deno-library/progress@*": "1.5.1",
     "jsr:@henrygd/queue@^1.0.7": "1.2.0",
     "jsr:@oscar6echo/postgres@3.4.5-d": "3.4.5-d",
     "jsr:@std/assert@0.224": "0.224.0",
+    "jsr:@std/async@0.224": "0.224.2",
     "jsr:@std/crypto@0.224": "0.224.0",
     "jsr:@std/fmt@0.224": "0.224.0",
+    "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/internal@0.224": "0.224.0",
+    "jsr:@std/io@0.225.0": "0.225.0",
     "jsr:@std/testing@0.224": "0.224.0",
     "npm:@supabase/supabase-js@^2.39.0": "2.86.0",
     "npm:@types/node@*": "22.5.4"
   },
   "jsr": {
+    "@deno-library/progress@1.5.1": {
+      "integrity": "966611826b8bb27baae73ab1c4fa4317cd4edd2abb99750cd6f8488d22d5b121",
+      "dependencies": [
+        "jsr:@std/fmt@1.0.3",
+        "jsr:@std/io"
+      ]
+    },
     "@henrygd/queue@1.2.0": {
       "integrity": "3e6c968f9bd56e3e7dfbd9952d0b7173a4ecdb7d4df041b3a0f4dfc896efeede"
     },
@@ -21,9 +32,12 @@
     "@std/assert@0.224.0": {
       "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f",
       "dependencies": [
-        "jsr:@std/fmt",
+        "jsr:@std/fmt@0.224",
         "jsr:@std/internal"
       ]
+    },
+    "@std/async@0.224.2": {
+      "integrity": "4d277d6e165df43d5e061ba0ef3edfddb8e8d558f5b920e3e6b1d2614b44d074"
     },
     "@std/crypto@0.224.0": {
       "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
@@ -34,11 +48,17 @@
     "@std/fmt@0.224.0": {
       "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
     },
+    "@std/fmt@1.0.3": {
+      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
+    },
     "@std/internal@0.224.0": {
       "integrity": "afc50644f9cdf4495eeb80523a8f6d27226b4b36c45c7c195dfccad4b8509291",
       "dependencies": [
-        "jsr:@std/fmt"
+        "jsr:@std/fmt@0.224"
       ]
+    },
+    "@std/io@0.225.0": {
+      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
     },
     "@std/testing@0.224.0": {
       "integrity": "371b8a929aa7132240d5dd766a439be8f780ef5c176ab194e0bcab72370c761e",
@@ -119,6 +139,9 @@
     "ws@8.18.3": {
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5"
   },
   "workspace": {
     "dependencies": [

--- a/pkgs/edge-worker/src/core/context.ts
+++ b/pkgs/edge-worker/src/core/context.ts
@@ -1,5 +1,5 @@
 /* DSL‐level ------------------------------------------------------------ */
-import type { BaseContext, AnyFlow, AllStepInputs } from '@pgflow/dsl';
+import type { BaseContext, AnyFlow, AllStepInputs, ExtractFlowInput } from '@pgflow/dsl';
 import type { Json } from './types.js';
 import type { PgmqMessageRecord } from '../queue/types.js';
 import type { StepTaskRecord } from '../flow/types.js';
@@ -30,6 +30,7 @@ export interface StepTaskExecution<TFlow extends AnyFlow = AnyFlow> {
   rawMessage: PgmqMessageRecord<AllStepInputs<TFlow>>;
   stepTask  : StepTaskRecord<TFlow>;
   workerConfig: Readonly<Omit<FlowWorkerConfig, 'sql'>>;
+  flowInput: ExtractFlowInput<TFlow>;
 }
 
 /** Message handler context for any platform */
@@ -52,6 +53,7 @@ export interface StepTaskWithMessage<TFlow extends AnyFlow> {
   msg_id : number;
   message: PgmqMessageRecord<AllStepInputs<TFlow>>;
   task   : StepTaskRecord<TFlow>;
+  flowInput: ExtractFlowInput<TFlow>;
 }
 
 import { deepClone, deepFreeze } from './deepUtils.js';

--- a/pkgs/edge-worker/src/flow/StepTaskPoller.ts
+++ b/pkgs/edge-worker/src/flow/StepTaskPoller.ts
@@ -103,7 +103,8 @@ export class StepTaskPoller<TFlow extends AnyFlow>
           return {
             message,
             task,
-            msg_id: task.msg_id
+            msg_id: task.msg_id,
+            flowInput: task.flow_input
           };
         })
         .filter((item): item is StepTaskWithMessage<TFlow> => item !== null);

--- a/pkgs/edge-worker/src/flow/createFlowWorker.ts
+++ b/pkgs/edge-worker/src/flow/createFlowWorker.ts
@@ -132,6 +132,7 @@ export function createFlowWorker<TFlow extends AnyFlow, TResources extends Recor
       rawMessage: taskWithMessage.message,
       stepTask: taskWithMessage.task,
       workerConfig: frozenWorkerConfig, // Reuse cached frozen config
+      flowInput: taskWithMessage.flowInput, // Original flow input for dependent steps
 
       // Platform-specific resources (generic)
       ...platformAdapter.platformResources

--- a/pkgs/edge-worker/src/test/test-helpers.ts
+++ b/pkgs/edge-worker/src/test/test-helpers.ts
@@ -1,6 +1,6 @@
 import type postgres from 'postgres';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { AnyFlow, AllStepInputs } from '@pgflow/dsl';
+import type { AnyFlow, AllStepInputs, ExtractFlowInput } from '@pgflow/dsl';
 import type { SupabaseResources } from '@pgflow/dsl/supabase';
 import type { Json } from '../core/types.js';
 import type { PgmqMessageRecord } from '../queue/types.js';
@@ -83,9 +83,10 @@ export function createSupabaseStepTaskContext<TFlow extends AnyFlow>(params: {
   abortSignal: AbortSignal;
   stepTask: StepTaskRecord<TFlow>;
   rawMessage: PgmqMessageRecord<AllStepInputs<TFlow>>;
+  flowInput: ExtractFlowInput<TFlow>;
   workerConfig?: Readonly<Omit<FlowWorkerConfig, 'sql'>>;
 }): SupabaseStepTaskContext<TFlow> {
-  const { env, sql, abortSignal, stepTask, rawMessage, workerConfig } = params;
+  const { env, sql, abortSignal, stepTask, rawMessage, flowInput, workerConfig } = params;
 
   // Validate required environment variables
   const supabaseUrl = env.SUPABASE_URL;
@@ -126,6 +127,7 @@ export function createSupabaseStepTaskContext<TFlow extends AnyFlow>(params: {
     rawMessage,
     stepTask,
     workerConfig: defaultWorkerConfig,
+    flowInput,
 
     // Supabase-specific resources (always present)
     sql,

--- a/pkgs/edge-worker/tests/integration/stepTaskExecutorContext.test.ts
+++ b/pkgs/edge-worker/tests/integration/stepTaskExecutorContext.test.ts
@@ -58,6 +58,7 @@ Deno.test(
       step_slug: 'test_step',
       task_index: 0,
       input: { run: { data: 'test data' } },
+      flow_input: { data: 'test data' },
     };
 
     // Create context with mock task and message using proper flow worker context creation
@@ -77,6 +78,7 @@ Deno.test(
         msg_id: 123,
         message: mockMessage,
         task: mockTask,
+        flowInput: { data: 'test data' },
       },
     });
 
@@ -120,6 +122,7 @@ Deno.test(
       step_slug: 'legacy_step',
       task_index: 0,
       input: { run: { value: 42 } },
+      flow_input: { value: 42 },
     };
 
     // Get the step handler
@@ -142,6 +145,7 @@ Deno.test(
         msg_id: 456,
         message: mockMessage,
         task: mockTask,
+        flowInput: { value: 42 },
       },
     });
 
@@ -187,6 +191,7 @@ Deno.test(
       step_slug: 'check_raw',
       task_index: 0,
       input: { run: {} },
+      flow_input: {},
     };
 
     // Create context - for this test we need a mock taskWithMessage
@@ -194,6 +199,7 @@ Deno.test(
       msg_id: 789,
       message: mockMessage,
       task: mockTask,
+      flowInput: {},
     };
 
     const context = createFlowWorkerContext({
@@ -247,6 +253,7 @@ Deno.test(
       step_slug: 'check_clients',
       task_index: 0,
       input: { run: {} },
+      flow_input: {},
     };
 
     // Create context with Supabase env vars
@@ -254,6 +261,7 @@ Deno.test(
       msg_id: 999,
       message: mockMessage,
       task: mockTask,
+      flowInput: {},
     };
 
     const context = createFlowWorkerContext({
@@ -328,6 +336,7 @@ Deno.test(
       step_slug: 'fetch_data',
       task_index: 0,
       input: { run: { id: 123 } },
+      flow_input: { id: 123 },
     };
 
     const context = createFlowWorkerContext({
@@ -338,6 +347,7 @@ Deno.test(
         msg_id: 456,
         message: mockMessageForComplex,
         task: mockTaskForComplex,
+        flowInput: { id: 123 },
       },
     });
 

--- a/pkgs/edge-worker/tests/unit/contextUtils.test.ts
+++ b/pkgs/edge-worker/tests/unit/contextUtils.test.ts
@@ -47,13 +47,18 @@ const mockStepMessage: PgmqMessageRecord<{ run: { test: string } }> = {
   headers: null,
 };
 
+// Mock flow input
+const mockFlowInput = { test: 'flow-input' };
+
 // Mock step task (using generic typing)
 const mockStepTask = {
   flow_slug: 'test-flow',
   run_id: 'run-456',
   step_slug: 'test-step',
   input: { run: { test: 'input' } },
-  msg_id: 123
+  msg_id: 123,
+  flow_input: mockFlowInput,
+  task_index: 0
 } as StepTaskRecord<never>;
 
 Deno.test('createSupabaseMessageContext - creates context with all Supabase resources', () => {
@@ -104,15 +109,17 @@ Deno.test('createSupabaseStepTaskContext - creates context with step task', () =
     abortSignal: mockAbortSignal,
     stepTask: mockStepTask,
     rawMessage: mockStepMessage,
+    flowInput: mockFlowInput,
   });
-  
+
   // Check all properties exist
   assertEquals(context.env, fullEnv);
   assertEquals(context.sql, mockSql);
   assertEquals(context.shutdownSignal, mockAbortSignal);
   assertEquals(context.stepTask, mockStepTask);
   assertEquals(context.rawMessage, mockStepMessage);
-  
+  assertEquals(context.flowInput, mockFlowInput);
+
   // Supabase client should always be present
   assertExists(context.supabase);
 });

--- a/pkgs/example-flows/src/example-flow.ts
+++ b/pkgs/example-flows/src/example-flow.ts
@@ -41,6 +41,7 @@ export const stepTaskRecord: StepTaskRecord<typeof ExampleFlow> = {
     // normalStep: { doubledValueArray: [1, 2, 3] }, --- this should be an error
   },
   msg_id: 1,
+  flow_input: { value: 23 },
 };
 
 // export const yolo: { value: number } = { value: 23, otherValue: 'yolo' };


### PR DESCRIPTION
# Add flow_input to StepTaskRecord and expose it in worker context

This PR adds the original flow input to the `StepTaskRecord` type and exposes it throughout the worker context. This allows dependent steps to access the original flow input parameters, which is useful for maintaining context across multi-step flows.

The changes:
- Add `flow_input` field to `StepTaskRecord` in core types
- Expose the flow input in the `StepTaskExecution` and `StepTaskWithMessage` interfaces
- Pass the flow input through the task poller to the worker context
- Update test helpers to include flow input in context creation
- Add tests to verify flow input is properly passed through the context

This enhancement enables step implementations to reference the original parameters that started the flow, improving the ability to build steps that depend on initial configuration.