### PR TITLE
feat: publish `@pgflow/edge-worker` to npm with Node/Bun process runtime support

### DIFF
--- a/.changeset/portable-edge-worker-npm.md
+++ b/.changeset/portable-edge-worker-npm.md
@@ -1,0 +1,9 @@
+---
+"@pgflow/core": minor
+"@pgflow/dsl": minor
+"@pgflow/client": minor
+"@pgflow/edge-worker": minor
+"pgflow": minor
+---
+
+Publish `@pgflow/edge-worker` to npm and add Node/Bun process runtime support.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "build": "nx run-many --target=build --all",
     "version": "pnpm changeset version && ./scripts/update-jsr-json-version.sh",
-    "validate:publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && git status && pnpm publish --dry-run --provenance --recursive --filter=!./pkgs/edge-worker",
+    "smoke:edge-worker:dist": "pnpm nx build edge-worker && node ./scripts/smoke-edge-worker-dist.mjs",
+    "validate:publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm smoke:edge-worker:dist && git status && pnpm publish --dry-run --provenance --recursive",
     "validate:publish:jsr": "cd ./pkgs/edge-worker && jsr publish --dry-run --allow-slow-types",
     "validate:publish": "pnpm run validate:publish:npm && pnpm run validate:publish:jsr",
-    "publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm publish --provenance --recursive --filter=!./pkgs/edge-worker",
+    "publish:npm": "pnpm nx run-many -t build --exclude=demo,website,example-flows && pnpm publish --provenance --recursive",
     "publish:jsr": "cd ./pkgs/edge-worker && jsr publish --allow-slow-types",
     "changeset:tag": "pnpm changeset tag && git push --follow-tags",
     "release": "git status && pnpm run validate:publish && pnpm run publish:npm && pnpm run publish:jsr && pnpm run changeset:tag"

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -8,11 +8,9 @@
       "executor": "nx:noop"
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build"]
-    },
-    "_build_disabled": {
       "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "dependsOn": ["^build"],
       "options": {
         "outputPath": "pkgs/edge-worker/dist",
         "main": "pkgs/edge-worker/src/index.ts",

--- a/pkgs/edge-worker/src/control-plane/index.ts
+++ b/pkgs/edge-worker/src/control-plane/index.ts
@@ -8,7 +8,7 @@
  * ```typescript
  * // Using namespace import (recommended)
  * import { ControlPlane } from '@pgflow/edge-worker';
- * import * as flows from '../../flows/index.ts';
+ * import * as flows from '../../flows/index.js';
  *
  * ControlPlane.serve(flows);
  * ```
@@ -17,7 +17,7 @@
  * ```typescript
  * // Using array (legacy)
  * import { ControlPlane } from '@pgflow/edge-worker';
- * import { MyFlow } from '../../flows/my_flow.ts';
+ * import { MyFlow } from '../../flows/my_flow.js';
  *
  * ControlPlane.serve([MyFlow]);
  * ```

--- a/pkgs/edge-worker/src/platform/processDeps.ts
+++ b/pkgs/edge-worker/src/platform/processDeps.ts
@@ -21,7 +21,7 @@ type CryptoLike = {
 
 export function getProcessDeps(): ProcessDeps {
   const processLike = (globalThis as { process?: ProcessLike }).process;
-  const cryptoLike = globalThis.crypto as CryptoLike | undefined;
+  const cryptoLike = (globalThis as { crypto?: CryptoLike }).crypto;
 
   if (!processLike?.env || !processLike.on || !processLike.exit || !cryptoLike?.randomUUID) {
     throw new Error('Process runtime is not available');

--- a/pkgs/edge-worker/src/platform/resolveConnection.ts
+++ b/pkgs/edge-worker/src/platform/resolveConnection.ts
@@ -1,4 +1,4 @@
-import { isLocalSupabaseEnv } from '../shared/localDetection.ts';
+import { isLocalSupabaseEnv } from '../shared/localDetection.js';
 import postgres from 'postgres';
 
 /**

--- a/pkgs/edge-worker/src/shared/authValidation.ts
+++ b/pkgs/edge-worker/src/shared/authValidation.ts
@@ -1,5 +1,18 @@
-import { timingSafeEqual } from '@std/crypto/timing-safe-equal';
-import { isLocalSupabaseEnv } from './localDetection.ts';
+import { isLocalSupabaseEnv } from './localDetection.js';
+
+function timingSafeEqualBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let diff = 0;
+
+  for (let index = 0; index < a.length; index += 1) {
+    diff |= a[index] ^ b[index];
+  }
+
+  return diff === 0;
+}
 
 export interface AuthValidationResult {
   valid: boolean;
@@ -38,12 +51,7 @@ export function validateServiceRoleAuth(
   const authBytes = encoder.encode(authHeader);
   const expectedBytes = encoder.encode(expected);
 
-  // Length check first (timingSafeEqual requires same length)
-  if (authBytes.length !== expectedBytes.length) {
-    return { valid: false, error: 'Invalid Authorization header' };
-  }
-
-  if (!timingSafeEqual(authBytes, expectedBytes)) {
+  if (!timingSafeEqualBytes(authBytes, expectedBytes)) {
     return { valid: false, error: 'Invalid Authorization header' };
   }
 

--- a/pkgs/edge-worker/tsconfig.json
+++ b/pkgs/edge-worker/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "lib": ["es2022", "dom", "dom.iterable"],
     "typeRoots": ["./node_modules/@types", "."],
     "types": [
       "node",

--- a/scripts/smoke-edge-worker-dist.mjs
+++ b/scripts/smoke-edge-worker-dist.mjs
@@ -1,0 +1,25 @@
+import * as edgeWorker from '../pkgs/edge-worker/dist/index.js';
+import * as internal from '../pkgs/edge-worker/dist/_internal.js';
+import * as testing from '../pkgs/edge-worker/dist/testing.js';
+
+const requiredExports = [
+  ['EdgeWorker', edgeWorker.EdgeWorker],
+  ['createQueueWorker', edgeWorker.createQueueWorker],
+  ['createFlowWorker', edgeWorker.createFlowWorker],
+  ['ProcessPlatformAdapter', edgeWorker.ProcessPlatformAdapter],
+  ['SupabasePlatformAdapter', edgeWorker.SupabasePlatformAdapter],
+];
+
+for (const [name, value] of requiredExports) {
+  if (value === undefined) {
+    throw new Error(`Missing edge-worker export: ${name}`);
+  }
+}
+
+if (Object.keys(internal).length === 0) {
+  throw new Error('Expected _internal export surface to load');
+}
+
+if (Object.keys(testing).length === 0) {
+  throw new Error('Expected testing export surface to load');
+}


### PR DESCRIPTION
`@pgflow/edge-worker` is now published to npm alongside the other pgflow packages. Previously it was excluded from npm publishing and only released to JSR.

To support npm distribution, the following changes were made:

- The TypeScript build target for `edge-worker` is now active, compiling sources to `dist/` via `@nx/js:tsc`
- Import paths updated from `.ts` to `.js` extensions for compatibility with compiled output
- Replaced the `@std/crypto/timing-safe-equal` Deno dependency with an inline `timingSafeEqualBytes` implementation, removing the Deno-specific dependency and enabling Node/Bun compatibility
- `globalThis.crypto` access updated to avoid TypeScript strict-mode errors in non-browser environments
- TypeScript config updated to include `es2022`, `dom`, and `dom.iterable` libs
- A smoke test script (`scripts/smoke-edge-worker-dist.mjs`) was added to verify the built `dist/` exports are valid before publishing
- The `validate:publish:npm` and `publish:npm` scripts now include `edge-worker` and run the smoke test as part of the publish flow