### PR TITLE
fix: properly pass maxPgConnections config through connection chain

### DIFF
--- a/.changeset/fix-max-pg-connections-config.md
+++ b/.changeset/fix-max-pg-connections-config.md
@@ -1,0 +1,5 @@
+---
+'@pgflow/edge-worker': patch
+---
+
+Fix maxPgConnections config being ignored - now properly passed through the connection chain with default of 4

--- a/pkgs/edge-worker/deno.lock
+++ b/pkgs/edge-worker/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@deno-library/progress@*": "1.5.1",
     "jsr:@henrygd/queue@^1.0.7": "1.2.0",
     "jsr:@oscar6echo/postgres@3.4.5-d": "3.4.5-d",
+    "jsr:@std/assert@*": "0.224.0",
     "jsr:@std/assert@0.224": "0.224.0",
     "jsr:@std/async@0.224": "0.224.2",
     "jsr:@std/crypto@0.224": "0.224.0",
@@ -42,7 +43,7 @@
     "@std/crypto@0.224.0": {
       "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
       "dependencies": [
-        "jsr:@std/assert"
+        "jsr:@std/assert@0.224"
       ]
     },
     "@std/fmt@0.224.0": {
@@ -63,7 +64,7 @@
     "@std/testing@0.224.0": {
       "integrity": "371b8a929aa7132240d5dd766a439be8f780ef5c176ab194e0bcab72370c761e",
       "dependencies": [
-        "jsr:@std/assert"
+        "jsr:@std/assert@0.224"
       ]
     }
   },

--- a/pkgs/edge-worker/src/EdgeWorker.ts
+++ b/pkgs/edge-worker/src/EdgeWorker.ts
@@ -143,6 +143,7 @@ export class EdgeWorker {
     const platform = await createAdapter({
       sql: config.sql,
       connectionString: config.connectionString,
+      maxPgConnections: config.maxPgConnections,
     });
     this.platform = platform;
 
@@ -197,6 +198,7 @@ export class EdgeWorker {
     const platform = await createAdapter({
       sql: config.sql,
       connectionString: config.connectionString,
+      maxPgConnections: config.maxPgConnections,
     });
     this.platform = platform;
 

--- a/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
+++ b/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
@@ -54,7 +54,7 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
   private loggingFactory!: ReturnType<typeof createLoggingFactory>;
 
   constructor(
-    options?: { sql?: postgres.Sql; connectionString?: string },
+    options?: { sql?: postgres.Sql; connectionString?: string; maxPgConnections?: number },
     deps: SupabasePlatformDeps = getPlatformDeps()
   ) {
     this.deps = deps;

--- a/pkgs/edge-worker/src/platform/createAdapter.ts
+++ b/pkgs/edge-worker/src/platform/createAdapter.ts
@@ -7,6 +7,7 @@ import { getPlatformDeps } from './deps.js';
 interface AdapterOptions {
   sql?: postgres.Sql;
   connectionString?: string;
+  maxPgConnections?: number;
 }
 
 /**

--- a/pkgs/edge-worker/src/platform/resolveConnection.ts
+++ b/pkgs/edge-worker/src/platform/resolveConnection.ts
@@ -24,6 +24,7 @@ export interface ConnectionOptions {
 export interface SqlConnectionOptions {
   sql?: postgres.Sql;
   connectionString?: string;
+  maxPgConnections?: number;
 }
 
 /**
@@ -82,19 +83,21 @@ export function resolveSqlConnection(
     return options.sql;
   }
 
+  const max = options?.maxPgConnections ?? 4;
+
   // 2. config.connectionString
   if (options?.connectionString) {
-    return postgres(options.connectionString, { prepare: false, max: 10 });
+    return postgres(options.connectionString, { prepare: false, max });
   }
 
   // 3. EDGE_WORKER_DB_URL
   if (env.EDGE_WORKER_DB_URL) {
-    return postgres(env.EDGE_WORKER_DB_URL, { prepare: false, max: 10 });
+    return postgres(env.EDGE_WORKER_DB_URL, { prepare: false, max });
   }
 
   // 4. Local Supabase detection + docker URL
   if (isLocalSupabaseEnv(env)) {
-    return postgres(DOCKER_TRANSACTION_POOLER_URL, { prepare: false, max: 10 });
+    return postgres(DOCKER_TRANSACTION_POOLER_URL, { prepare: false, max });
   }
 
   throw new Error(

--- a/pkgs/edge-worker/supabase/functions/conn_max_pg_default/index.ts
+++ b/pkgs/edge-worker/supabase/functions/conn_max_pg_default/index.ts
@@ -1,0 +1,20 @@
+import { EdgeWorker } from '@pgflow/edge-worker';
+
+// Tests that default maxPgConnections is 4 (not the old hardcoded 10)
+// NO maxPgConnections specified - should default to 4
+EdgeWorker.start(
+  async (_payload, { sql }) => {
+    const queueName = 'conn_max_pg_default';
+    const actualMax = sql.options.max;
+    const status = actualMax === 4 ? 'success' : 'error';
+    const errorMessage = actualMax === 4 ? null : `Expected max=4, got ${actualMax}`;
+
+    await sql`
+      INSERT INTO e2e_test_results (queue_name, status, actual, error_message)
+      VALUES (${queueName}, ${status}, ${sql.json({ max: actualMax })}, ${errorMessage})
+    `;
+
+    return { max: actualMax };
+  },
+  { queueName: 'conn_max_pg_default' }
+);

--- a/pkgs/edge-worker/supabase/functions/conn_max_pg_override/index.ts
+++ b/pkgs/edge-worker/supabase/functions/conn_max_pg_override/index.ts
@@ -1,0 +1,22 @@
+import { EdgeWorker } from '@pgflow/edge-worker';
+
+// Tests that explicit maxPgConnections: 7 is respected
+EdgeWorker.start(
+  async (_payload, { sql }) => {
+    const queueName = 'conn_max_pg_override';
+    const actualMax = sql.options.max;
+    const status = actualMax === 7 ? 'success' : 'error';
+    const errorMessage = actualMax === 7 ? null : `Expected max=7, got ${actualMax}`;
+
+    await sql`
+      INSERT INTO e2e_test_results (queue_name, status, actual, error_message)
+      VALUES (${queueName}, ${status}, ${sql.json({ max: actualMax })}, ${errorMessage})
+    `;
+
+    return { max: actualMax };
+  },
+  {
+    queueName: 'conn_max_pg_override',
+    maxPgConnections: 7,
+  }
+);

--- a/pkgs/edge-worker/tests/unit/platform/connectionPriority.test.ts
+++ b/pkgs/edge-worker/tests/unit/platform/connectionPriority.test.ts
@@ -219,3 +219,21 @@ Deno.test('resolveSqlConnection - sql takes priority over everything', () => {
   assertEquals(result, mockSql);
   mockSql.end();
 });
+
+// ============================================================
+// maxPgConnections tests
+// ============================================================
+
+Deno.test('resolveSqlConnection - uses default maxPgConnections of 4', () => {
+  const env = { SUPABASE_URL: LOCAL_SUPABASE_URL };
+  const result = resolveSqlConnection(env);
+  assertEquals(result.options.max, 4);
+  result.end();
+});
+
+Deno.test('resolveSqlConnection - respects maxPgConnections override', () => {
+  const env = { SUPABASE_URL: LOCAL_SUPABASE_URL };
+  const result = resolveSqlConnection(env, { maxPgConnections: 7 });
+  assertEquals(result.options.max, 7);
+  result.end();
+});


### PR DESCRIPTION
# Fix maxPgConnections Configuration

This PR fixes an issue where the `maxPgConnections` configuration parameter was being ignored in the edge worker. The parameter is now properly passed through the connection chain with a default value of 4 (previously hardcoded to 10).

## Changes:
- Added `maxPgConnections` parameter to all relevant interfaces and function calls
- Updated the connection resolution logic to use the configured value or default to 4
- Added test functions to verify both default and custom connection limits
- Added unit tests to validate the connection configuration behavior
- Added E2E tests to ensure the configuration is properly applied

This change ensures that users can now properly control the maximum number of PostgreSQL connections used by the edge worker, which is important for resource management and performance tuning.