### PR TITLE
ci: add edge-worker Bun smoke test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,41 @@ jobs:
         if: steps.check.outputs.affected == 'true'
         run: pnpm nx run edge-worker:test:integration
 
-  # ─────────────────────────────────────── 2b. CLI E2E ──────────────────────────────────────
+  # ─────────────────────────────────────── 2b. EDGE-WORKER BUN SMOKE ──────────────────────────────────────
+  edge-worker-bun-smoke:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          atlas-cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check if edge-worker is affected
+        id: check
+        run: |
+          if pnpm nx show projects --affected --base=origin/main --head=HEAD | grep -q "^edge-worker$"; then
+            echo "affected=true" >> $GITHUB_OUTPUT
+            echo "edge-worker is affected, running Bun smoke"
+          else
+            echo "affected=false" >> $GITHUB_OUTPUT
+            echo "edge-worker not affected, skipping Bun smoke"
+          fi
+
+      - name: Run edge-worker Bun smoke
+        if: steps.check.outputs.affected == 'true'
+        run: pnpm nx run edge-worker:smoke:bun
+
+  # ─────────────────────────────────────── 2c. CLI E2E ──────────────────────────────────────
   cli-e2e:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
@@ -208,7 +242,7 @@ jobs:
         if: steps.check.outputs.affected == 'true'
         run: pnpm nx run cli:e2e
 
-  # ─────────────────────────────────────── 2c. CLIENT E2E ──────────────────────────────────────
+  # ─────────────────────────────────────── 2d. CLIENT E2E ──────────────────────────────────────
   client-e2e:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
@@ -244,7 +278,7 @@ jobs:
         if: steps.check.outputs.affected == 'true'
         run: pnpm nx run client:e2e
 
-  # ─────────────────────────────────────── 2d. CORE PGTAP ──────────────────────────────────────
+  # ─────────────────────────────────────── 2e. CORE PGTAP ──────────────────────────────────────
   core-pgtap:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
@@ -288,6 +322,7 @@ jobs:
         build-and-test,
         edge-worker-e2e,
         edge-worker-integration,
+        edge-worker-bun-smoke,
         cli-e2e,
         client-e2e,
         core-pgtap,
@@ -340,6 +375,7 @@ jobs:
         build-and-test,
         edge-worker-e2e,
         edge-worker-integration,
+        edge-worker-bun-smoke,
         cli-e2e,
         client-e2e,
         core-pgtap,

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -152,6 +152,14 @@
         "cwd": "pkgs/edge-worker"
       }
     },
+    "smoke:bun": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "command": "bun run scripts/smoke-bun-dist.ts",
+        "cwd": "pkgs/edge-worker"
+      }
+    },
     "test:integration": {
       "dependsOn": ["db:ensure", "^build"],
       "executor": "nx:run-commands",

--- a/pkgs/edge-worker/scripts/smoke-bun-dist.ts
+++ b/pkgs/edge-worker/scripts/smoke-bun-dist.ts
@@ -1,0 +1,19 @@
+import {
+  EdgeWorker,
+  ProcessPlatformAdapter,
+  SupabasePlatformAdapter,
+} from '../dist/index.js';
+
+const exportsToCheck = {
+  EdgeWorker,
+  ProcessPlatformAdapter,
+  SupabasePlatformAdapter,
+};
+
+for (const [name, value] of Object.entries(exportsToCheck)) {
+  if (value === undefined) {
+    throw new Error(`Missing Bun smoke export: ${name}`);
+  }
+}
+
+console.log('edge-worker bun dist smoke passed');


### PR DESCRIPTION
Adds a Bun smoke test for the `edge-worker` package that verifies key exports (`EdgeWorker`, `ProcessPlatformAdapter`, `SupabasePlatformAdapter`) are present and defined in the built distribution when loaded under Bun. A new `smoke:bun` Nx target runs the smoke script after the build step, and a corresponding `edge-worker-bun-smoke` CI job executes it conditionally when the `edge-worker` package is affected, integrated into the existing gate and release workflows.