### PR TITLE
chore: add `.coi/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ pkgs/client/AGENTS.md
 pkgs/edge-worker/AGENTS.md
 pkgs/website/AGENTS.md
 
+
+.coi/


### PR DESCRIPTION
Adds `.coi/` directory to `.gitignore` to prevent it from being tracked by version control.