### PR TITLE
chore: update `.gitignore` to fix `.coi` and add `.local`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ pkgs/edge-worker/AGENTS.md
 pkgs/website/AGENTS.md
 
 
-.coi/
+.coi
+.local


### PR DESCRIPTION
Adds `.local` to `.gitignore` and removes the trailing slash from the `.coi` entry.