### PR TITLE
refactor: change step handler input to use asymmetric pattern for better type safety

### DIFF
--- a/pkgs/client/__tests__/types/client-basic.test-d.ts
+++ b/pkgs/client/__tests__/types/client-basic.test-d.ts
@@ -20,8 +20,8 @@ const AnalyzeWebsite = new Flow<{ url: string }>({
   baseDelay: 5,
   timeout: 10,
 })
-  .step({ slug: 'website' }, (input) => ({
-    content: `Content for ${input.run.url}`,
+  .step({ slug: 'website' }, (flowInput) => ({
+    content: `Content for ${flowInput.url}`,
   }))
   .step({ slug: 'sentiment', dependsOn: ['website'] }, (_input) => ({
     score: 0.75,
@@ -150,11 +150,15 @@ describe('PgflowClient Type Tests', () => {
       .resolves.toHaveProperty('output')
       .toEqualTypeOf<SentimentOutput | null>();
 
-    // Check input type for a step
+    // Check input type for a step - dependent steps only get their deps (no run key)
+    // flowInput is available via context.flowInput for dependent steps
     type SentimentInput = StepInput<typeof AnalyzeWebsite, 'sentiment'>;
     expectTypeOf<SentimentInput>().toMatchTypeOf<{
-      run: { url: string };
       website: { content: string };
+    }>();
+    // Verify it does NOT have run key (asymmetric input)
+    expectTypeOf<SentimentInput>().not.toMatchTypeOf<{
+      run: { url: string };
     }>();
   });
 

--- a/pkgs/client/__tests__/unit/concurrent-operations.test.ts
+++ b/pkgs/client/__tests__/unit/concurrent-operations.test.ts
@@ -23,7 +23,7 @@ import { RUN_ID, FLOW_SLUG, STEP_SLUG, startedRunSnapshot, stepStatesSample } fr
 // Create a test flow for proper typing
 const TestFlow = new Flow<{ test: string }>({ slug: 'test_flow' }).step(
   { slug: 'test_step' },
-  (input) => ({ result: input.run.test })
+  (flowInput) => ({ result: flowInput.test })
 );
 
 // Mock uuid to return predictable IDs

--- a/pkgs/dsl/__tests__/types/context-inference.test-d.ts
+++ b/pkgs/dsl/__tests__/types/context-inference.test-d.ts
@@ -15,7 +15,7 @@ interface TestRedis {
 describe('Context Type Inference Tests', () => {
   it('should have FlowContext by default (no custom resources)', () => {
     const flow = new Flow({ slug: 'minimal_flow' })
-      .step({ slug: 'process' }, (input, context) => {
+      .step({ slug: 'process' }, (flowInput, context) => {
         // Handler automatically gets FlowContext (no annotation needed!)
         expectTypeOf(context).toMatchTypeOf<FlowContext>();
         expectTypeOf(context.env).toEqualTypeOf<Record<string, string | undefined>>();
@@ -33,7 +33,7 @@ describe('Context Type Inference Tests', () => {
 
   it('should provide custom context via Flow type parameter', () => {
     const flow = new Flow<Json, { sql: TestSql }>({ slug: 'custom_context' })
-      .step({ slug: 'query' }, (input, context) => {
+      .step({ slug: 'query' }, (flowInput, context) => {
         // No handler annotation needed! Type parameter provides context
         expectTypeOf(context.sql).toEqualTypeOf<TestSql>();
         expectTypeOf(context.env).toEqualTypeOf<Record<string, string | undefined>>();
@@ -49,13 +49,13 @@ describe('Context Type Inference Tests', () => {
 
   it('should share custom context across all steps', () => {
     const flow = new Flow<Json, { sql: TestSql; redis: TestRedis }>({ slug: 'shared_context' })
-      .step({ slug: 'query' }, (input, context) => {
+      .step({ slug: 'query' }, (flowInput, context) => {
         // All steps get the same context automatically
         expectTypeOf(context.sql).toEqualTypeOf<TestSql>();
         expectTypeOf(context.redis).toEqualTypeOf<TestRedis>();
         return { users: [] };
       })
-      .step({ slug: 'cache' }, (input, context) => {
+      .step({ slug: 'cache' }, (flowInput, context) => {
         // Second step also has access to all resources
         expectTypeOf(context.sql).toEqualTypeOf<TestSql>();
         expectTypeOf(context.redis).toEqualTypeOf<TestRedis>();
@@ -72,20 +72,21 @@ describe('Context Type Inference Tests', () => {
 
   it('should preserve existing step type inference while adding context', () => {
     const flow = new Flow<{ initial: number }, { multiplier: number }>({ slug: 'step_chain' })
-      .step({ slug: 'double' }, (input, context) => {
-        // Input inference still works
-        expectTypeOf(input.run.initial).toEqualTypeOf<number>();
+      .step({ slug: 'double' }, (flowInput, context) => {
+        // Input inference still works - root step gets flow input directly
+        expectTypeOf(flowInput.initial).toEqualTypeOf<number>();
         // Custom context available
         expectTypeOf(context.multiplier).toEqualTypeOf<number>();
-        return { doubled: input.run.initial * 2 };
+        return { doubled: flowInput.initial * 2 };
       })
-      .step({ slug: 'format', dependsOn: ['double'] }, (input, context) => {
-        // Dependent step has access to previous step output
-        expectTypeOf(input.run.initial).toEqualTypeOf<number>();
-        expectTypeOf(input.double.doubled).toEqualTypeOf<number>();
+      .step({ slug: 'format', dependsOn: ['double'] }, (deps, context) => {
+        // Dependent step has access to previous step output via deps
+        expectTypeOf(deps.double.doubled).toEqualTypeOf<number>();
         // And still has custom context
         expectTypeOf(context.multiplier).toEqualTypeOf<number>();
-        return { formatted: String(input.double.doubled) };
+        // Access flow input via context.flowInput
+        expectTypeOf(context.flowInput.initial).toEqualTypeOf<number>();
+        return { formatted: String(deps.double.doubled) };
       });
 
     // Context includes custom resources

--- a/pkgs/dsl/__tests__/types/example-flow.test-d.ts
+++ b/pkgs/dsl/__tests__/types/example-flow.test-d.ts
@@ -6,45 +6,44 @@ const sentimentStepDef = AnalyzeWebsite.getStepDefinition('sentiment');
 const summaryStepDef = AnalyzeWebsite.getStepDefinition('summary');
 const saveToDbStepDef = AnalyzeWebsite.getStepDefinition('saveToDb');
 
-const run = { url: 'https://example.com' };
+const flowInput = { url: 'https://example.com' };
 const website = { content: 'holahola' };
 const summary = { aiSummary: 'holahola' };
 const sentiment = { score: 0.5 };
 
 it('should correctly handle AnalyzeWebsite flow steps with proper types', () => {
-  // Test website step handler type
+  // Test website step handler type - root step receives flowInput directly (no run key)
   expectTypeOf(websiteStepDef.handler).toBeFunction();
   expectTypeOf(websiteStepDef.handler).parameters.toMatchTypeOf<
-    [{ run: { url: string } }, any]
+    [{ url: string }, any]
   >();
   expectTypeOf(websiteStepDef.handler).returns.toMatchTypeOf<
     Promise<{ content: string }> | { content: string }
   >();
 
-  // Test sentiment step handler type
+  // Test sentiment step handler type - dependent step receives deps only (no run key)
   expectTypeOf(sentimentStepDef.handler).toBeFunction();
   expectTypeOf(sentimentStepDef.handler).parameters.toMatchTypeOf<
-    [{ run: { url: string }; website: { content: string } }, any]
+    [{ website: { content: string } }, any]
   >();
   expectTypeOf(sentimentStepDef.handler).returns.toMatchTypeOf<
     Promise<{ score: number }> | { score: number }
   >();
 
-  // Test summary step handler type
+  // Test summary step handler type - dependent step receives deps only
   expectTypeOf(summaryStepDef.handler).toBeFunction();
   expectTypeOf(summaryStepDef.handler).parameters.toMatchTypeOf<
-    [{ run: { url: string }; website: { content: string } }, any]
+    [{ website: { content: string } }, any]
   >();
   expectTypeOf(summaryStepDef.handler).returns.toMatchTypeOf<
     Promise<{ aiSummary: string }> | { aiSummary: string }
   >();
 
-  // Test saveToDb step handler type
+  // Test saveToDb step handler type - dependent step receives deps only
   expectTypeOf(saveToDbStepDef.handler).toBeFunction();
   expectTypeOf(saveToDbStepDef.handler).parameters.toMatchTypeOf<
     [
       {
-        run: { url: string };
         sentiment: { score: number };
         summary: { aiSummary: string };
       },
@@ -58,24 +57,26 @@ it('should correctly handle AnalyzeWebsite flow steps with proper types', () => 
 
 it('allows to call handlers with matching inputs and context', () => {
   // Handlers now require context parameter (FlowContext)
+  // Root step: receives flowInput directly
   const mockContext = {} as any;
-  websiteStepDef.handler({ run }, mockContext);
-  sentimentStepDef.handler({ run, website }, mockContext);
-  summaryStepDef.handler({ run, website }, mockContext);
-  saveToDbStepDef.handler({ run, summary, sentiment }, mockContext);
+  websiteStepDef.handler(flowInput, mockContext);
+  // Dependent steps: receive deps only (no run key)
+  sentimentStepDef.handler({ website }, mockContext);
+  summaryStepDef.handler({ website }, mockContext);
+  saveToDbStepDef.handler({ summary, sentiment }, mockContext);
 });
 it('does not allow to call with additional keys', () => {
   const mockContext = {} as any;
 
   // @ts-expect-error - no additional keys allowed
-  websiteStepDef.handler({ run, newKey: true }, mockContext);
+  websiteStepDef.handler({ ...flowInput, newKey: true }, mockContext);
 
   // @ts-expect-error - no additional keys allowed
-  sentimentStepDef.handler({ run, website, newKey: true }, mockContext);
+  sentimentStepDef.handler({ website, newKey: true }, mockContext);
 
   // @ts-expect-error - no additional keys allowed
-  summaryStepDef.handler({ run, website, newKey: true }, mockContext);
+  summaryStepDef.handler({ website, newKey: true }, mockContext);
 
   // @ts-expect-error - no additional keys allowed
-  saveToDbStepDef.handler({ run, summary, sentiment, newKey: true }, mockContext);
+  saveToDbStepDef.handler({ summary, sentiment, newKey: true }, mockContext);
 });

--- a/pkgs/dsl/__tests__/types/extract-flow-output.test-d.ts
+++ b/pkgs/dsl/__tests__/types/extract-flow-output.test-d.ts
@@ -19,8 +19,8 @@ describe('ExtractFlowOutput utility type', () => {
   it('should correctly output for a flow with a single leaf step', () => {
     const singleStepFlow = new Flow<{ input: string }>({
       slug: 'single_step_flow',
-    }).step({ slug: 'process' }, (input) => ({
-      result: input.run.input.toUpperCase(),
+    }).step({ slug: 'process' }, (flowInput) => ({
+      result: flowInput.input.toUpperCase(),
     }));
 
     type SingleStepFlowType = typeof singleStepFlow;
@@ -45,14 +45,14 @@ describe('ExtractFlowOutput utility type', () => {
     const multiLeafFlow = new Flow<{ data: number }>({
       slug: 'multi_leaf_flow',
     })
-      .step({ slug: 'intermediate' }, (input) => ({
-        value: input.run.data * 2,
+      .step({ slug: 'intermediate' }, (flowInput) => ({
+        value: flowInput.data * 2,
       }))
-      .step({ slug: 'leaf1', dependsOn: ['intermediate'] }, (input) => ({
-        squared: input.intermediate.value ** 2,
+      .step({ slug: 'leaf1', dependsOn: ['intermediate'] }, (deps) => ({
+        squared: deps.intermediate.value ** 2,
       }))
-      .step({ slug: 'leaf2', dependsOn: ['intermediate'] }, (input) => ({
-        doubled: input.intermediate.value * 2,
+      .step({ slug: 'leaf2', dependsOn: ['intermediate'] }, (deps) => ({
+        doubled: deps.intermediate.value * 2,
       }));
 
     type FlowOutput = ExtractFlowOutput<typeof multiLeafFlow>;
@@ -74,14 +74,14 @@ describe('ExtractFlowOutput utility type', () => {
 
   it('should correctly handle a root step that is also a leaf step', () => {
     const rootLeafFlow = new Flow<{ input: string }>({ slug: 'root_leaf_flow' })
-      .step({ slug: 'rootLeaf' }, (input) => ({
-        processed: input.run.input.trim(),
+      .step({ slug: 'rootLeaf' }, (flowInput) => ({
+        processed: flowInput.input.trim(),
       }))
-      .step({ slug: 'intermediate' }, (input) => ({
-        length: input.run.input.length,
+      .step({ slug: 'intermediate' }, (flowInput) => ({
+        length: flowInput.input.length,
       }))
-      .step({ slug: 'dependent', dependsOn: ['intermediate'] }, (input) => ({
-        result: input.intermediate.length > 10,
+      .step({ slug: 'dependent', dependsOn: ['intermediate'] }, (deps) => ({
+        result: deps.intermediate.length > 10,
       }));
 
     type FlowOutput = ExtractFlowOutput<typeof rootLeafFlow>;
@@ -105,16 +105,16 @@ describe('ExtractFlowOutput utility type', () => {
 
   it('should handle complex dependency chains', () => {
     const complexFlow = new Flow<{ input: number }>({ slug: 'complex_flow' })
-      .step({ slug: 'step1' }, (input) => ({ value: input.run.input + 1 }))
-      .step({ slug: 'step2', dependsOn: ['step1'] }, (input) => ({
-        value: input.step1.value * 2,
+      .step({ slug: 'step1' }, (flowInput) => ({ value: flowInput.input + 1 }))
+      .step({ slug: 'step2', dependsOn: ['step1'] }, (deps) => ({
+        value: deps.step1.value * 2,
       }))
-      .step({ slug: 'step3', dependsOn: ['step1'] }, (input) => ({
-        value: input.step1.value - 1,
+      .step({ slug: 'step3', dependsOn: ['step1'] }, (deps) => ({
+        value: deps.step1.value - 1,
       }))
-      .step({ slug: 'step4', dependsOn: ['step2', 'step3'] }, (input) => ({
-        sum: input.step2.value + input.step3.value,
-        original: input.run.input,
+      .step({ slug: 'step4', dependsOn: ['step2', 'step3'] }, (deps, ctx) => ({
+        sum: deps.step2.value + deps.step3.value,
+        original: ctx.flowInput.input,
       }));
 
     type FlowOutput = ExtractFlowOutput<typeof complexFlow>;

--- a/pkgs/dsl/__tests__/types/supabase-context-inference.test-d.ts
+++ b/pkgs/dsl/__tests__/types/supabase-context-inference.test-d.ts
@@ -6,7 +6,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 describe('Supabase Flow Context Inference', () => {
   it('should infer platform context without annotations', () => {
     const flow = new Flow({ slug: 'test' })
-      .step({ slug: 'query' }, (input, context) => {  // NO annotation!
+      .step({ slug: 'query' }, (flowInput, context) => {  // NO annotation!
         // Platform resources
         expectTypeOf(context.sql).toEqualTypeOf<Sql>();
         expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
@@ -26,13 +26,13 @@ describe('Supabase Flow Context Inference', () => {
 
   it('should work across multiple steps', () => {
     const flow = new Flow({ slug: 'multi' })
-      .step({ slug: 's1' }, (input, context) => {
+      .step({ slug: 's1' }, (flowInput, context) => {
         expectTypeOf(context.sql).toEqualTypeOf<Sql>();
         return { data: 'test' };
       })
-      .step({ slug: 's2', dependsOn: ['s1'] }, (input, context) => {
+      .step({ slug: 's2', dependsOn: ['s1'] }, (deps, context) => {
         expectTypeOf(context.supabase).toEqualTypeOf<SupabaseClient>();
-        expectTypeOf(input.s1.data).toEqualTypeOf<string>();
+        expectTypeOf(deps.s1.data).toEqualTypeOf<string>();
         return { final: true };
       });
 

--- a/pkgs/edge-worker/README.md
+++ b/pkgs/edge-worker/README.md
@@ -65,18 +65,18 @@ import { Flow } from 'jsr:@pgflow/dsl/supabase';
 const AnalyzeWebsite = new Flow<{ url: string }>({
   slug: 'analyzeWebsite',
 })
-  .step({ slug: 'fetch' }, async (input, context) => {
+  .step({ slug: 'fetch' }, async (flowInput, context) => {
     // Access Supabase resources through context
-    const response = await fetch(input.run.url, {
+    const response = await fetch(flowInput.url, {
       signal: context.shutdownSignal,
     });
     return { html: await response.text() };
   })
-  .step({ slug: 'save' }, async (input, context) => {
+  .step({ slug: 'save', dependsOn: ['fetch'] }, async (deps, context) => {
     // Use Supabase client from context
     const { data } = await context.supabase
       .from('websites')
-      .insert({ url: input.run.url, html: input.fetch.html })
+      .insert({ url: context.flowInput.url, html: deps.fetch.html })
       .select()
       .single();
     return data;

--- a/pkgs/edge-worker/src/core/supabase-test-utils.ts
+++ b/pkgs/edge-worker/src/core/supabase-test-utils.ts
@@ -103,6 +103,7 @@ export function createFlowWorkerContext<TFlow extends AnyFlow = AnyFlow>(params:
     // Step task execution context
     rawMessage: taskWithMessage.message,
     stepTask: taskWithMessage.task,
+    flowInput: taskWithMessage.flowInput,
     workerConfig: createContextSafeConfig(resolvedConfig),
 
     // Supabase-specific resources (always present in Phase 1)

--- a/pkgs/edge-worker/src/flow/StepTaskExecutor.ts
+++ b/pkgs/edge-worker/src/flow/StepTaskExecutor.ts
@@ -105,8 +105,21 @@ export class StepTaskExecutor<TFlow extends AnyFlow, TContext extends StepTaskHa
       // Measure handler execution duration
       const startTime = Date.now();
 
+      // Route input based on step type and dependencies
+      let handlerInput: unknown;
+      if (stepDef.stepType === 'map') {
+        // Map steps: SQL already extracted element
+        handlerInput = this.stepTask.input;
+      } else if (stepDef.dependencies.length === 0) {
+        // Root single/array step: use flowInput from context
+        handlerInput = this.context.flowInput;
+      } else {
+        // Dependent single/array step: use deps object from task input
+        handlerInput = this.stepTask.input;
+      }
+
       // !!! HANDLER EXECUTION !!!
-      const result = await stepDef.handler(this.stepTask.input, this.context);
+      const result = await stepDef.handler(handlerInput, this.context);
       // !!! HANDLER EXECUTION !!!
 
       const durationMs = Date.now() - startTime;

--- a/pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
@@ -10,9 +10,9 @@ import { integrationConfig } from '../../config.ts';
 
 // Define a minimal test flow
 const TestCompilationFlow = new Flow<{ value: number }>({ slug: 'test_compilation_flow' })
-  .step({ slug: 'double' }, async (input) => {
+  .step({ slug: 'double' }, async (flowInput) => {
     await delay(1);
-    return input.run.value * 2;
+    return flowInput.value * 2;
   });
 
 const noop = () => {};

--- a/pkgs/edge-worker/tests/integration/flow/mapFlow.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/mapFlow.test.ts
@@ -30,12 +30,12 @@ const DependentMapFlow = new Flow<{ prefix: string }>({ slug: 'test_dependent_ma
     await delay(1);
     return str.toUpperCase();
   })
-  .step({ slug: 'aggregate', dependsOn: ['uppercase'] }, async (input) => {
+  .step({ slug: 'aggregate', dependsOn: ['uppercase'] }, async (deps, ctx) => {
     await delay(1);
     return {
-      prefix: input.run.prefix,
-      processed: input.uppercase,
-      count: input.uppercase.length
+      prefix: ctx.flowInput.prefix,
+      processed: deps.uppercase,
+      count: deps.uppercase.length
     };
   });
 

--- a/pkgs/edge-worker/tests/integration/flow/minimalFlow.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/minimalFlow.test.ts
@@ -17,15 +17,15 @@ import {
 // 1. Convert a number to a string
 // 2. Wrap the string in an array
 const MinimalFlow = new Flow<number>({ slug: 'test_minimal_flow' })
-  .step({ slug: 'toStringStep' }, async (input) => {
+  .step({ slug: 'toStringStep' }, async (flowInput) => {
     await delay(1);
-    return input.run.toString();
+    return flowInput.toString();
   })
   .step(
     { slug: 'wrapInArrayStep', dependsOn: ['toStringStep'] },
-    async (input) => {
+    async (deps) => {
       await delay(1);
-      return [input.toStringStep];
+      return [deps.toStringStep];
     }
   );
 

--- a/pkgs/edge-worker/tests/integration/flow/startDelayFlow.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/startDelayFlow.test.ts
@@ -7,64 +7,64 @@ import { startFlow, startWorker } from '../_helpers.ts';
 import { waitForRunCompletion, getStepStates, getStepTasks, getRunOutput } from './_testHelpers.ts';
 
 // Test flow with root step delay
-const RootStepDelayFlow = new Flow<{ message: string }>({ 
+const RootStepDelayFlow = new Flow<{ message: string }>({
   slug: 'test_root_step_delay_flow',
   maxAttempts: 2,
   timeout: 5
 })
-  .step({ 
+  .step({
     slug: 'delayedRoot',
     startDelay: 2  // 2 second delay
-  }, async (input) => {
+  }, async (flowInput) => {
     await delay(1);
-    return `Delayed: ${input.run.message}`;
+    return `Delayed: ${flowInput.message}`;
   });
 
 // Test flow with normal step delay
-const NormalStepDelayFlow = new Flow<{ value: number }>({ 
+const NormalStepDelayFlow = new Flow<{ value: number }>({
   slug: 'test_normal_step_delay_flow'
 })
-  .step({ 
-    slug: 'immediate' 
-  }, async (input) => {
+  .step({
+    slug: 'immediate'
+  }, async (flowInput) => {
     await delay(1);
-    return input.run.value * 2;
+    return flowInput.value * 2;
   })
-  .step({ 
+  .step({
     slug: 'delayed',
     dependsOn: ['immediate'],
     startDelay: 3  // 3 second delay after immediate completes
-  }, async (input) => {
+  }, async (deps) => {
     await delay(1);
-    return (input.immediate as number) + 10;
+    return (deps.immediate as number) + 10;
   });
 
 // Test flow with cascaded delays
-const CascadedDelayFlow = new Flow<{ start: string }>({ 
+const CascadedDelayFlow = new Flow<{ start: string }>({
   slug: 'test_cascaded_delay_flow'
 })
-  .step({ 
+  .step({
     slug: 'first',
     startDelay: 1  // 1 second delay
-  }, async (input) => {
+  }, async (flowInput) => {
     await delay(1);
-    return `${input.run.start}->first`;
+    return `${flowInput.start}->first`;
   })
-  .step({ 
+  .step({
     slug: 'second',
     dependsOn: ['first'],
     startDelay: 2  // 2 second delay after first completes
-  }, async (input) => {
+  }, async (deps) => {
     await delay(1);
-    return `${input.first}->second`;
+    return `${deps.first}->second`;
   })
-  .step({ 
+  .step({
     slug: 'third',
     dependsOn: ['second'],
     startDelay: 1  // 1 second delay after second completes
-  }, async (input) => {
+  }, async (deps) => {
     await delay(1);
-    return `${input.second}->third`;
+    return `${deps.second}->third`;
   });
 
 Deno.test(

--- a/pkgs/edge-worker/tests/integration/flow_deprecation.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow_deprecation.test.ts
@@ -8,17 +8,17 @@ import { startWorker } from './_helpers.ts';
 // Create a simple test flow that tracks executions
 const createTestFlow = (flowName: string, executions: { step1: number; step2: number }) => {
   return new Flow<{ value: number }>({ slug: flowName })
-    .step({ slug: 'step1' }, async (input) => {
+    .step({ slug: 'step1' }, async (flowInput) => {
       executions.step1++;
       await delay(50);
-      return { result: input.run.value * 2 };
+      return { result: flowInput.value * 2 };
     })
     .step(
       { slug: 'step2', dependsOn: ['step1'] },
-      async (input) => {
+      async (deps) => {
         executions.step2++;
         await delay(50);
-        return { final: input.step1.result + 10 };
+        return { final: deps.step1.result + 10 };
       }
     );
 };

--- a/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.compilation.test.ts
+++ b/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.compilation.test.ts
@@ -52,7 +52,7 @@ class MockQueries extends Queries {
 
 // Real Flow for testing - using the DSL to create a valid flow
 const TestFlow = new Flow<{ value: number }>({ slug: 'test_flow' })
-  .step({ slug: 'step1' }, (input) => input.run.value);
+  .step({ slug: 'step1' }, (flowInput) => flowInput.value);
 
 const createMockFlow = () => TestFlow;
 

--- a/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.deprecation.test.ts
+++ b/pkgs/edge-worker/tests/unit/FlowWorkerLifecycle.deprecation.test.ts
@@ -60,7 +60,7 @@ class MockQueries extends Queries {
 
 // Real Flow for testing - using the DSL to create a valid flow
 const TestFlow = new Flow<{ value: number }>({ slug: 'test_flow' })
-  .step({ slug: 'step1' }, (input) => input.run.value);
+  .step({ slug: 'step1' }, (flowInput) => flowInput.value);
 
 const createMockFlow = () => TestFlow;
 

--- a/pkgs/edge-worker/tests/unit/control-plane/server.test.ts
+++ b/pkgs/edge-worker/tests/unit/control-plane/server.test.ts
@@ -21,14 +21,14 @@ const FlowWithMultipleSteps = new Flow({ slug: 'flow_multiple_steps' })
 const FlowWithArrayStep = new Flow<{ items: string[] }>({
   slug: 'flow_with_array',
 })
-  .array({ slug: 'process_items' }, ({ run }) =>
-    run.items.map((item) => ({ item, processed: true }))
+  .array({ slug: 'process_items' }, (flowInput) =>
+    flowInput.items.map((item) => ({ item, processed: true }))
   );
 
 const FlowWithMapStep = new Flow<string[]>({ slug: 'flow_with_map' })
   .map({ slug: 'uppercase' }, (text) => text.toUpperCase())
-  .step({ slug: 'join', dependsOn: ['uppercase'] }, (input) => ({
-    result: input.uppercase.join(','),
+  .step({ slug: 'join', dependsOn: ['uppercase'] }, (deps) => ({
+    result: deps.uppercase.join(','),
   }));
 
 const FlowWithStepOptions = new Flow({ slug: 'flow_step_options' })

--- a/pkgs/example-flows/src/example-flow.ts
+++ b/pkgs/example-flows/src/example-flow.ts
@@ -9,23 +9,23 @@ export const ExampleFlow = new Flow<{ value: number }>({
   // rootStep return type will be inferred to:
   //
   // { doubledValue: number; };
-  .step({ slug: 'rootStep' }, async (input) => ({
-    doubledValue: input.run.value * 2,
+  .step({ slug: 'rootStep' }, async (flowInput) => ({
+    doubledValue: flowInput.value * 2,
   }))
   // normalStep return type will be inferred to:
   // { doubledValueArray: number[] };
-  // The input will only include 'run' and 'rootStep' properties
+  // The input will only include 'rootStep' dependency
   .step(
     { slug: 'normalStep', dependsOn: ['rootStep'], maxAttempts: 5 },
-    async (input) => ({
-      doubledValueArray: [input.rootStep.doubledValue],
+    async (deps) => ({
+      doubledValueArray: [deps.rootStep.doubledValue],
     })
   )
-  // This step depends on normalStep, so its input will include 'run', 'normalStep'
+  // This step depends on normalStep, so its input will include 'normalStep'
   // but not 'rootStep' since it's not directly declared as a dependency
-  .step({ slug: 'thirdStep', dependsOn: ['normalStep'] }, async (input) => ({
-    // input.rootStep would be a type error since it's not in dependsOn
-    finalValue: input.normalStep.doubledValueArray.length,
+  .step({ slug: 'thirdStep', dependsOn: ['normalStep'] }, async (deps) => ({
+    // deps.rootStep would be a type error since it's not in dependsOn
+    finalValue: deps.normalStep.doubledValueArray.length,
   }));
 export default ExampleFlow;
 
@@ -35,7 +35,6 @@ export const stepTaskRecord: StepTaskRecord<typeof ExampleFlow> = {
   step_slug: 'normalStep',
   task_index: 0,
   input: {
-    run: { value: 23 },
     rootStep: { doubledValue: 23 },
     // thirdStep: { finalValue: 23 }, --- this should be an error
     // normalStep: { doubledValueArray: [1, 2, 3] }, --- this should be an error

--- a/pkgs/example-flows/src/wide.ts
+++ b/pkgs/example-flows/src/wide.ts
@@ -7,75 +7,75 @@ const WideFlow = new Flow<string>({
   slug: 'wide_flow',
   maxAttempts: 3,
 })
-  .step({ slug: 'start' }, async (input) => {
+  .step({ slug: 'start' }, async (flowInput) => {
     await simulateWorkThenError();
-    return `[${input.run}]start`;
+    return `[${flowInput}]start`;
   })
-  .step({ slug: 'download_stream', dependsOn: ['start'] }, async (input) => {
+  .step({ slug: 'download_stream', dependsOn: ['start'] }, async (deps) => {
     await simulateWorkThenError();
-    return `${input.start}/download_stream`;
+    return `${deps.start}/download_stream`;
   })
   .step(
     { slug: 'extract_frames', dependsOn: ['download_stream'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.download_stream}/extract_frames`;
+      return `${deps.download_stream}/extract_frames`;
     }
   )
   .step(
     { slug: 'extract_audio', dependsOn: ['download_stream'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.download_stream}/extract_audio`;
+      return `${deps.download_stream}/extract_audio`;
     }
   )
   .step(
     { slug: 'collect_chat_data', dependsOn: ['download_stream'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.download_stream}/collect_chat_data`;
+      return `${deps.download_stream}/collect_chat_data`;
     }
   )
   .step(
     { slug: 'detect_scenes', dependsOn: ['extract_frames'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.extract_frames}/detect_scenes`;
+      return `${deps.extract_frames}/detect_scenes`;
     }
   )
   .step(
     { slug: 'detect_players', dependsOn: ['extract_frames'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.extract_frames}/detect_players`;
+      return `${deps.extract_frames}/detect_players`;
     }
   )
   .step(
     { slug: 'scene_classification', dependsOn: ['detect_scenes'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.detect_scenes}/scene_classification`;
+      return `${deps.detect_scenes}/scene_classification`;
     }
   )
   .step(
     { slug: 'scene_segmentation', dependsOn: ['detect_scenes'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.detect_scenes}/scene_segmentation`;
+      return `${deps.detect_scenes}/scene_segmentation`;
     }
   )
   .step(
     { slug: 'face_recognition', dependsOn: ['detect_players'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.detect_players}/face_recognition`;
+      return `${deps.detect_players}/face_recognition`;
     }
   )
   .step(
     { slug: 'jersey_recognition', dependsOn: ['detect_players'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.detect_players}/jersey_recognition`;
+      return `${deps.detect_players}/jersey_recognition`;
     }
   )
   .step(
@@ -83,44 +83,44 @@ const WideFlow = new Flow<string>({
       slug: 'identify_players',
       dependsOn: ['face_recognition', 'jersey_recognition'],
     },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.face_recognition} & ${input.jersey_recognition}/identify_players`;
+      return `${deps.face_recognition} & ${deps.jersey_recognition}/identify_players`;
     }
   )
   .step(
     { slug: 'transcribe_audio', dependsOn: ['extract_audio'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.extract_audio}/transcribe_audio`;
+      return `${deps.extract_audio}/transcribe_audio`;
     }
   )
   .step(
     { slug: 'analyze_audio_sentiment', dependsOn: ['transcribe_audio'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.transcribe_audio}/analyze_audio_sentiment`;
+      return `${deps.transcribe_audio}/analyze_audio_sentiment`;
     }
   )
   .step(
     { slug: 'keyword_extraction', dependsOn: ['transcribe_audio'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.transcribe_audio}/keyword_extraction`;
+      return `${deps.transcribe_audio}/keyword_extraction`;
     }
   )
   .step(
     { slug: 'filter_spam', dependsOn: ['collect_chat_data'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.collect_chat_data}/filter_spam`;
+      return `${deps.collect_chat_data}/filter_spam`;
     }
   )
   .step(
     { slug: 'analyze_chat_sentiment', dependsOn: ['filter_spam'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.filter_spam}/analyze_chat_sentiment`;
+      return `${deps.filter_spam}/analyze_chat_sentiment`;
     }
   )
   .step(
@@ -128,9 +128,9 @@ const WideFlow = new Flow<string>({
       slug: 'sentiment_summary',
       dependsOn: ['analyze_audio_sentiment', 'analyze_chat_sentiment'],
     },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.analyze_audio_sentiment} & ${input.analyze_chat_sentiment}/sentiment_summary`;
+      return `${deps.analyze_audio_sentiment} & ${deps.analyze_chat_sentiment}/sentiment_summary`;
     }
   )
   .step(
@@ -138,9 +138,9 @@ const WideFlow = new Flow<string>({
       slug: 'generate_statistics',
       dependsOn: ['sentiment_summary', 'identify_players'],
     },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.sentiment_summary} & ${input.identify_players}/generate_statistics`;
+      return `${deps.sentiment_summary} & ${deps.identify_players}/generate_statistics`;
     }
   )
   .step(
@@ -153,9 +153,9 @@ const WideFlow = new Flow<string>({
         'identify_players',
       ],
     },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.scene_classification}, ${input.scene_segmentation}, ${input.keyword_extraction}, ${input.identify_players}/generate_highlights`;
+      return `${deps.scene_classification}, ${deps.scene_segmentation}, ${deps.keyword_extraction}, ${deps.identify_players}/generate_highlights`;
     }
   )
   .step(
@@ -163,23 +163,23 @@ const WideFlow = new Flow<string>({
       slug: 'update_dashboard',
       dependsOn: ['generate_statistics', 'generate_highlights'],
     },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.generate_statistics} & ${input.generate_highlights}/update_dashboard`;
+      return `${deps.generate_statistics} & ${deps.generate_highlights}/update_dashboard`;
     }
   )
   .step(
     { slug: 'send_notifications', dependsOn: ['update_dashboard'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.update_dashboard}/send_notifications`;
+      return `${deps.update_dashboard}/send_notifications`;
     }
   )
   .step(
     { slug: 'finish', dependsOn: ['send_notifications'] },
-    async (input) => {
+    async (deps) => {
       await simulateWorkThenError();
-      return `${input.send_notifications}/finish`;
+      return `${deps.send_notifications}/finish`;
     }
   );
 


### PR DESCRIPTION
# Asymmetric Step Input Pattern for Improved Type Safety and Composition

This PR introduces a significant improvement to the step input pattern across the PgFlow DSL:

- Root steps now receive flow input directly (no `run` wrapper)
- Dependent steps receive only their dependencies (flow input available via `context.flowInput`)

This change enables better functional composition where subflows can receive typed inputs without the `run` wrapper that previously blocked type matching. The asymmetric input pattern makes the API more intuitive while maintaining full type safety.

## Key Changes:

- Updated `StepInput` utility type to implement the asymmetric pattern
- Modified step handler signatures to use `flowInput` instead of `input.run`
- Added `flowInput` to the `FlowContext` interface for dependent steps
- Updated all tests to use the new pattern
- Improved type tests to verify the asymmetric behavior

This change is backward compatible at runtime but will require updating handler parameter names in client code. The improved type safety and composability are worth the minor migration effort.