### PR TITLE
feat: improve type safety for flow step outputs and skippable dependencies

### DIFF
--- a/pkgs/core/supabase/tests/condition_evaluation/dependent_step_condition_met.test.sql
+++ b/pkgs/core/supabase/tests/condition_evaluation/dependent_step_condition_met.test.sql
@@ -16,7 +16,7 @@ select pgflow.add_step(
   '{first}',  -- depends on first
   null, null, null, null,  -- default options
   'single',  -- step_type
-  '{"first": {"success": true}}'::jsonb,  -- condition: first.success must be true
+  '{"first": {"success": true}}'::jsonb,  -- if: first.success must be true
   'skip'  -- when_unmet
 );
 

--- a/pkgs/core/supabase/tests/condition_evaluation/dependent_step_condition_unmet_skip.test.sql
+++ b/pkgs/core/supabase/tests/condition_evaluation/dependent_step_condition_unmet_skip.test.sql
@@ -16,7 +16,7 @@ select pgflow.add_step(
   '{first}',  -- depends on first
   null, null, null, null,  -- default options
   'single',  -- step_type
-  '{"first": {"success": true}}'::jsonb,  -- condition: first.success must be true
+  '{"first": {"success": true}}'::jsonb,  -- if: first.success must be true
   'skip'  -- when_unmet
 );
 

--- a/pkgs/core/supabase/tests/condition_evaluation/plain_skip_iterates_until_convergence.test.sql
+++ b/pkgs/core/supabase/tests/condition_evaluation/plain_skip_iterates_until_convergence.test.sql
@@ -25,7 +25,7 @@ select pgflow.add_step(
   '{}',  -- root step
   null, null, null, null,
   'single',
-  '{"enabled": true}'::jsonb,  -- condition: requires enabled=true
+  '{"enabled": true}'::jsonb,  -- if: requires enabled=true
   'skip'  -- plain skip
 );
 select pgflow.add_step(
@@ -34,7 +34,7 @@ select pgflow.add_step(
   '{step_a}',  -- depends on a
   null, null, null, null,
   'single',
-  '{"step_a": {"success": true}}'::jsonb,  -- condition: a.success must be true
+  '{"step_a": {"success": true}}'::jsonb,  -- if: a.success must be true
   'skip'  -- plain skip (won't be met since a was skipped)
 );
 select pgflow.add_step(

--- a/pkgs/core/supabase/tests/condition_evaluation/plain_skip_propagates_to_map.test.sql
+++ b/pkgs/core/supabase/tests/condition_evaluation/plain_skip_propagates_to_map.test.sql
@@ -21,7 +21,7 @@ select pgflow.add_step(
   '{}',  -- root step
   null, null, null, null,  -- default options
   'single',  -- step_type
-  '{"enabled": true}'::jsonb,  -- condition: requires enabled=true
+  '{"enabled": true}'::jsonb,  -- if: requires enabled=true
   'skip'  -- when_unmet - plain skip (not skip-cascade)
 );
 -- Map consumer: no condition, just depends on producer

--- a/pkgs/core/supabase/tests/condition_evaluation/skipped_deps_excluded_from_input.test.sql
+++ b/pkgs/core/supabase/tests/condition_evaluation/skipped_deps_excluded_from_input.test.sql
@@ -27,7 +27,7 @@ select pgflow.add_step(
   '{}',  -- root step
   null, null, null, null,
   'single',
-  '{"enabled": true}'::jsonb,  -- condition: requires enabled=true
+  '{"enabled": true}'::jsonb,  -- if: requires enabled=true
   'skip'  -- plain skip
 );
 select pgflow.add_step(

--- a/pkgs/dsl/src/dsl.ts
+++ b/pkgs/dsl/src/dsl.ts
@@ -494,7 +494,7 @@ export interface StepRuntimeOptions extends RuntimeOptions {
   /**
    * What to do when the 'if' pattern doesn't match the input
    *
-   * @default 'fail'
+   * @default 'skip'
    *
    * @example
    * { else: 'fail' }        // Pattern doesn't match -> step fails -> run fails


### PR DESCRIPTION
# Improved Type Safety for Flow Steps and Skippable Dependencies

This PR enhances the type system for Flow steps and skippable dependencies:

1. Refactored `ExtractFlowSteps` to return step slugs as keys, and introduced a new `StepOutput<>` utility type to get the output type from a specific step.

2. Updated type tests to use the new `StepOutput<>` type for accessing step output types, providing a clearer and more consistent API.

3. Added comprehensive compile-time error tests for skippable dependencies to ensure TypeScript correctly rejects invalid patterns:
   - Direct property access on optional dependencies without null checks
   - Proper handling of dependencies with `whenUnmet: 'skip'` and `retriesExhausted: 'skip'` options
   - Type safety for mixed dependencies (required and optional)
   - Type checking for array and map steps with skip modes

These changes improve the developer experience by providing better type safety and clearer error messages when working with potentially skipped steps in flows.