### PR TITLE
feat: support Supabase CLI v2+ opaque API keys in local environment detection

### DIFF
--- a/.changeset/support-supabase-opaque-keys.md
+++ b/.changeset/support-supabase-opaque-keys.md
@@ -1,0 +1,5 @@
+---
+'@pgflow/edge-worker': patch
+---
+
+Add support for new Supabase CLI v2+ opaque API keys in local environment detection

--- a/pkgs/edge-worker/src/shared/localDetection.ts
+++ b/pkgs/edge-worker/src/shared/localDetection.ts
@@ -1,16 +1,31 @@
+// Old HS256 JWT keys (Supabase CLI v1)
 export const KNOWN_LOCAL_ANON_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
 
 export const KNOWN_LOCAL_SERVICE_ROLE_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
 
+// New opaque keys (Supabase CLI v2+)
+// Source: https://github.com/supabase/cli/blob/develop/pkg/config/apikeys.go
+export const KNOWN_LOCAL_PUBLISHABLE_KEY =
+  'sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH';
+
+export const KNOWN_LOCAL_SECRET_KEY = 'sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz';
+
 /**
  * Checks if the provided environment indicates local Supabase.
  * Use when you have access to an env record (e.g., from PlatformAdapter).
+ * Supports both old HS256 JWT keys and new opaque keys from Supabase CLI v2+.
  */
 export function isLocalSupabaseEnv(env: Record<string, string | undefined>): boolean {
   const anonKey = env['SUPABASE_ANON_KEY'];
   const serviceRoleKey = env['SUPABASE_SERVICE_ROLE_KEY'];
-  return anonKey === KNOWN_LOCAL_ANON_KEY ||
-         serviceRoleKey === KNOWN_LOCAL_SERVICE_ROLE_KEY;
+
+  const isLocalAnonKey =
+    anonKey === KNOWN_LOCAL_ANON_KEY || anonKey === KNOWN_LOCAL_PUBLISHABLE_KEY;
+  const isLocalServiceRoleKey =
+    serviceRoleKey === KNOWN_LOCAL_SERVICE_ROLE_KEY ||
+    serviceRoleKey === KNOWN_LOCAL_SECRET_KEY;
+
+  return isLocalAnonKey || isLocalServiceRoleKey;
 }

--- a/pkgs/edge-worker/tests/unit/shared/localDetection.test.ts
+++ b/pkgs/edge-worker/tests/unit/shared/localDetection.test.ts
@@ -3,6 +3,8 @@ import {
   isLocalSupabaseEnv,
   KNOWN_LOCAL_ANON_KEY,
   KNOWN_LOCAL_SERVICE_ROLE_KEY,
+  KNOWN_LOCAL_PUBLISHABLE_KEY,
+  KNOWN_LOCAL_SECRET_KEY,
 } from '../../../src/shared/localDetection.ts';
 
 // ============================================================
@@ -20,6 +22,20 @@ Deno.test('KNOWN_LOCAL_SERVICE_ROLE_KEY - matches expected value', () => {
   assertEquals(
     KNOWN_LOCAL_SERVICE_ROLE_KEY,
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+  );
+});
+
+Deno.test('KNOWN_LOCAL_PUBLISHABLE_KEY - matches expected value', () => {
+  assertEquals(
+    KNOWN_LOCAL_PUBLISHABLE_KEY,
+    'sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH'
+  );
+});
+
+Deno.test('KNOWN_LOCAL_SECRET_KEY - matches expected value', () => {
+  assertEquals(
+    KNOWN_LOCAL_SECRET_KEY,
+    'sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz'
   );
 });
 
@@ -76,6 +92,44 @@ Deno.test('isLocalSupabaseEnv - returns true when only anon key matches (service
 Deno.test('isLocalSupabaseEnv - returns true when only service role matches (anon is prod)', () => {
   const env = {
     SUPABASE_ANON_KEY: 'prod-anon-key',
+    SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SERVICE_ROLE_KEY,
+  };
+  assertEquals(isLocalSupabaseEnv(env), true);
+});
+
+// ============================================================
+// New opaque key tests (Supabase CLI v2+)
+// ============================================================
+
+Deno.test('isLocalSupabaseEnv - returns true when anon key matches new publishable key', () => {
+  const env = { SUPABASE_ANON_KEY: KNOWN_LOCAL_PUBLISHABLE_KEY };
+  assertEquals(isLocalSupabaseEnv(env), true);
+});
+
+Deno.test('isLocalSupabaseEnv - returns true when service role matches new secret key', () => {
+  const env = { SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SECRET_KEY };
+  assertEquals(isLocalSupabaseEnv(env), true);
+});
+
+Deno.test('isLocalSupabaseEnv - returns true when both new opaque keys match', () => {
+  const env = {
+    SUPABASE_ANON_KEY: KNOWN_LOCAL_PUBLISHABLE_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SECRET_KEY,
+  };
+  assertEquals(isLocalSupabaseEnv(env), true);
+});
+
+Deno.test('isLocalSupabaseEnv - returns true when mixing old JWT anon with new secret key', () => {
+  const env = {
+    SUPABASE_ANON_KEY: KNOWN_LOCAL_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SECRET_KEY,
+  };
+  assertEquals(isLocalSupabaseEnv(env), true);
+});
+
+Deno.test('isLocalSupabaseEnv - returns true when mixing new publishable with old JWT service role', () => {
+  const env = {
+    SUPABASE_ANON_KEY: KNOWN_LOCAL_PUBLISHABLE_KEY,
     SUPABASE_SERVICE_ROLE_KEY: KNOWN_LOCAL_SERVICE_ROLE_KEY,
   };
   assertEquals(isLocalSupabaseEnv(env), true);


### PR DESCRIPTION
# Add support for Supabase CLI v2+ opaque API keys in local environment detection

This PR adds support for detecting local Supabase environments that use the new opaque API keys format introduced in Supabase CLI v2+. The edge worker can now recognize both:

- The original HS256 JWT keys (from Supabase CLI v1)
- The new opaque keys format (from Supabase CLI v2+)

The implementation:
- Adds constants for the new publishable and secret keys
- Updates the `isLocalSupabaseEnv` function to check for both key formats
- Adds comprehensive tests for all key combinations

This ensures compatibility with both older and newer Supabase CLI versions when running in local development environments.