### PR TITLE
fix: remove postinstall chmod that breaks Windows npm install

### DIFF
--- a/pkgs/cli/package.json
+++ b/pkgs/cli/package.json
@@ -38,7 +38,5 @@
   "files": [
     "dist"
   ],
-  "scripts": {
-    "postinstall": "chmod +x dist/index.js || true"
-  }
+  "scripts": {}
 }


### PR DESCRIPTION
npm automatically sets the executable bit on files declared in the `bin` field when installing a package, making the `chmod +x` in postinstall redundant. The script also broke on Windows since `chmod` and `true` are not available in cmd.exe.

Closes #610