### PR TITLE
chore: update gitignore and add .ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,12 @@ deno-dist/
 .github/instructions/nx.instructions.md
 config.toml.backup
 sqruff-cli.tar.gz
+
+.opencode
+.ignore
+AGENTS.md
+pkgs/cli/AGENTS.md
+pkgs/client/AGENTS.md
+pkgs/edge-worker/AGENTS.md
+pkgs/website/AGENTS.md
+

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+!.claude
+!.notes


### PR DESCRIPTION
Added `.opencode`, `.ignore`, and `AGENTS.md` files to .gitignore

This PR adds several new entries to the `.gitignore` file:
- `.opencode` directory
- `.ignore` file
- `AGENTS.md` files in the root and various package directories

Additionally, creates a new `.ignore` file that explicitly includes `.claude` and `.notes` files in searches, ensuring they aren't excluded when using tools that respect the `.ignore` file.