### PR TITLE
feat: add type safety for skippable step dependencies

### DIFF
--- a/pkgs/dsl/__tests__/runtime/condition-options.test.ts
+++ b/pkgs/dsl/__tests__/runtime/condition-options.test.ts
@@ -3,61 +3,61 @@ import { Flow } from '../../src/dsl.js';
 import { compileFlow } from '../../src/compile-flow.js';
 
 describe('Condition Options', () => {
-  describe('DSL accepts condition and whenUnmet', () => {
-    it('should accept condition option on a step', () => {
+  describe('DSL accepts if and else', () => {
+    it('should accept if option on a step', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'conditional_step', condition: { enabled: true } },
+          { slug: 'conditional_step', if: { enabled: true } },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('conditional_step');
-      expect(step.options.condition).toEqual({ enabled: true });
+      expect(step.options.if).toEqual({ enabled: true });
     });
 
-    it('should accept whenUnmet option on a step', () => {
+    it('should accept else option on a step', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'conditional_step', whenUnmet: 'skip' },
+          { slug: 'conditional_step', else: 'skip' },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('conditional_step');
-      expect(step.options.whenUnmet).toBe('skip');
+      expect(step.options.else).toBe('skip');
     });
 
-    it('should accept both condition and whenUnmet together', () => {
+    it('should accept both if and else together', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
           {
             slug: 'conditional_step',
-            condition: { status: 'active' },
-            whenUnmet: 'skip-cascade',
+            if: { status: 'active' },
+            else: 'skip-cascade',
           },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('conditional_step');
-      expect(step.options.condition).toEqual({ status: 'active' });
-      expect(step.options.whenUnmet).toBe('skip-cascade');
+      expect(step.options.if).toEqual({ status: 'active' });
+      expect(step.options.else).toBe('skip-cascade');
     });
 
-    it('should accept condition on dependent steps', () => {
+    it('should accept if on dependent steps', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step({ slug: 'first' }, () => ({ success: true }))
         .step(
           {
             slug: 'conditional_step',
             dependsOn: ['first'],
-            condition: { first: { success: true } },
-            whenUnmet: 'skip',
+            if: { first: { success: true } },
+            else: 'skip',
           },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('conditional_step');
-      expect(step.options.condition).toEqual({ first: { success: true } });
-      expect(step.options.whenUnmet).toBe('skip');
+      expect(step.options.if).toEqual({ first: { success: true } });
+      expect(step.options.else).toBe('skip');
     });
   });
 
@@ -65,7 +65,7 @@ describe('Condition Options', () => {
     it('should compile condition_pattern for root step', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', condition: { enabled: true } },
+          { slug: 'step1', if: { enabled: true } },
           () => 'result'
         );
 
@@ -78,7 +78,7 @@ describe('Condition Options', () => {
     it('should compile when_unmet for step', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenUnmet: 'fail' },
+          { slug: 'step1', else: 'fail' },
           () => 'result'
         );
 
@@ -93,8 +93,8 @@ describe('Condition Options', () => {
         .step(
           {
             slug: 'step1',
-            condition: { active: true, type: 'premium' },
-            whenUnmet: 'skip-cascade',
+            if: { active: true, type: 'premium' },
+            else: 'skip-cascade',
           },
           () => 'result'
         );
@@ -113,8 +113,8 @@ describe('Condition Options', () => {
             slug: 'step1',
             maxAttempts: 3,
             timeout: 60,
-            condition: { enabled: true },
-            whenUnmet: 'skip',
+            if: { enabled: true },
+            else: 'skip',
           },
           () => 'result'
         );
@@ -135,8 +135,8 @@ describe('Condition Options', () => {
           {
             slug: 'second',
             dependsOn: ['first'],
-            condition: { first: { success: true } },
-            whenUnmet: 'skip',
+            if: { first: { success: true } },
+            else: 'skip',
           },
           () => 'result'
         );
@@ -150,26 +150,26 @@ describe('Condition Options', () => {
     });
   });
 
-  describe('whenUnmet validation', () => {
-    it('should only accept valid whenUnmet values', () => {
+  describe('else validation', () => {
+    it('should only accept valid else values', () => {
       // Valid values should work
       expect(() =>
         new Flow({ slug: 'test' }).step(
-          { slug: 's1', whenUnmet: 'fail' },
+          { slug: 's1', else: 'fail' },
           () => 1
         )
       ).not.toThrow();
 
       expect(() =>
         new Flow({ slug: 'test' }).step(
-          { slug: 's1', whenUnmet: 'skip' },
+          { slug: 's1', else: 'skip' },
           () => 1
         )
       ).not.toThrow();
 
       expect(() =>
         new Flow({ slug: 'test' }).step(
-          { slug: 's1', whenUnmet: 'skip-cascade' },
+          { slug: 's1', else: 'skip-cascade' },
           () => 1
         )
       ).not.toThrow();

--- a/pkgs/dsl/__tests__/runtime/when-failed-options.test.ts
+++ b/pkgs/dsl/__tests__/runtime/when-failed-options.test.ts
@@ -2,65 +2,65 @@ import { describe, it, expect } from 'vitest';
 import { Flow } from '../../src/dsl.js';
 import { compileFlow } from '../../src/compile-flow.js';
 
-describe('whenFailed Options', () => {
-  describe('DSL accepts whenFailed option', () => {
-    it('should accept whenFailed option on a step', () => {
+describe('retriesExhausted Options', () => {
+  describe('DSL accepts retriesExhausted option', () => {
+    it('should accept retriesExhausted option on a step', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenFailed: 'skip' },
+          { slug: 'step1', retriesExhausted: 'skip' },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('step1');
-      expect(step.options.whenFailed).toBe('skip');
+      expect(step.options.retriesExhausted).toBe('skip');
     });
 
-    it('should accept whenFailed: fail (default behavior)', () => {
+    it('should accept retriesExhausted: fail (default behavior)', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenFailed: 'fail' },
+          { slug: 'step1', retriesExhausted: 'fail' },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('step1');
-      expect(step.options.whenFailed).toBe('fail');
+      expect(step.options.retriesExhausted).toBe('fail');
     });
 
-    it('should accept whenFailed: skip-cascade', () => {
+    it('should accept retriesExhausted: skip-cascade', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenFailed: 'skip-cascade' },
+          { slug: 'step1', retriesExhausted: 'skip-cascade' },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('step1');
-      expect(step.options.whenFailed).toBe('skip-cascade');
+      expect(step.options.retriesExhausted).toBe('skip-cascade');
     });
 
-    it('should accept whenFailed on dependent steps', () => {
+    it('should accept retriesExhausted on dependent steps', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step({ slug: 'first' }, () => ({ data: 'test' }))
         .step(
           {
             slug: 'second',
             dependsOn: ['first'],
-            whenFailed: 'skip',
+            retriesExhausted: 'skip',
           },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('second');
-      expect(step.options.whenFailed).toBe('skip');
+      expect(step.options.retriesExhausted).toBe('skip');
     });
 
-    it('should accept whenFailed together with other options', () => {
+    it('should accept retriesExhausted together with other options', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
           {
             slug: 'step1',
             maxAttempts: 3,
             timeout: 60,
-            whenFailed: 'skip-cascade',
+            retriesExhausted: 'skip-cascade',
           },
           () => 'result'
         );
@@ -68,25 +68,25 @@ describe('whenFailed Options', () => {
       const step = flow.getStepDefinition('step1');
       expect(step.options.maxAttempts).toBe(3);
       expect(step.options.timeout).toBe(60);
-      expect(step.options.whenFailed).toBe('skip-cascade');
+      expect(step.options.retriesExhausted).toBe('skip-cascade');
     });
 
-    it('should accept both whenUnmet and whenFailed together', () => {
+    it('should accept both else and retriesExhausted together', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
           {
             slug: 'step1',
-            condition: { enabled: true },
-            whenUnmet: 'skip',
-            whenFailed: 'skip-cascade',
+            if: { enabled: true },
+            else: 'skip',
+            retriesExhausted: 'skip-cascade',
           },
           () => 'result'
         );
 
       const step = flow.getStepDefinition('step1');
-      expect(step.options.condition).toEqual({ enabled: true });
-      expect(step.options.whenUnmet).toBe('skip');
-      expect(step.options.whenFailed).toBe('skip-cascade');
+      expect(step.options.if).toEqual({ enabled: true });
+      expect(step.options.else).toBe('skip');
+      expect(step.options.retriesExhausted).toBe('skip-cascade');
     });
   });
 
@@ -94,7 +94,7 @@ describe('whenFailed Options', () => {
     it('should compile when_failed for step', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenFailed: 'skip' },
+          { slug: 'step1', retriesExhausted: 'skip' },
           () => 'result'
         );
 
@@ -107,7 +107,7 @@ describe('whenFailed Options', () => {
     it('should compile when_failed: fail', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenFailed: 'fail' },
+          { slug: 'step1', retriesExhausted: 'fail' },
           () => 'result'
         );
 
@@ -120,7 +120,7 @@ describe('whenFailed Options', () => {
     it('should compile when_failed: skip-cascade', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
-          { slug: 'step1', whenFailed: 'skip-cascade' },
+          { slug: 'step1', retriesExhausted: 'skip-cascade' },
           () => 'result'
         );
 
@@ -130,16 +130,16 @@ describe('whenFailed Options', () => {
       expect(statements[1]).toContain("when_failed => 'skip-cascade'");
     });
 
-    it('should compile step with all options including whenFailed', () => {
+    it('should compile step with all options including retriesExhausted', () => {
       const flow = new Flow({ slug: 'test_flow' })
         .step(
           {
             slug: 'step1',
             maxAttempts: 3,
             timeout: 60,
-            condition: { enabled: true },
-            whenUnmet: 'skip',
-            whenFailed: 'skip-cascade',
+            if: { enabled: true },
+            else: 'skip',
+            retriesExhausted: 'skip-cascade',
           },
           () => 'result'
         );
@@ -168,22 +168,22 @@ describe('whenFailed Options', () => {
     });
   });
 
-  describe('whenFailed on map steps', () => {
-    it('should accept whenFailed on map step', () => {
+  describe('retriesExhausted on map steps', () => {
+    it('should accept retriesExhausted on map step', () => {
       const flow = new Flow<string[]>({ slug: 'test_flow' })
         .map(
-          { slug: 'map_step', whenFailed: 'skip' },
+          { slug: 'map_step', retriesExhausted: 'skip' },
           (item) => item.toUpperCase()
         );
 
       const step = flow.getStepDefinition('map_step');
-      expect(step.options.whenFailed).toBe('skip');
+      expect(step.options.retriesExhausted).toBe('skip');
     });
 
     it('should compile when_failed for map step', () => {
       const flow = new Flow<string[]>({ slug: 'test_flow' })
         .map(
-          { slug: 'map_step', whenFailed: 'skip-cascade' },
+          { slug: 'map_step', retriesExhausted: 'skip-cascade' },
           (item) => item.toUpperCase()
         );
 

--- a/pkgs/dsl/__tests__/types/condition-pattern.test-d.ts
+++ b/pkgs/dsl/__tests__/types/condition-pattern.test-d.ts
@@ -133,48 +133,48 @@ describe('ContainmentPattern<T> utility type', () => {
   });
 });
 
-describe('condition option typing in step methods', () => {
-  describe('root step condition', () => {
-    it('should type condition as ContainmentPattern<FlowInput>', () => {
+describe('if option typing in step methods', () => {
+  describe('root step if', () => {
+    it('should type if as ContainmentPattern<FlowInput>', () => {
       type FlowInput = { userId: string; role: string };
 
       // This should compile - valid partial pattern
       const flow = new Flow<FlowInput>({ slug: 'test_flow' }).step(
-        { slug: 'check', condition: { role: 'admin' } },
+        { slug: 'check', if: { role: 'admin' } },
         (input) => input.userId
       );
 
       expectTypeOf(flow).toBeObject();
     });
 
-    it('should reject invalid keys in condition', () => {
+    it('should reject invalid keys in if', () => {
       type FlowInput = { userId: string; role: string };
 
       // @ts-expect-error - 'invalidKey' does not exist on FlowInput
       new Flow<FlowInput>({ slug: 'test_flow' }).step(
-        { slug: 'check', condition: { invalidKey: 'value' } },
+        { slug: 'check', if: { invalidKey: 'value' } },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (input: any) => input.userId
       );
     });
 
-    it('should reject wrong value types in condition', () => {
+    it('should reject wrong value types in if', () => {
       type FlowInput = { userId: string; role: string };
 
       // @ts-expect-error - role should be string, not number
       new Flow<FlowInput>({ slug: 'test_flow' }).step(
-        { slug: 'check', condition: { role: 123 } },
+        { slug: 'check', if: { role: 123 } },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (input: any) => input.userId
       );
     });
 
-    it('should allow empty object condition (always matches)', () => {
+    it('should allow empty object if (always matches)', () => {
       type FlowInput = { userId: string; role: string };
 
       // Empty object should be valid
       const flow = new Flow<FlowInput>({ slug: 'test_flow' }).step(
-        { slug: 'check', condition: {} },
+        { slug: 'check', if: {} },
         (input) => input.userId
       );
 
@@ -185,7 +185,7 @@ describe('condition option typing in step methods', () => {
       type FlowInput = { user: { name: string; role: string } };
 
       const flow = new Flow<FlowInput>({ slug: 'test_flow' }).step(
-        { slug: 'check', condition: { user: { role: 'admin' } } },
+        { slug: 'check', if: { user: { role: 'admin' } } },
         (input) => input.user.name
       );
 
@@ -193,15 +193,15 @@ describe('condition option typing in step methods', () => {
     });
   });
 
-  describe('dependent step condition', () => {
-    it('should type condition as ContainmentPattern<DepsObject>', () => {
+  describe('dependent step if', () => {
+    it('should type if as ContainmentPattern<DepsObject>', () => {
       const flow = new Flow<{ initial: string }>({ slug: 'test_flow' })
         .step({ slug: 'fetch' }, () => ({ status: 'ok', data: 'result' }))
         .step(
           {
             slug: 'process',
             dependsOn: ['fetch'],
-            condition: { fetch: { status: 'ok' } },
+            if: { fetch: { status: 'ok' } },
           },
           (deps) => deps.fetch.data
         );
@@ -209,7 +209,7 @@ describe('condition option typing in step methods', () => {
       expectTypeOf(flow).toBeObject();
     });
 
-    it('should reject invalid dep slug in condition', () => {
+    it('should reject invalid dep slug in if', () => {
       new Flow<{ initial: string }>({ slug: 'test_flow' })
         .step({ slug: 'fetch' }, () => ({ status: 'ok' }))
         .step(
@@ -217,7 +217,7 @@ describe('condition option typing in step methods', () => {
             slug: 'process',
             dependsOn: ['fetch'],
             // @ts-expect-error - 'nonexistent' is not a dependency
-            condition: { nonexistent: { status: 'ok' } },
+            if: { nonexistent: { status: 'ok' } },
           },
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (deps: any) => deps.fetch.status
@@ -232,14 +232,14 @@ describe('condition option typing in step methods', () => {
             slug: 'process',
             dependsOn: ['fetch'],
             // @ts-expect-error - 'invalidField' does not exist on fetch output
-            condition: { fetch: { invalidField: 'value' } },
+            if: { fetch: { invalidField: 'value' } },
           },
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (deps: any) => deps.fetch.status
         );
     });
 
-    it('should handle multiple dependencies in condition', () => {
+    it('should handle multiple dependencies in if', () => {
       const flow = new Flow<{ initial: string }>({ slug: 'test_flow' })
         .step({ slug: 'step1' }, () => ({ ready: true }))
         .step({ slug: 'step2' }, () => ({ valid: true }))
@@ -247,7 +247,7 @@ describe('condition option typing in step methods', () => {
           {
             slug: 'final',
             dependsOn: ['step1', 'step2'],
-            condition: { step1: { ready: true }, step2: { valid: true } },
+            if: { step1: { ready: true }, step2: { valid: true } },
           },
           (deps) => deps.step1.ready && deps.step2.valid
         );
@@ -256,26 +256,26 @@ describe('condition option typing in step methods', () => {
     });
   });
 
-  describe('array step condition', () => {
-    it('should type condition for root array step', () => {
+  describe('array step if', () => {
+    it('should type if for root array step', () => {
       type FlowInput = { items: string[]; enabled: boolean };
 
       const flow = new Flow<FlowInput>({ slug: 'test_flow' }).array(
-        { slug: 'getItems', condition: { enabled: true } },
+        { slug: 'getItems', if: { enabled: true } },
         (input) => input.items
       );
 
       expectTypeOf(flow).toBeObject();
     });
 
-    it('should type condition for dependent array step', () => {
+    it('should type if for dependent array step', () => {
       const flow = new Flow<{ initial: string }>({ slug: 'test_flow' })
         .step({ slug: 'fetch' }, () => ({ ready: true, items: ['a', 'b'] }))
         .array(
           {
             slug: 'process',
             dependsOn: ['fetch'],
-            condition: { fetch: { ready: true } },
+            if: { fetch: { ready: true } },
           },
           (deps) => deps.fetch.items
         );
@@ -284,20 +284,20 @@ describe('condition option typing in step methods', () => {
     });
   });
 
-  describe('map step condition', () => {
-    it('should type condition for root map step', () => {
+  describe('map step if', () => {
+    it('should type if for root map step', () => {
       type FlowInput = { type: string; value: number }[];
 
       const flow = new Flow<FlowInput>({ slug: 'test_flow' }).map(
-        // Root map condition checks the array itself
-        { slug: 'process', condition: [{ type: 'active' }] },
+        // Root map if checks the array itself
+        { slug: 'process', if: [{ type: 'active' }] },
         (item) => item.value * 2
       );
 
       expectTypeOf(flow).toBeObject();
     });
 
-    it('should type condition for dependent map step', () => {
+    it('should type if for dependent map step', () => {
       const flow = new Flow<{ initial: string }>({ slug: 'test_flow' })
         .step({ slug: 'fetch' }, () => [
           { id: 1, active: true },
@@ -308,7 +308,7 @@ describe('condition option typing in step methods', () => {
             slug: 'process',
             array: 'fetch',
             // Condition checks the array dep
-            condition: { fetch: [{ active: true }] },
+            if: { fetch: [{ active: true }] },
           },
           (item) => item.id
         );

--- a/pkgs/dsl/__tests__/types/map-method.test-d.ts
+++ b/pkgs/dsl/__tests__/types/map-method.test-d.ts
@@ -1,4 +1,4 @@
-import { Flow, type Json, type StepInput, type ExtractFlowContext } from '../../src/index.js';
+import { Flow, type Json, type StepInput, type ExtractFlowContext, type ExtractFlowSteps } from '../../src/index.js';
 import { describe, it, expectTypeOf } from 'vitest';
 
 describe('.map() method type constraints', () => {
@@ -11,9 +11,7 @@ describe('.map() method type constraints', () => {
         });
 
       // The map step should return an array of the handler return type
-      type ProcessOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['process']
-        : never;
+      type ProcessOutput = ExtractFlowSteps<typeof flow>['process'];
       expectTypeOf<ProcessOutput>().toEqualTypeOf<{ processed: string }[]>();
     });
 
@@ -34,9 +32,7 @@ describe('.map() method type constraints', () => {
           return item.length;
         });
 
-      type FlattenOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['flatten']
-        : never;
+      type FlattenOutput = ExtractFlowSteps<typeof flow>['flatten'];
       expectTypeOf<FlattenOutput>().toEqualTypeOf<number[]>();
     });
 
@@ -47,9 +43,7 @@ describe('.map() method type constraints', () => {
           return String(item);
         });
 
-      type StringifyOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['stringify']
-        : never;
+      type StringifyOutput = ExtractFlowSteps<typeof flow>['stringify'];
       expectTypeOf<StringifyOutput>().toEqualTypeOf<string[]>();
     });
   });
@@ -65,9 +59,7 @@ describe('.map() method type constraints', () => {
           return item * 2;
         });
 
-      type DoubleOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['double']
-        : never;
+      type DoubleOutput = ExtractFlowSteps<typeof flow>['double'];
       expectTypeOf<DoubleOutput>().toEqualTypeOf<number[]>();
     });
 
@@ -105,9 +97,7 @@ describe('.map() method type constraints', () => {
           return user.name;
         });
 
-      type NamesOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['extractNames']
-        : never;
+      type NamesOutput = ExtractFlowSteps<typeof flow>['extractNames'];
       expectTypeOf<NamesOutput>().toEqualTypeOf<string[]>();
     });
   });
@@ -149,9 +139,7 @@ describe('.map() method type constraints', () => {
           return item.length;
         });
 
-      type LengthsOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['lengths']
-        : never;
+      type LengthsOutput = ExtractFlowSteps<typeof flow>['lengths'];
       expectTypeOf<LengthsOutput>().toEqualTypeOf<number[]>();
     });
 
@@ -163,9 +151,7 @@ describe('.map() method type constraints', () => {
           return deps.double.reduce((a, b) => a + b, 0);
         });
 
-      type SumOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['sum']
-        : never;
+      type SumOutput = ExtractFlowSteps<typeof flow>['sum'];
       expectTypeOf<SumOutput>().toEqualTypeOf<number>();
     });
   });
@@ -239,9 +225,7 @@ describe('.map() method type constraints', () => {
           return String(item);
         });
 
-      type StringifyOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['stringify']
-        : never;
+      type StringifyOutput = ExtractFlowSteps<typeof flow>['stringify'];
       expectTypeOf<StringifyOutput>().toEqualTypeOf<string[]>();
     });
 
@@ -252,9 +236,7 @@ describe('.map() method type constraints', () => {
           return item !== null;
         });
 
-      type FilterOutput = typeof flow extends Flow<any, any, infer Steps, any>
-        ? Steps['filter']
-        : never;
+      type FilterOutput = ExtractFlowSteps<typeof flow>['filter'];
       expectTypeOf<FilterOutput>().toEqualTypeOf<boolean[]>();
     });
   });

--- a/pkgs/dsl/__tests__/types/map-return-type-inference.test-d.ts
+++ b/pkgs/dsl/__tests__/types/map-return-type-inference.test-d.ts
@@ -1,4 +1,4 @@
-import { Flow } from '../../src/index.js';
+import { Flow, type ExtractFlowSteps } from '../../src/index.js';
 import { describe, it, expectTypeOf } from 'vitest';
 
 describe('map step return type inference bug', () => {
@@ -38,9 +38,7 @@ describe('map step return type inference bug', () => {
       );
 
     // Verify the map step output type is not any[]
-    type ProcessChunksOutput = typeof flow extends Flow<any, any, infer Steps, any>
-      ? Steps['processChunks']
-      : never;
+    type ProcessChunksOutput = ExtractFlowSteps<typeof flow>['processChunks'];
 
     expectTypeOf<ProcessChunksOutput>().not.toEqualTypeOf<any[]>();
   });
@@ -73,9 +71,7 @@ describe('map step return type inference bug', () => {
         return { ok: true };
       });
 
-    type TransformOutput = typeof flow extends Flow<any, any, infer Steps, any>
-      ? Steps['transform']
-      : never;
+    type TransformOutput = ExtractFlowSteps<typeof flow>['transform'];
 
     expectTypeOf<TransformOutput>().toEqualTypeOf<ComplexResult[]>();
     expectTypeOf<TransformOutput>().not.toEqualTypeOf<any[]>();
@@ -100,9 +96,7 @@ describe('map step return type inference bug', () => {
         return { done: true };
       });
 
-    type ProcessOutput = typeof flow extends Flow<any, any, infer Steps, any>
-      ? Steps['process']
-      : never;
+    type ProcessOutput = ExtractFlowSteps<typeof flow>['process'];
 
     expectTypeOf<ProcessOutput>().not.toEqualTypeOf<any[]>();
   });
@@ -127,9 +121,7 @@ describe('map step return type inference bug', () => {
         return { ok: true };
       });
 
-    type TransformOutput = typeof flow extends Flow<any, any, infer Steps, any>
-      ? Steps['transform']
-      : never;
+    type TransformOutput = ExtractFlowSteps<typeof flow>['transform'];
 
     expectTypeOf<TransformOutput>().toEqualTypeOf<{ value: string; length: number }[]>();
     expectTypeOf<TransformOutput>().not.toEqualTypeOf<any[]>();
@@ -155,9 +147,7 @@ describe('map step return type inference bug', () => {
         return { count: deps.uppercase.length };
       });
 
-    type UppercaseOutput = typeof flow extends Flow<any, any, infer Steps, any>
-      ? Steps['uppercase']
-      : never;
+    type UppercaseOutput = ExtractFlowSteps<typeof flow>['uppercase'];
 
     expectTypeOf<UppercaseOutput>().toEqualTypeOf<{ original: string; transformed: string }[]>();
     expectTypeOf<UppercaseOutput>().not.toEqualTypeOf<any[]>();

--- a/pkgs/dsl/__tests__/types/skippable-deps.test-d.ts
+++ b/pkgs/dsl/__tests__/types/skippable-deps.test-d.ts
@@ -1,0 +1,440 @@
+import { Flow, type StepInput, type StepOutput } from '../../src/index.js';
+import { describe, it, expectTypeOf } from 'vitest';
+
+/**
+ * Type tests for skippable step dependencies
+ *
+ * When a step has `else: 'skip' | 'skip-cascade'` or `retriesExhausted: 'skip' | 'skip-cascade'`,
+ * it may not execute. Dependent steps should receive that step's output as an optional key.
+ */
+
+describe('skippable deps type safety', () => {
+  describe('core skippability - else', () => {
+    it('step with else: skip makes output optional for dependents', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step(
+          { slug: 'conditional', if: { value: 42 }, else: 'skip' },
+          (input) => ({ result: input.value * 2 })
+        )
+        .step({ slug: 'dependent', dependsOn: ['conditional'] }, (deps) => {
+          // conditional should be optional - can't access without null check
+          expectTypeOf(deps.conditional).toEqualTypeOf<
+            { result: number } | undefined
+          >();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        conditional?: { result: number };
+      }>();
+    });
+
+    it('step with else: skip-cascade makes output optional for dependents', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step(
+          { slug: 'conditional', if: { value: 42 }, else: 'skip-cascade' },
+          (input) => ({ result: input.value * 2 })
+        )
+        .step({ slug: 'dependent', dependsOn: ['conditional'] }, (deps) => {
+          expectTypeOf(deps.conditional).toEqualTypeOf<
+            { result: number } | undefined
+          >();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        conditional?: { result: number };
+      }>();
+    });
+
+    it('step with else: fail keeps output required (default behavior)', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step(
+          { slug: 'conditional', if: { value: 42 }, else: 'fail' },
+          (input) => ({ result: input.value * 2 })
+        )
+        .step({ slug: 'dependent', dependsOn: ['conditional'] }, (deps) => {
+          // else: 'fail' means step either runs or flow fails - output is guaranteed
+          expectTypeOf(deps.conditional).toEqualTypeOf<{ result: number }>();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        conditional: { result: number };
+      }>();
+    });
+
+    it('step without else keeps output required', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'normal' }, (input) => ({ result: input.value * 2 }))
+        .step({ slug: 'dependent', dependsOn: ['normal'] }, (deps) => {
+          expectTypeOf(deps.normal).toEqualTypeOf<{ result: number }>();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        normal: { result: number };
+      }>();
+    });
+  });
+
+  describe('core skippability - retriesExhausted', () => {
+    it('step with retriesExhausted: skip makes output optional for dependents', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'risky', retriesExhausted: 'skip' }, (input) => ({
+          result: input.value * 2,
+        }))
+        .step({ slug: 'dependent', dependsOn: ['risky'] }, (deps) => {
+          expectTypeOf(deps.risky).toEqualTypeOf<
+            { result: number } | undefined
+          >();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        risky?: { result: number };
+      }>();
+    });
+
+    it('step with retriesExhausted: skip-cascade makes output optional for dependents', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'risky', retriesExhausted: 'skip-cascade' }, (input) => ({
+          result: input.value * 2,
+        }))
+        .step({ slug: 'dependent', dependsOn: ['risky'] }, (deps) => {
+          expectTypeOf(deps.risky).toEqualTypeOf<
+            { result: number } | undefined
+          >();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        risky?: { result: number };
+      }>();
+    });
+
+    it('step with retriesExhausted: fail keeps output required', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'risky', retriesExhausted: 'fail' }, (input) => ({
+          result: input.value * 2,
+        }))
+        .step({ slug: 'dependent', dependsOn: ['risky'] }, (deps) => {
+          expectTypeOf(deps.risky).toEqualTypeOf<{ result: number }>();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        risky: { result: number };
+      }>();
+    });
+  });
+
+  describe('multiple dependencies - mixed skippability', () => {
+    it('mixed deps: some optional, some required', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'skippable', if: { value: 42 }, else: 'skip' }, () => ({
+          a: 1,
+        }))
+        .step({ slug: 'required' }, () => ({ b: 2 }))
+        .step(
+          { slug: 'dependent', dependsOn: ['skippable', 'required'] },
+          (deps) => {
+            expectTypeOf(deps.skippable).toEqualTypeOf<
+              { a: number } | undefined
+            >();
+            expectTypeOf(deps.required).toEqualTypeOf<{ b: number }>();
+            return { done: true };
+          }
+        );
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        skippable?: { a: number };
+        required: { b: number };
+      }>();
+    });
+
+    it('all deps skippable: all optional', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'skip1', retriesExhausted: 'skip' }, () => ({ a: 1 }))
+        .step({ slug: 'skip2', retriesExhausted: 'skip' }, () => ({ b: 2 }))
+        .step({ slug: 'dependent', dependsOn: ['skip1', 'skip2'] }, (deps) => {
+          expectTypeOf(deps.skip1).toEqualTypeOf<{ a: number } | undefined>();
+          expectTypeOf(deps.skip2).toEqualTypeOf<{ b: number } | undefined>();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        skip1?: { a: number };
+        skip2?: { b: number };
+      }>();
+    });
+
+    it('all deps required: none optional', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'req1' }, () => ({ a: 1 }))
+        .step({ slug: 'req2' }, () => ({ b: 2 }))
+        .step({ slug: 'dependent', dependsOn: ['req1', 'req2'] }, (deps) => {
+          expectTypeOf(deps.req1).toEqualTypeOf<{ a: number }>();
+          expectTypeOf(deps.req2).toEqualTypeOf<{ b: number }>();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        req1: { a: number };
+        req2: { b: number };
+      }>();
+    });
+  });
+
+  describe('chains and graphs', () => {
+    it('chain A(skip) -> B -> C: A optional in B, B required in C', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'a', retriesExhausted: 'skip' }, () => ({ aVal: 1 }))
+        .step({ slug: 'b', dependsOn: ['a'] }, (deps) => {
+          expectTypeOf(deps.a).toEqualTypeOf<{ aVal: number } | undefined>();
+          return { bVal: 2 };
+        })
+        .step({ slug: 'c', dependsOn: ['b'] }, (deps) => {
+          // B is not skippable, so B's output is required
+          expectTypeOf(deps.b).toEqualTypeOf<{ bVal: number }>();
+          return { cVal: 3 };
+        });
+
+      type BInput = StepInput<typeof flow, 'b'>;
+      expectTypeOf<BInput>().toEqualTypeOf<{ a?: { aVal: number } }>();
+
+      type CInput = StepInput<typeof flow, 'c'>;
+      expectTypeOf<CInput>().toEqualTypeOf<{ b: { bVal: number } }>();
+    });
+
+    it('diamond: A(skip) -> B, A -> C, B+C -> D: A optional in B and C', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'a', retriesExhausted: 'skip' }, () => ({ aVal: 1 }))
+        .step({ slug: 'b', dependsOn: ['a'] }, (deps) => {
+          expectTypeOf(deps.a).toEqualTypeOf<{ aVal: number } | undefined>();
+          return { bVal: 2 };
+        })
+        .step({ slug: 'c', dependsOn: ['a'] }, (deps) => {
+          expectTypeOf(deps.a).toEqualTypeOf<{ aVal: number } | undefined>();
+          return { cVal: 3 };
+        })
+        .step({ slug: 'd', dependsOn: ['b', 'c'] }, (deps) => {
+          // B and C are not skippable themselves
+          expectTypeOf(deps.b).toEqualTypeOf<{ bVal: number }>();
+          expectTypeOf(deps.c).toEqualTypeOf<{ cVal: number }>();
+          return { dVal: 4 };
+        });
+
+      type BInput = StepInput<typeof flow, 'b'>;
+      expectTypeOf<BInput>().toEqualTypeOf<{ a?: { aVal: number } }>();
+
+      type CInput = StepInput<typeof flow, 'c'>;
+      expectTypeOf<CInput>().toEqualTypeOf<{ a?: { aVal: number } }>();
+
+      type DInput = StepInput<typeof flow, 'd'>;
+      expectTypeOf<DInput>().toEqualTypeOf<{
+        b: { bVal: number };
+        c: { cVal: number };
+      }>();
+    });
+
+    it('cascade does NOT propagate: A(skip-cascade) -> B: B output NOT automatically optional', () => {
+      // skip-cascade means A and its dependents get skipped at RUNTIME
+      // but B itself is not marked as skippable in its definition
+      // so if B does run, its output is required for its own dependents
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'a', retriesExhausted: 'skip-cascade' }, () => ({
+          aVal: 1,
+        }))
+        .step({ slug: 'b', dependsOn: ['a'] }, (deps) => {
+          expectTypeOf(deps.a).toEqualTypeOf<{ aVal: number } | undefined>();
+          return { bVal: 2 };
+        })
+        .step({ slug: 'c', dependsOn: ['b'] }, (deps) => {
+          // B is not skippable in its own definition, so its output is required
+          expectTypeOf(deps.b).toEqualTypeOf<{ bVal: number }>();
+          return { cVal: 3 };
+        });
+
+      type CInput = StepInput<typeof flow, 'c'>;
+      expectTypeOf<CInput>().toEqualTypeOf<{ b: { bVal: number } }>();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('root step with skip: valid config, no dependents affected (no deps)', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' }).step(
+        { slug: 'root', retriesExhausted: 'skip' },
+        (input) => ({ result: input.value })
+      );
+
+      // Root step has no deps, so StepInput is the flow input
+      type RootInput = StepInput<typeof flow, 'root'>;
+      expectTypeOf<RootInput>().toEqualTypeOf<{ value: number }>();
+    });
+
+    it('map step with skip: entire output array is optional type', () => {
+      const flow = new Flow<string[]>({ slug: 'test' })
+        .map({ slug: 'process', retriesExhausted: 'skip' }, (item) =>
+          item.toUpperCase()
+        )
+        .step({ slug: 'aggregate', dependsOn: ['process'] }, (deps) => {
+          expectTypeOf(deps.process).toEqualTypeOf<string[] | undefined>();
+          return { done: true };
+        });
+
+      type AggInput = StepInput<typeof flow, 'aggregate'>;
+      expectTypeOf<AggInput>().toEqualTypeOf<{
+        process?: string[];
+      }>();
+    });
+
+    it('array step with skip: entire output array is optional type', () => {
+      const flow = new Flow<{ count: number }>({ slug: 'test' })
+        .array({ slug: 'generate', retriesExhausted: 'skip' }, (input) =>
+          Array(input.count)
+            .fill(0)
+            .map((_, i) => i)
+        )
+        .step({ slug: 'sum', dependsOn: ['generate'] }, (deps) => {
+          expectTypeOf(deps.generate).toEqualTypeOf<number[] | undefined>();
+          return { done: true };
+        });
+
+      type SumInput = StepInput<typeof flow, 'sum'>;
+      expectTypeOf<SumInput>().toEqualTypeOf<{
+        generate?: number[];
+      }>();
+    });
+
+    it('both else and retriesExhausted set: still skippable', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step(
+          {
+            slug: 'both',
+            if: { value: 42 },
+            else: 'skip',
+            retriesExhausted: 'skip',
+          },
+          () => ({ result: 1 })
+        )
+        .step({ slug: 'dependent', dependsOn: ['both'] }, (deps) => {
+          expectTypeOf(deps.both).toEqualTypeOf<
+            { result: number } | undefined
+          >();
+          return { done: true };
+        });
+
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{
+        both?: { result: number };
+      }>();
+    });
+  });
+
+  describe('type inference and narrowing', () => {
+    it('cannot access property on optional dep without null check', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'skippable', retriesExhausted: 'skip' }, () => ({
+          foo: 'bar',
+        }))
+        .step({ slug: 'dependent', dependsOn: ['skippable'] }, (deps) => {
+          // Direct property access should be a compile error - we test via runtime pattern
+          // The type system should make deps.skippable potentially undefined
+          expectTypeOf(deps.skippable).toEqualTypeOf<
+            { foo: string } | undefined
+          >();
+          return { done: true };
+        });
+
+      // Type verification
+      type DepInput = StepInput<typeof flow, 'dependent'>;
+      expectTypeOf<DepInput>().toEqualTypeOf<{ skippable?: { foo: string } }>();
+    });
+
+    it('type narrowing works after existence check', () => {
+      new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'skippable', retriesExhausted: 'skip' }, () => ({
+          foo: 'bar',
+        }))
+        .step({ slug: 'dependent', dependsOn: ['skippable'] }, (deps) => {
+          if (deps.skippable) {
+            // After narrowing, foo is accessible
+            expectTypeOf(deps.skippable.foo).toEqualTypeOf<string>();
+          }
+          return { done: true };
+        });
+    });
+
+    it('handler receives correctly typed deps object', () => {
+      new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'skip1', retriesExhausted: 'skip' }, () => ({ a: 1 }))
+        .step({ slug: 'req1' }, () => ({ b: 'str' }))
+        .step({ slug: 'dependent', dependsOn: ['skip1', 'req1'] }, (deps) => {
+          // Handler parameter should have correct mixed optionality
+          expectTypeOf(deps).toEqualTypeOf<{
+            skip1?: { a: number };
+            req1: { b: string };
+          }>();
+          return { done: true };
+        });
+    });
+  });
+
+  describe('utility types', () => {
+    it('StepOutput returns output type (not metadata)', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'normal' }, () => ({ result: 42 }))
+        .step({ slug: 'skippable', retriesExhausted: 'skip' }, () => ({
+          other: 'str',
+        }));
+
+      // StepOutput should return the actual output type, not the metadata structure
+      type NormalOutput = StepOutput<typeof flow, 'normal'>;
+      expectTypeOf<NormalOutput>().toEqualTypeOf<{ result: number }>();
+
+      type SkippableOutput = StepOutput<typeof flow, 'skippable'>;
+      expectTypeOf<SkippableOutput>().toEqualTypeOf<{ other: string }>();
+    });
+
+    it('keyof ExtractFlowSteps still returns slug union', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .step({ slug: 'a' }, () => 1)
+        .step({ slug: 'b', retriesExhausted: 'skip' }, () => 2)
+        .step({ slug: 'c', dependsOn: ['a', 'b'] }, () => 3);
+
+      type StepSlugs = keyof import('../../src/index.js').ExtractFlowSteps<
+        typeof flow
+      >;
+      expectTypeOf<StepSlugs>().toEqualTypeOf<'a' | 'b' | 'c'>();
+    });
+  });
+
+  describe('dependent map with skippable array source', () => {
+    it('dependent map on skippable array: deps should be optional', () => {
+      const flow = new Flow<{ value: number }>({ slug: 'test' })
+        .array({ slug: 'items', retriesExhausted: 'skip' }, () => [1, 2, 3])
+        .map({ slug: 'double', array: 'items' }, (item) => item * 2)
+        .step({ slug: 'sum', dependsOn: ['double'] }, (deps) => {
+          // The map step itself doesn't have skip, but its source does
+          // This is an interesting edge case - map depends on skippable array
+          // For now, map's own skippability determines its output optionality
+          expectTypeOf(deps.double).toEqualTypeOf<number[]>();
+          return { done: true };
+        });
+
+      type SumInput = StepInput<typeof flow, 'sum'>;
+      expectTypeOf<SumInput>().toEqualTypeOf<{ double: number[] }>();
+    });
+  });
+});

--- a/pkgs/dsl/src/compile-flow.ts
+++ b/pkgs/dsl/src/compile-flow.ts
@@ -62,18 +62,18 @@ function formatRuntimeOptions(options: RuntimeOptions | StepRuntimeOptions): str
     parts.push(`start_delay => ${options.startDelay}`);
   }
 
-  if ('condition' in options && options.condition !== undefined) {
+  if ('if' in options && options.if !== undefined) {
     // Serialize JSON pattern and escape for SQL
-    const jsonStr = JSON.stringify(options.condition);
+    const jsonStr = JSON.stringify(options.if);
     parts.push(`condition_pattern => '${jsonStr}'`);
   }
 
-  if ('whenUnmet' in options && options.whenUnmet !== undefined) {
-    parts.push(`when_unmet => '${options.whenUnmet}'`);
+  if ('else' in options && options.else !== undefined) {
+    parts.push(`when_unmet => '${options.else}'`);
   }
 
-  if ('whenFailed' in options && options.whenFailed !== undefined) {
-    parts.push(`when_failed => '${options.whenFailed}'`);
+  if ('retriesExhausted' in options && options.retriesExhausted !== undefined) {
+    parts.push(`when_failed => '${options.retriesExhausted}'`);
   }
 
   return parts.length > 0 ? `, ${parts.join(', ')}` : '';


### PR DESCRIPTION
# Add Type Safety for Skippable Step Dependencies

This PR enhances the Flow DSL's type system to properly handle skippable steps. When a step has `whenUnmet: 'skip'` or `whenFailed: 'skip'`, dependent steps now receive that step's output as an optional property in their dependencies object.

Key improvements:

- Added a `StepMeta` interface to track both output type and skippability status
- Modified `StepInput` to make dependencies optional when they come from skippable steps
- Added comprehensive type tests to verify correct behavior in various scenarios
- Ensured type narrowing works properly after existence checks

This change improves type safety by preventing runtime errors when accessing potentially undefined outputs from skipped steps. Developers will now get proper TypeScript errors if they try to access properties on skippable dependencies without first checking for their existence.

Example usage:
```typescript
flow.step({ slug: 'risky', whenFailed: 'skip' }, () => ({ result: 42 }))
    .step({ slug: 'dependent', dependsOn: ['risky'] }, (deps) => {
      // TypeScript now requires a null check before accessing properties
      if (deps.risky) {
        return { value: deps.risky.result };
      }
      return { value: 0 };
    });
```