### PR TITLE
fix: improve type safety for skip-cascade mode in flow steps

### DIFF
--- a/pkgs/core/supabase/tests/condition_evaluation/ifnot_empty_object_absent_dep.test.sql
+++ b/pkgs/core/supabase/tests/condition_evaluation/ifnot_empty_object_absent_dep.test.sql
@@ -1,0 +1,59 @@
+-- Test: ifNot empty object pattern - step runs when dependency is absent/skipped
+--
+-- Verifies that ifNot: { dep: {} } (empty object pattern) correctly detects
+-- when a dependency is absent (skipped) and causes the fallback step to run.
+--
+-- PostgreSQL containment semantics:
+-- - When dep is skipped, deps_output is {} (empty object)
+-- - {} @> { dep: {} } = FALSE (empty object doesn't contain dep key)
+-- - NOT(FALSE) = TRUE, so ifNot condition is met -> step runs
+begin;
+select plan(2);
+
+select pgflow_tests.reset_db();
+
+-- Create flow: skippable_dep -> fallback (with ifNot: { skippable_dep: {} })
+select pgflow.create_flow('empty_pattern_test');
+
+-- Step A: Skippable based on input pattern
+select pgflow.add_step(
+  flow_slug => 'empty_pattern_test',
+  step_slug => 'skippable_dep',
+  required_input_pattern => '{"run_dep": true}'::jsonb,
+  when_unmet => 'skip'
+);
+
+-- Step B: Fallback - runs when A is absent (empty object pattern)
+select pgflow.add_step(
+  flow_slug => 'empty_pattern_test',
+  step_slug => 'fallback',
+  deps_slugs => ARRAY['skippable_dep'],
+  forbidden_input_pattern => '{"skippable_dep": {}}'::jsonb,
+  when_unmet => 'skip'
+);
+
+-- Start flow with input that causes dep to skip (run_dep: false)
+with flow as (
+  select * from pgflow.start_flow('empty_pattern_test', '{"run_dep": false}'::jsonb)
+)
+select run_id into temporary run_ids from flow;
+
+-- Test 1: skippable_dep should be skipped
+select is(
+  (select status from pgflow.step_states
+   where run_id = (select run_id from run_ids) and step_slug = 'skippable_dep'),
+  'skipped',
+  'Dependency with unmet condition should be skipped'
+);
+
+-- Test 2: fallback should be started (empty object pattern matched -> ifNot passed)
+select is(
+  (select status from pgflow.step_states
+   where run_id = (select run_id from run_ids) and step_slug = 'fallback'),
+  'started',
+  'Step with ifNot: {dep: {}} should start when dep is absent'
+);
+
+drop table if exists run_ids;
+select finish();
+rollback;


### PR DESCRIPTION
# Improved Type Safety for Skip-Cascade Dependencies

This PR fixes a type safety issue with the `skip-cascade` mode in our Flow DSL. Previously, dependencies with `whenUnmet: 'skip-cascade'` or `retriesExhausted: 'skip-cascade'` were incorrectly marked as optional for dependent steps.

The key insight is that with `skip-cascade`, if a step is skipped, its dependents are also skipped at runtime. This means that if a dependent handler runs at all, the parent step must have succeeded, and therefore the dependency should be required, not optional.

Changes:
- Replaced the boolean `skippable` flag with a more precise `SkippableMode` type (`'skip'` | `'skip-cascade'` | `false`)
- Updated type helpers to only make dependencies optional when the mode is specifically `'skip'` (not `'skip-cascade'`)
- Fixed test cases to reflect the correct behavior
- Added clarifying comments explaining the distinction between the two skipping modes

This change improves type safety by preventing unnecessary null checks for dependencies that are guaranteed to exist when using `skip-cascade`.