### PR TITLE
docs: add self-hosted Supabase deployment guide

### DIFF
--- a/pkgs/website/src/content/docs/deploy/database-connection.mdx
+++ b/pkgs/website/src/content/docs/deploy/database-connection.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 110
 ---
 
-import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 pgflow auto-detects your database connection in local development and requires minimal configuration for production. This guide explains how connection detection works and how to configure it for different environments.
 
@@ -13,17 +13,19 @@ pgflow auto-detects your database connection in local development and requires m
 
 When an Edge Worker starts, pgflow resolves the database connection using this priority chain:
 
-| Priority | Source | Use Case |
-|----------|--------|----------|
-| 1 | `config.sql` | Full postgres.js control (SSL, custom options) |
-| 2 | `config.connectionString` | Custom connection URL |
-| 3 | `EDGE_WORKER_DB_URL` | Production environment variable |
-| 4 | Local fallback | Supabase local development (automatic) |
+| Priority | Source                    | Use Case                                       |
+| -------- | ------------------------- | ---------------------------------------------- |
+| 1        | `config.sql`              | Full postgres.js control (SSL, custom options) |
+| 2        | `config.connectionString` | Custom connection URL                          |
+| 3        | `EDGE_WORKER_DB_URL`      | Production environment variable                |
+| 4        | Local fallback            | Supabase local development (automatic)         |
 
 If none of these are available, the worker throws an error: `"No database connection available"`.
 
 <Aside type="note" title="Explicit config wins">
-Providing `config.sql`, `config.connectionString`, or `EDGE_WORKER_DB_URL` **skips the automatic local connection**. The local fallback only applies when no explicit configuration is provided.
+  Providing `config.sql`, `config.connectionString`, or `EDGE_WORKER_DB_URL`
+  **skips the automatic local connection**. The local fallback only applies when
+  no explicit configuration is provided.
 </Aside>
 
 ## Local Development
@@ -31,15 +33,18 @@ Providing `config.sql`, `config.connectionString`, or `EDGE_WORKER_DB_URL` **ski
 When running locally with `supabase start`, pgflow automatically connects to your database without any configuration needed.
 
 ```typescript title="supabase/functions/my-worker/index.ts"
-import { EdgeWorker } from "@pgflow/edge-worker";
-import { MyFlow } from "../../flows/index.ts";
+import { EdgeWorker } from '@pgflow/edge-worker';
+import { MyFlow } from '../../flows/index.ts';
 
 // Just works locally - no config needed!
 EdgeWorker.start(MyFlow);
 ```
 
 <Aside type="note" title="How local connections work">
-pgflow recognizes local Supabase environments by checking for known local dev credentials in environment variables. When running locally, it connects to the Docker pooler at `postgresql://postgres.localhost:postgres@127.0.0.1:54329/postgres`.
+  pgflow recognizes local Supabase environments by checking for known local dev
+  credentials in environment variables. When running locally, it connects to the
+  Docker pooler at
+  `postgresql://postgres.localhost:postgres@127.0.0.1:54329/postgres`.
 </Aside>
 
 ## Production Deployment
@@ -50,11 +55,18 @@ For production, set the `EDGE_WORKER_DB_URL` secret in your Supabase project:
 npx supabase secrets set EDGE_WORKER_DB_URL="postgresql://postgres.pooler-yourproject:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 ```
 
+<Aside type="note" title="Self-hosted Supabase">
+  Self-hosted instances do not auto-configure `EDGE_WORKER_DB_URL`. You must set
+  it explicitly in your Edge Function environment. See the [Self-Hosted Supabase
+  guide](/deploy/supabase/self-hosted/) for the connection string format for
+  your pooler.
+</Aside>
+
 Your worker code stays the same - pgflow automatically uses the environment variable when not in local development:
 
 ```typescript title="supabase/functions/my-worker/index.ts"
-import { EdgeWorker } from "@pgflow/edge-worker";
-import { MyFlow } from "../../flows/index.ts";
+import { EdgeWorker } from '@pgflow/edge-worker';
+import { MyFlow } from '../../flows/index.ts';
 
 // Uses EDGE_WORKER_DB_URL in production
 EdgeWorker.start(MyFlow);
@@ -69,11 +81,11 @@ See [Get Connection String](/deploy/supabase/get-connection-string/) for how to 
 If you need to use a custom connection URL (different from `EDGE_WORKER_DB_URL`), pass it via `config.connectionString`:
 
 ```typescript title="supabase/functions/my-worker/index.ts"
-import { EdgeWorker } from "@pgflow/edge-worker";
-import { MyFlow } from "../../flows/index.ts";
+import { EdgeWorker } from '@pgflow/edge-worker';
+import { MyFlow } from '../../flows/index.ts';
 
 EdgeWorker.start(MyFlow, {
-  connectionString: Deno.env.get("MY_CUSTOM_DB_URL"),
+  connectionString: Deno.env.get('MY_CUSTOM_DB_URL'),
 });
 ```
 
@@ -82,14 +94,14 @@ EdgeWorker.start(MyFlow, {
 For advanced scenarios requiring SSL certificates or other postgres.js settings, create the SQL client yourself and pass it via `config.sql`. Note that `prepare: false` is required when using a transaction pooler:
 
 ```typescript title="supabase/functions/my-worker/index.ts" {6}
-import { EdgeWorker } from "@pgflow/edge-worker";
-import postgres from "postgres";
-import { MyFlow } from "../../flows/index.ts";
+import { EdgeWorker } from '@pgflow/edge-worker';
+import postgres from 'postgres';
+import { MyFlow } from '../../flows/index.ts';
 
-const sql = postgres(Deno.env.get("DATABASE_URL")!, {
+const sql = postgres(Deno.env.get('DATABASE_URL')!, {
   prepare: false, // Required for transaction pooling
   connection: {
-    application_name: "my-flow-worker", // Visible in pg_stat_activity
+    application_name: 'my-flow-worker', // Visible in pg_stat_activity
   },
 });
 
@@ -103,12 +115,12 @@ See [Database SSL](/deploy/database-ssl/) for SSL configuration examples.
 If you need to connect to a different database during local development (e.g., a remote staging database), provide an explicit configuration:
 
 ```typescript title="supabase/functions/my-worker/index.ts"
-import { EdgeWorker } from "@pgflow/edge-worker";
-import { MyFlow } from "../../flows/index.ts";
+import { EdgeWorker } from '@pgflow/edge-worker';
+import { MyFlow } from '../../flows/index.ts';
 
 // Skips automatic local connection, uses custom URL instead
 EdgeWorker.start(MyFlow, {
-  connectionString: Deno.env.get("STAGING_DB_URL"),
+  connectionString: Deno.env.get('STAGING_DB_URL'),
 });
 ```
 

--- a/pkgs/website/src/content/docs/deploy/index.mdx
+++ b/pkgs/website/src/content/docs/deploy/index.mdx
@@ -11,9 +11,14 @@ Learn how to deploy pgflow to production, monitor workflow execution, and mainta
 
 <CardGrid>
   <LinkCard
-    title="Deploy to Supabase"
+    title="Supabase.com"
     href="/deploy/supabase/"
     description="Step-by-step guide to deploying pgflow workers to Supabase.com production"
+  />
+  <LinkCard
+    title="Self-Hosted Supabase"
+    href="/deploy/supabase/self-hosted/"
+    description="Deploy pgflow on self-hosted Supabase instances running on your own infrastructure"
   />
 </CardGrid>
 

--- a/pkgs/website/src/content/docs/deploy/supabase/index.mdx
+++ b/pkgs/website/src/content/docs/deploy/supabase/index.mdx
@@ -5,11 +5,24 @@ sidebar:
   order: 0
 ---
 
-import { Steps, LinkButton, Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
+import {
+  Steps,
+  LinkButton,
+  Card,
+  CardGrid,
+  LinkCard,
+  Aside,
+} from '@astrojs/starlight/components';
 
 This guide walks you through deploying pgflow workers to Supabase.com. Workers run as Edge Functions that poll for tasks, execute your flow handlers, and report results back to the database.
 
 Before starting, ensure you have completed [Getting Started](/get-started/installation/) and have a Supabase project linked to your local environment.
+
+<Aside type="tip" title="Self-hosted Supabase?">
+  Running Supabase on your own infrastructure? See the [Self-Hosted Supabase
+  guide](/deploy/supabase/self-hosted/) for specific setup instructions
+  including Postgres image upgrades and database connection configuration.
+</Aside>
 
 ## Deployment Overview
 

--- a/pkgs/website/src/content/docs/deploy/supabase/self-hosted.mdx
+++ b/pkgs/website/src/content/docs/deploy/supabase/self-hosted.mdx
@@ -1,0 +1,136 @@
+---
+title: Self-Hosted Supabase
+description: Deploy pgflow on self-hosted Supabase instances running on your own infrastructure
+sidebar:
+  order: 50
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+:::note[Acknowledgments]
+This guide is based on community feedback in [GitHub Issue #616](https://github.com/pgflow-dev/pgflow/issues/616).
+:::
+
+This guide covers running pgflow on self-hosted Supabase instances. Self-hosted deployments differ from Supabase.com in several ways this guide addresses.
+
+## Requirements
+
+Before running pgflow on self-hosted Supabase, ensure you have:
+
+- **pgmq 1.5.0+** - Required for pgflow. May require upgrading your Supabase Postgres image.
+- **Connection pooler enabled** - Supavisor must be running and accessible to Edge Functions.
+- **Manual pgflow setup** - Since the Supabase CLI doesn't work with self-hosted, follow the [Manual Installation guide](/reference/manual-installation/) to set up migrations and functions.
+
+## Upgrade Postgres Image
+
+The default Supabase docker image may ship with an older pgmq version. If you see errors related to missing `pgmq` functions after installing pgflow migrations, upgrade your Postgres image.
+
+In your `docker/docker-compose.yml`, update the `db` service image:
+
+```yaml
+db:
+  image: supabase/postgres:15.14.1.098
+```
+
+<Aside type="tip">
+  A known working version for the 15.x branch is `15.14.1.098`. PostgreSQL 17 is
+  also supported (v17.6.1.100 or later).
+</Aside>
+
+After updating, restart your containers:
+
+```bash frame="none"
+docker compose down
+docker compose up -d
+```
+
+## Database Connection
+
+Self-hosted Supabase does not auto-configure `EDGE_WORKER_DB_URL`. You must set this environment variable explicitly on your Edge Functions.
+
+The connection string format for self-hosted Supabase:
+
+```bash frame="none"
+EDGE_WORKER_DB_URL=postgresql://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@supavisor:${POOLER_PROXY_PORT_TRANSACTION}/postgres
+```
+
+Where:
+
+- `POOLER_TENANT_ID` - Your pooler tenant ID (set in your `.env` file)
+- `POSTGRES_PASSWORD` - Your Postgres password
+- `POOLER_PROXY_PORT_TRANSACTION` - The transaction pooler port (default: `6543`)
+
+<Aside type="note">
+  The hostname is `supavisor` (not `pooler` which is used by the Supabase CLI
+  local development environment).
+</Aside>
+
+Set this environment variable in your Edge Function deployment configuration. See [Database Connection](/deploy/database-connection/) for all connection options including SSL configuration.
+
+## Function Deployment
+
+The Supabase CLI is designed for Supabase.com and local development. For self-hosted deployments, deploy Edge Functions manually:
+
+<Steps>
+1. Copy your function directories to `./volumes/functions/` in your Supabase project
+
+2. Mount the volumes in your `docker-compose.yml` under the `functions` service
+
+3. Ensure your flows are also accessible (either in the functions volume or a separate mounted volume)
+
+4. Restart the Edge Functions container
+</Steps>
+
+### Docker Compose Changes
+
+Apply these changes to your `docker/docker-compose.yml`:
+
+```diff
+--- a/docker-compose.yaml
++++ b/docker-compose.yaml
+@@ -420,6 +420,7 @@ services:
+     restart: unless-stopped
+     volumes:
+       - ./volumes/functions:/home/deno/functions:Z
++      - ./volumes/flows:/home/deno/flows:Z
+       - deno-cache:/root/.cache/deno
+     depends_on:
+       kong:
+@@ -438,6 +439,8 @@ services:
+       SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+       # TODO: Allow configuring VERIFY_JWT per function.
+       VERIFY_JWT: "${FUNCTIONS_VERIFY_JWT}"
++      # Allow pgflow workers to resolve pg connections via supavisor
++      EDGE_WORKER_DB_URL: postgresql://postgres.${POOLER_TENANT_ID}:${POSTGRES_PASSWORD}@supavisor:${POOLER_PROXY_PORT_TRANSACTION}/postgres
+     command:
+       [
+@@ -495,7 +498,7 @@ services:
+   # Comment out everything below this point if you are using an external Postgres database
+   db:
+     container_name: supabase-db
+-    image: supabase/postgres:15.8.1.085
++    image: supabase/postgres:15.14.1.098
+     restart: unless-stopped
+```
+
+Key changes:
+
+- **flows volume** - Mount your flows directory so Edge Functions can access them
+- **EDGE_WORKER_DB_URL** - Set the database connection string for pgflow workers
+- **postgres image** - Upgrade to a version with pgmq 1.5.0+
+
+## Running Migrations
+
+When applying pgflow migrations to a self-hosted database, you may need to bypass SSL verification:
+
+```bash frame="none"
+PGSSLMODE=disable npx supabase migrations up --db-url $DB_URL
+```
+
+Where `DB_URL` is your direct Postgres connection string (not the pooler URL).
+
+## See Also
+
+- [Database Connection](/deploy/database-connection/) - Connection configuration options
+- [Database SSL](/deploy/database-ssl/) - SSL configuration for production
+- [Update pgflow](/deploy/update-pgflow/) - Upgrading pgflow on self-hosted

--- a/pkgs/website/src/content/docs/reference/manual-installation.mdx
+++ b/pkgs/website/src/content/docs/reference/manual-installation.mdx
@@ -5,19 +5,19 @@ sidebar:
   order: 100
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-This guide explains how to manually set up pgflow and Edge Worker without using the automatic installer. While we recommend using the `pgflow install` command for most users, this manual approach can be helpful in certain scenarios:
+This guide explains how to manually set up pgflow without using the automatic installer. This manual approach is required for self-hosted Supabase deployments since the Supabase CLI only works with Supabase.com and local development.
 
-- When you need more control over the installation process
-- When troubleshooting installation issues
-- When integrating with custom deployment pipelines
-- When you want to understand what happens behind the scenes
+This guide is also helpful when:
 
-<Aside type="caution" title="Prerequisites">
-- Supabase CLI version **2.50.3** or higher (check with `supabase -v`)
-- A local Supabase project set up
-- Basic understanding of Supabase configuration
+- Troubleshooting installation issues
+- Integrating with custom deployment pipelines
+- You want to understand what happens behind the scenes
+
+<Aside type="note" title="Prerequisites">
+  - Access to your self-hosted Supabase deployment via direct database
+  connection - Basic understanding of your Supabase configuration
 </Aside>
 
 ## Manual Installation Steps
@@ -38,6 +38,7 @@ To manually install the required migration files:
 Copy files from the extracted archive's `pkgs/core/supabase/migrations/*.sql` to your project's `supabase/migrations/` folder.
 
 **Important:** Rename each migration file with a timestamp that comes after your latest existing migration. The format is `YYYYMMDDHHmmss_originalname.sql`. For example, if your latest migration is `20250101120000_create_users.sql`, rename the pgflow migrations to:
+
 - `20250101120001_001_install_pgmq.sql`
 - `20250101120002_002_create_pgflow_schema.sql`
 - etc.
@@ -46,11 +47,14 @@ This ensures pgflow migrations run after your existing migrations in the correct
 
 **Apply the migrations**
 
-After copying the migration files, apply them:
+After copying the migration files, apply them using your direct database connection:
 
 ```bash frame="none"
-npx supabase migration up
+psql $DATABASE_URL -f supabase/migrations/your_timestamp_001_install_pgmq.sql
+psql $DATABASE_URL -f supabase/migrations/your_timestamp_002_create_pgflow_schema.sql
 ```
+
+Or use your preferred database migration tool.
 
 :::note
 The installation process is exactly the same whether you're using Edge Worker or pgflow, as pgflow builds on top of Edge Worker and the migration files include everything needed for both.
@@ -86,16 +90,16 @@ Function early termination. This will change in the future.
 Change the Edge Runtime policy to `per_worker` to enable
 Background Tasks (see more in [Testing background tasks locally](https://supabase.com/docs/guides/functions/background-tasks#testing-background-tasks-locally)).
 
-  ```diff lang="toml"
-    [edge_runtime]
-    enabled = true
-    # Configure one of the supported request policies: `oneshot`, `per_worker`.
-    # Use `oneshot` for hot reload, or `per_worker` for load testing.
-  - policy = "oneshot"
-  + policy = "per_worker"
-    # Port to attach the Chrome inspector for debugging edge functions.
-    inspector_port = 8083
-  ```
+```diff lang="toml"
+  [edge_runtime]
+  enabled = true
+  # Configure one of the supported request policies: `oneshot`, `per_worker`.
+  # Use `oneshot` for hot reload, or `per_worker` for load testing.
+- policy = "oneshot"
++ policy = "per_worker"
+  # Port to attach the Chrome inspector for debugging edge functions.
+  inspector_port = 8083
+```
 
 ### 4. Create flows directory
 
@@ -137,49 +141,9 @@ Create `supabase/flows/index.ts` to export your flows:
 export { GreetUser } from './greet-user.ts';
 ```
 
-### 5. Create Control Plane edge function
+### 5. Create example worker
 
-The Control Plane is an edge function that registers and serves your flows.
-
-Create the directory:
-
-```bash frame="none"
-mkdir -p supabase/functions/pgflow
-```
-
-Create `supabase/functions/pgflow/index.ts`:
-
-```typescript title="supabase/functions/pgflow/index.ts"
-import { ControlPlane } from '@pgflow/edge-worker';
-import * as flows from '../../flows/index.ts';
-
-ControlPlane.serve(flows);
-```
-
-Create `supabase/functions/pgflow/deno.json` with the pgflow package imports (replace `VERSION` with your desired version):
-
-```json title="supabase/functions/pgflow/deno.json"
-{
-  "imports": {
-    "@pgflow/core": "npm:@pgflow/core@VERSION",
-    "@pgflow/core/": "npm:@pgflow/core@VERSION/",
-    "@pgflow/dsl": "npm:@pgflow/dsl@VERSION",
-    "@pgflow/dsl/": "npm:@pgflow/dsl@VERSION/",
-    "@pgflow/dsl/supabase": "npm:@pgflow/dsl@VERSION/supabase",
-    "@pgflow/edge-worker": "jsr:@pgflow/edge-worker@VERSION",
-    "@pgflow/edge-worker/": "jsr:@pgflow/edge-worker@VERSION/",
-    "@pgflow/edge-worker/_internal": "jsr:@pgflow/edge-worker@VERSION/_internal"
-  }
-}
-```
-
-:::tip[Finding the latest version]
-Check the [pgflow releases page](https://github.com/pgflow-dev/pgflow/releases) for the latest version number.
-:::
-
-### 6. Create example worker
-
-The worker executes the tasks defined in your flows.
+The worker executes the tasks defined in your flows. Workers use auto-compilation to build flows from files in the mounted flows directory.
 
 Create the directory:
 
@@ -195,6 +159,8 @@ import { GreetUser } from '../../flows/greet-user.ts';
 
 EdgeWorker.start(GreetUser);
 ```
+
+The worker imports your flow directly and uses auto-compilation to build it at startup.
 
 Create `supabase/functions/greet-user-worker/deno.json` with the same imports (replace `VERSION` with your desired version):
 
@@ -213,13 +179,16 @@ Create `supabase/functions/greet-user-worker/deno.json` with the same imports (r
 }
 ```
 
-### 7. Restart Supabase
+:::tip[Finding the latest version]
+Check the [pgflow releases page](https://github.com/pgflow-dev/pgflow/releases) for the latest version number.
+:::
 
-To apply the changes, restart Supabase:
+### 6. Restart Edge Runtime
+
+To apply the changes, restart your Edge Functions container:
 
 ```bash frame="none"
-npx supabase stop
-npx supabase start
+docker compose restart functions
 ```
 
 ## What gets installed
@@ -227,19 +196,22 @@ npx supabase start
 When following these steps, the installation sets up:
 
 **Database (via migrations):**
+
 - `pgflow` schema with tables for flows, execution state, and worker management
 - `pgmq` schema for message queuing
 - SQL functions for worker lifecycle management and flow operations
 
 **Configuration:**
+
 - Connection pooler enabled with transaction mode
 - Edge runtime policy set to `per_worker`
 
 **Edge Functions:**
-- Control Plane (`supabase/functions/pgflow/`) - registers and serves your flows
-- Example worker (`supabase/functions/greet-user-worker/`) - executes flow tasks
+
+- Example worker (`supabase/functions/greet-user-worker/`) - executes flow tasks with auto-compilation
 
 **Flow definitions:**
+
 - Flows directory (`supabase/flows/`) with example GreetUser flow
 
 ## What's the difference?
@@ -250,10 +222,10 @@ The manual installation process performs the same steps as the automatic `pgflow
 2. Updates your `config.toml` file (pooler + edge runtime settings)
 3. Copies the migration files with proper timestamps
 4. Creates the flows directory with example flow
-5. Creates the Control Plane edge function
-6. Creates the example worker edge function
+5. Creates the example worker edge function
 
 The automatic installer also:
+
 - Checks if each component is already installed to avoid duplicates
 - Creates backups before modifying existing files
 - Uses the current pgflow version for package imports


### PR DESCRIPTION
This pull request adds documentation for deploying pgflow on self-hosted Supabase instances. The changes include:

- Added a new self-hosted Supabase deployment guide covering Postgres image upgrades, database connection configuration, and manual Edge Function deployment
- Updated the deployment index page to include a link to the self-hosted guide alongside the existing Supabase.com guide
- Enhanced the database connection documentation with a note about self-hosted instances requiring explicit `EDGE_WORKER_DB_URL` configuration
- Added cross-references between the main Supabase deployment guide and the new self-hosted guide
- Standardized quote usage from double quotes to single quotes throughout the affected documentation files

The new guide addresses key differences in self-hosted deployments including the need for pgmq 1.5.0+, manual environment variable configuration, and alternative deployment methods since the Supabase CLI only works with Supabase.com.