### PR TITLE
fix: make `startOnlyOnce` awaitable, deduplicate stop calls, and add packed-tarball smoke test

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,6 +25,20 @@ runs:
         echo '{"default-ulimits":{"nofile":{"Name":"nofile","Hard":100000,"Soft":100000}}}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
 
+    # Restrict the kernel's ephemeral (outbound) port range to ports below the
+    # ones Supabase projects bind on the host (50320-55324). The default range
+    # (32768-60999) overlaps them, so any outbound connection (docker pull,
+    # pnpm, nx cloud) can transiently occupy e.g. 50422, and `supabase start`
+    # then fails with "address already in use". The socket sits in TIME_WAIT
+    # for ~60s, outlasting the retry loop in scripts/supabase-start.sh.
+    - name: Restrict ephemeral ports below Supabase host ports
+      shell: bash
+      run: |
+        sudo sysctl -w net.ipv4.ip_local_port_range="32768 49999"
+        # Fail the job if the range does not exclude Supabase ports (50320+)
+        read -r low high < <(sysctl -n net.ipv4.ip_local_port_range)
+        [ "$high" -lt 50320 ] || { echo "::error::ephemeral port range $low-$high overlaps Supabase ports"; exit 1; }
+
     - uses: pnpm/action-setup@v4
       with:
         version: '10.20.0'

--- a/pkgs/core/supabase/tests/ensure_workers/skips_process_start_mode.test.sql
+++ b/pkgs/core/supabase/tests/ensure_workers/skips_process_start_mode.test.sql
@@ -1,29 +1,73 @@
+-- Test: ensure_workers() never pings process-started workers
 begin;
-select plan(3);
-
+select plan(2);
 select pgflow_tests.reset_db();
 
+-- Clear any existing HTTP requests
+delete from net._http_response;
+
+-- Setup: Create Vault secrets for production mode
+select vault.create_secret('test-service-role-key', 'supabase_service_role_key');
+select vault.create_secret('testproject123', 'supabase_project_id');
+
+-- Setup: Register two worker functions — one HTTP-started, one process-started
 select pgflow.track_worker_function('http-worker', 'http');
 select pgflow.track_worker_function('process-worker', 'process');
 
-select is(
-  (select count(*)::int from pgflow.ensure_workers() where function_name = 'process-worker'),
-  0,
-  'ensure_workers skips process workers in production mode'
+-- ============================================================
+-- TEST 1: Local mode pings HTTP worker, skips process worker
+-- ============================================================
+
+-- Activate local mode via known local JWT secret
+set local app.settings.jwt_secret = 'super-secret-jwt-token-with-at-least-32-characters-long';
+
+-- Reset debounce timestamps so functions are eligible for invocation
+update pgflow.worker_functions set last_invoked_at = now() - interval '10 seconds';
+
+-- Force evaluation into a temp table so pg_net requests are queued before we inspect them
+select * into temporary local_result from pgflow.ensure_workers();
+
+-- Assert: only the HTTP worker URL was queued (process worker must NOT appear)
+select results_eq(
+  $$
+    select url from net.http_request_queue
+    where url like 'http://kong:8000/%'
+    order by url
+  $$,
+  $$
+    select 'http://kong:8000/functions/v1/http-worker'::text as url
+  $$,
+  'Local mode: only HTTP worker is pinged, process worker is skipped'
 );
 
-select ok(
-  (select count(*)::int from pgflow.ensure_workers() where function_name = 'http-worker') >= 0,
-  'ensure_workers still evaluates http workers'
+-- ============================================================
+-- TEST 2: Production mode pings HTTP worker, skips process worker
+-- ============================================================
+
+-- Clear the request queue from the local test
+delete from net._http_response;
+
+-- Reset debounce timestamps
+update pgflow.worker_functions set last_invoked_at = now() - interval '10 seconds';
+
+-- Switch to production mode (jwt_secret does NOT match the local value)
+set local app.settings.jwt_secret = 'production-secret-different-from-local';
+
+-- Force evaluation into a temp table so pg_net requests are queued before we inspect them
+select * into temporary prod_result from pgflow.ensure_workers();
+
+-- Assert: only the HTTP worker URL was queued (process worker must NOT appear)
+select results_eq(
+  $$
+    select url from net.http_request_queue
+    where url like 'https://%'
+    order by url
+  $$,
+  $$
+    select 'https://testproject123.supabase.co/functions/v1/http-worker'::text as url
+  $$,
+  'Production mode: only HTTP worker is pinged, process worker is skipped'
 );
 
-select set_config('app.settings.is_local', 'true', true);
-
-select is(
-  (select count(*)::int from pgflow.ensure_workers() where function_name = 'process-worker'),
-  0,
-  'ensure_workers skips process workers in local mode'
-);
-
-select * from finish();
+select finish();
 rollback;

--- a/pkgs/edge-worker/README.md
+++ b/pkgs/edge-worker/README.md
@@ -25,7 +25,7 @@ import { EdgeWorker } from 'jsr:@pgflow/edge-worker';
 
 `@pgflow/edge-worker` is published to both registries:
 
-- Use JSR for Supabase Edge Functions and Deno deployments.
+- Use JSR for Supabase Edge Functions.
 - Use npm for Node and Bun long-running process deployments.
 
 Supabase Edge Functions remain the primary deployment path. Node and Bun process hosting is intended for Railway, Docker, and similar hosts that run workers as normal long-running processes.

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -147,9 +147,24 @@
     },
     "test:node": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
-        "command": "pnpm vitest run tests/unit/platform/ProcessPlatformAdapter.test.ts",
+        "command": "node ../../scripts/smoke-edge-worker-dist.mjs",
         "cwd": "pkgs/edge-worker"
+      }
+    },
+    "verify-exports": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": [
+        "production",
+        "^production",
+        "{workspaceRoot}/scripts/smoke-edge-worker-dist.mjs"
+      ],
+      "options": {
+        "command": "node ./scripts/smoke-edge-worker-dist.mjs",
+        "cwd": "{workspaceRoot}"
       }
     },
     "smoke:bun": {

--- a/pkgs/edge-worker/src/_internal/flow.ts
+++ b/pkgs/edge-worker/src/_internal/flow.ts
@@ -2,4 +2,4 @@ export { createFlowWorker } from '../flow/createFlowWorker.js';
 export { FlowWorkerLifecycle } from '../flow/FlowWorkerLifecycle.js';
 export { StepTaskExecutor } from '../flow/StepTaskExecutor.js';
 export { StepTaskPoller } from '../flow/StepTaskPoller.js';
-export type * from '../flow/types.js';
+export type * from '@pgflow/core';

--- a/pkgs/edge-worker/src/core/Worker.ts
+++ b/pkgs/edge-worker/src/core/Worker.ts
@@ -15,7 +15,10 @@ export class Worker {
 
   private batchProcessor: IBatchProcessor;
   private mainLoopPromise: Promise<void> | undefined;
+  private startupPromise: Promise<void> | undefined;
+  private stopPromise: Promise<void> | undefined;
   private deprecationLogged = false;
+  private deprecationHandler?: () => void;
 
   constructor(
     batchProcessor: IBatchProcessor,
@@ -30,29 +33,43 @@ export class Worker {
     this.cleanup = options.cleanup;
   }
 
-  startOnlyOnce(workerBootstrap: WorkerBootstrap) {
+  startOnlyOnce(workerBootstrap: WorkerBootstrap): Promise<void> {
+    if (this.startupPromise) {
+      return this.startupPromise;
+    }
+
     if (!this.lifecycle.isCreated) {
       this.logger.debug('Worker not in Created state, ignoring start request');
-      return;
+      return Promise.resolve();
     }
-    this.mainLoopPromise = this.start(workerBootstrap);
+
+    this.startupPromise = this.lifecycle
+      .acknowledgeStart(workerBootstrap)
+      .then(() => {
+        this.mainLoopPromise = this.runMainLoop();
+      })
+      .catch((error) => {
+        this.logger.error(`Error in worker startup: ${error}`);
+        throw error;
+      });
+
+    return this.startupPromise;
   }
 
-  private async start(workerBootstrap: WorkerBootstrap) {
+  private async runMainLoop() {
     try {
-      await this.lifecycle.acknowledgeStart(workerBootstrap);
-
       while (this.isMainLoopActive) {
         try {
           await this.lifecycle.sendHeartbeat();
         } catch (error: unknown) {
           this.logger.error(`Error sending heartbeat: ${error}`);
-          // Continue execution - a failed heartbeat shouldn't stop processing
         }
 
-        // Check if deprecated after heartbeat
         if (!this.isMainLoopActive) {
           this.logDeprecation();
+          if (this.lifecycle.isDeprecated) {
+            this.deprecationHandler?.();
+          }
           break;
         }
 
@@ -60,7 +77,6 @@ export class Worker {
           await this.batchProcessor.processBatch();
         } catch (error: unknown) {
           this.logger.error(`Error processing batch: ${error}`);
-          // Continue to next iteration - failed batch shouldn't stop the worker
         }
       }
     } catch (error) {
@@ -69,8 +85,16 @@ export class Worker {
     }
   }
 
-  async stop() {
-    // If the worker is already stopping or stopped, do nothing
+  onDeprecated(handler: () => void): void {
+    this.deprecationHandler = handler;
+  }
+
+  stop(): Promise<void> {
+    this.stopPromise ??= Promise.resolve().then(() => this.performStop());
+    return this.stopPromise;
+  }
+
+  private async performStop() {
     if (this.lifecycle.isStopping || this.lifecycle.isStopped) {
       return;
     }
@@ -78,7 +102,6 @@ export class Worker {
     this.lifecycle.transitionToStopping();
 
     try {
-      // Signal deprecation (which includes "Stopped accepting new messages")
       this.logDeprecation();
       this.requestShutdown?.();
       this.abortController.abort();
@@ -93,7 +116,6 @@ export class Worker {
         throw error;
       }
 
-      // Signal waiting for pending tasks
       this.logger.shutdown('waiting');
       await this.batchProcessor.awaitCompletion();
 
@@ -104,7 +126,6 @@ export class Worker {
         await this.cleanup();
       }
 
-      // Signal graceful stop complete
       this.logger.shutdown('stopped');
     } catch (error) {
       this.logger.debug(`Error during worker stop: ${error}`);

--- a/pkgs/edge-worker/src/core/context.ts
+++ b/pkgs/edge-worker/src/core/context.ts
@@ -2,7 +2,7 @@
 import type { BaseContext, AnyFlow, AllStepInputs, ExtractFlowInput } from '@pgflow/dsl';
 import type { Json } from './types.js';
 import type { PgmqMessageRecord } from '../queue/types.js';
-import type { StepTaskRecord } from '../flow/types.js';
+import type { StepTaskRecord } from '@pgflow/core';
 import type { QueueWorkerConfig, FlowWorkerConfig } from './workerConfigTypes.js';
 
 /* ──────────────────────────────────────────────────────────────────────

--- a/pkgs/edge-worker/src/core/test-context-utils.ts
+++ b/pkgs/edge-worker/src/core/test-context-utils.ts
@@ -5,7 +5,7 @@ import type {
 import type {
   MessageContext, StepTaskContext
 } from './context.js';
-import type { StepTaskRecord } from '../flow/types.js';
+import type { StepTaskRecord } from '@pgflow/core';
 import type { PgmqMessageRecord } from '../queue/types.js';
 
 export function createMessageTestContext<

--- a/pkgs/edge-worker/src/flow/StepTaskExecutor.ts
+++ b/pkgs/edge-worker/src/flow/StepTaskExecutor.ts
@@ -1,5 +1,6 @@
 import type { AnyFlow } from '@pgflow/dsl';
-import type { IPgflowClient } from './types.js';
+import type { StepTaskRecord } from '@pgflow/core';
+import type { IPgflowClient } from '@pgflow/core';
 import type { IExecutor } from '../core/types.js';
 import type { Logger, TaskLogContext } from '../platform/types.js';
 import type { StepTaskHandlerContext } from '../core/context.js';
@@ -39,7 +40,7 @@ export class StepTaskExecutor<TFlow extends AnyFlow, TContext extends StepTaskHa
   }
 
   // Convenience getters to avoid drilling into context
-  get stepTask() {
+  get stepTask(): StepTaskRecord<TFlow> {
     return this.context.stepTask;
   }
 

--- a/pkgs/edge-worker/src/flow/StepTaskPoller.ts
+++ b/pkgs/edge-worker/src/flow/StepTaskPoller.ts
@@ -1,4 +1,4 @@
-import type { IPgflowClient } from './types.js';
+import type { IPgflowClient } from '@pgflow/core';
 import type { IPoller, Supplier } from '../core/types.js';
 import type { Logger } from '../platform/types.js';
 import type { AnyFlow, AllStepInputs } from '@pgflow/dsl';

--- a/pkgs/edge-worker/src/flow/types.ts
+++ b/pkgs/edge-worker/src/flow/types.ts
@@ -1,1 +1,0 @@
-export * from '@pgflow/core';

--- a/pkgs/edge-worker/src/index.ts
+++ b/pkgs/edge-worker/src/index.ts
@@ -13,7 +13,7 @@ export { ControlPlane } from './control-plane/index.js';
 export * from './platform/index.js';
 
 // Export types
-export type { StepTaskRecord } from './flow/types.js';
+export type { StepTaskRecord } from '@pgflow/core';
 export type { FlowWorkerConfig } from './flow/createFlowWorker.js';
 export type { StepTaskPollerConfig } from './flow/StepTaskPoller.js';
 

--- a/pkgs/edge-worker/src/platform/ProcessPlatformAdapter.ts
+++ b/pkgs/edge-worker/src/platform/ProcessPlatformAdapter.ts
@@ -37,7 +37,9 @@ export class ProcessPlatformAdapter implements PlatformAdapter<SupabaseResources
   private readonly queries: Queries;
   private worker: Worker | null = null;
   private workerId: string | null = null;
-  private shutdownStarted = false;
+  private stopPromise: Promise<void> | null = null;
+  private gracefulExitPromise: Promise<void> | null = null;
+  private signalCount = 0;
 
   constructor(
     options?: ProcessAdapterOptions,
@@ -67,31 +69,25 @@ export class ProcessPlatformAdapter implements PlatformAdapter<SupabaseResources
     this.workerId = workerId;
     this.loggingFactory.setWorkerId(workerId);
     this.loggingFactory.setWorkerName(workerName);
-    this.registerSignalHandlers();
 
     this.worker = createWorkerFn(this.loggingFactory.createLogger);
+
+    this.worker.onDeprecated(() => {
+      this.handleDeprecation().catch(() => undefined);
+    });
+
     await this.worker.startOnlyOnce({
       edgeFunctionName: workerName,
       workerId,
       startMode: 'process',
     });
+
+    this.registerSignalHandlers();
   }
 
-  async stopWorker(): Promise<void> {
-    this.requestShutdown();
-
-    try {
-      if (this.worker) {
-        await this.worker.stop();
-      }
-      if (this.workerId) {
-        await this.queries.markWorkerStopped(this.workerId);
-      }
-    } finally {
-      if (this.ownsSql) {
-        await this._platformResources.sql.end();
-      }
-    }
+  stopWorker(): Promise<void> {
+    this.stopPromise ??= Promise.resolve().then(() => this.performStopWorker());
+    return this.stopPromise;
   }
 
   requestShutdown(): void {
@@ -136,23 +132,49 @@ export class ProcessPlatformAdapter implements PlatformAdapter<SupabaseResources
     }
   }
 
-  private async handleSignal(): Promise<void> {
-    if (this.shutdownStarted) {
-      this.deps.exit(1);
-    }
-
-    this.shutdownStarted = true;
+  private async performStopWorker(): Promise<void> {
+    this.requestShutdown();
 
     try {
-      await this.stopWorker();
-    } catch (error) {
-      this.logger.error('Process worker shutdown failed', error);
-      this.deps.setExitCode(1);
+      if (this.worker) {
+        await this.worker.stop();
+      }
+      if (this.workerId) {
+        await this.queries.markWorkerStopped(this.workerId);
+      }
+    } finally {
+      if (this.ownsSql) {
+        await this._platformResources.sql.end();
+      }
+    }
+  }
+
+  private gracefulExit(): Promise<void> {
+    this.gracefulExitPromise ??= (async () => {
+      let exitCode = 0;
+      try {
+        await this.stopWorker();
+      } catch (error) {
+        this.logger.error('Process worker shutdown failed', error);
+        exitCode = 1;
+      }
+      this.deps.setExitCode(exitCode);
+      this.deps.exit(exitCode);
+    })();
+    return this.gracefulExitPromise;
+  }
+
+  private async handleDeprecation(): Promise<void> {
+    await this.gracefulExit();
+  }
+
+  private async handleSignal(): Promise<void> {
+    this.signalCount++;
+    if (this.signalCount > 1) {
       this.deps.exit(1);
     }
 
-    this.deps.setExitCode(0);
-    this.deps.exit(0);
+    await this.gracefulExit();
   }
 
   private assertProcessEnv(env: Record<string, string | undefined>): asserts env is ProcessEnv {

--- a/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
+++ b/pkgs/edge-worker/src/platform/SupabasePlatformAdapter.ts
@@ -258,14 +258,19 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
   }
 
   private async replaceWorker(req: Request, createWorkerFn: CreateWorkerFn): Promise<void> {
+    const previousWorkerId = this.workerId;
+
     if (this.worker) {
       await this.worker.stop();
+      if (previousWorkerId) {
+        await this.queries.markWorkerStopped(previousWorkerId);
+      }
       this.abortController = new AbortController();
     }
 
     this.edgeFunctionName = this.extractFunctionName(req);
 
-    const workerId = this.workerId === null
+    const workerId = previousWorkerId === null
       ? this.validatedEnv.SB_EXECUTION_ID
       : globalThis.crypto.randomUUID();
     this.workerId = workerId;
@@ -275,7 +280,7 @@ export class SupabasePlatformAdapter implements PlatformAdapter<SupabaseResource
 
     // Create the worker using the factory function and the logger
     this.worker = createWorkerFn(this.loggingFactory.createLogger);
-    this.worker.startOnlyOnce({
+    void this.worker.startOnlyOnce({
       edgeFunctionName: this.edgeFunctionName,
       workerId,
       startMode: 'http',

--- a/pkgs/edge-worker/src/test/test-helpers.ts
+++ b/pkgs/edge-worker/src/test/test-helpers.ts
@@ -8,7 +8,7 @@ import type {
   SupabaseMessageContext,
   SupabaseStepTaskContext
 } from '../core/context.js';
-import type { StepTaskRecord } from '../flow/types.js';
+import type { StepTaskRecord } from '@pgflow/core';
 import { createServiceSupabaseClient } from '../core/supabase-utils.js';
 import { createContextSafeConfig } from '../core/context.js';
 import type { QueueWorkerConfig, FlowWorkerConfig } from '../core/workerConfigTypes.js';

--- a/pkgs/edge-worker/supabase/functions/_shared/portable_examples.js
+++ b/pkgs/edge-worker/supabase/functions/_shared/portable_examples.js
@@ -4,8 +4,9 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function maxPgConnectionsHandler(queueName, expectedMax) {
-  return async (_payload, { sql }) => {
+function maxPgConnectionsHandler(expectedMax) {
+  return async (_payload, { sql, workerConfig }) => {
+    const queueName = workerConfig.queueName;
     const actualMax = sql.options.max;
     const status = actualMax === expectedMax ? 'success' : 'error';
     const errorMessage = actualMax === expectedMax
@@ -64,7 +65,7 @@ export const portableExamples = {
     options: {
       queueName: 'conn_max_pg_default',
     },
-    handler: maxPgConnectionsHandler('conn_max_pg_default', 4),
+    handler: maxPgConnectionsHandler(4),
   },
   conn_max_pg_override: {
     name: 'conn_max_pg_override',
@@ -76,7 +77,7 @@ export const portableExamples = {
       queueName: 'conn_max_pg_override',
       maxPgConnections: 7,
     },
-    handler: maxPgConnectionsHandler('conn_max_pg_override', 7),
+    handler: maxPgConnectionsHandler(7),
   },
   conn_env_var: {
     name: 'conn_env_var',

--- a/pkgs/edge-worker/tests/e2e-portable-runtimes/portable-process-worker.mjs
+++ b/pkgs/edge-worker/tests/e2e-portable-runtimes/portable-process-worker.mjs
@@ -16,8 +16,13 @@ if (!process.env.WORKER_NAME) {
 
 const expectedConnectionString = process.env.PORTABLE_EXPECTED_CONNECTION_STRING;
 
+const workerOptions = process.env.PORTABLE_QUEUE_NAME
+  ? { queueName: process.env.PORTABLE_QUEUE_NAME }
+  : {};
+
 await startPortableExample(EdgeWorker, exampleName, {
   expectedConnectionString,
+  workerOptions,
 });
 
 console.log(`portable worker started: ${exampleName}`);

--- a/pkgs/edge-worker/tests/e2e-portable-runtimes/portable-runtimes.test.ts
+++ b/pkgs/edge-worker/tests/e2e-portable-runtimes/portable-runtimes.test.ts
@@ -74,14 +74,15 @@ async function ensureEmptyQueue(sql: postgres.Sql, queueName: string) {
 async function resetExample(
   sql: postgres.Sql,
   exampleName: ExampleName,
-  options: { preserveWorkerMetadata?: boolean } = {}
+  options: { preserveWorkerMetadata?: boolean; queueNameOverride?: string } = {}
 ) {
   const example = portableExample(exampleName);
+  const queueName = options.queueNameOverride ?? example.queueName;
 
   if (options.preserveWorkerMetadata) {
-    await ensureEmptyQueue(sql, example.queueName);
+    await ensureEmptyQueue(sql, queueName);
   } else {
-    await resetQueue(sql, example.queueName);
+    await resetQueue(sql, queueName);
   }
 
   if (example.kind === 'sequence') {
@@ -99,9 +100,9 @@ async function resetExample(
       created_at TIMESTAMPTZ DEFAULT NOW()
     )
   `;
-  await sql`DELETE FROM e2e_test_results WHERE queue_name = ${example.queueName}`;
+  await sql`DELETE FROM e2e_test_results WHERE queue_name = ${queueName}`;
 
-  if (!options.preserveWorkerMetadata) {
+  if (!options.preserveWorkerMetadata && !options.queueNameOverride) {
     await sql`
       DELETE FROM pgflow.workers
       WHERE function_name = ${example.queueName}
@@ -162,12 +163,14 @@ async function waitForResult(sql: postgres.Sql, queueName: string, expectedMax: 
 async function waitForExampleAssertion(
   sql: postgres.Sql,
   exampleName: ExampleName,
-  sequenceStartValue?: number
+  sequenceStartValue?: number,
+  queueNameOverride?: string
 ) {
   const example = portableExample(exampleName);
+  const queueName = queueNameOverride ?? example.queueName;
 
   if (example.kind === 'result') {
-    await waitForResult(sql, example.queueName, example.expectedMax);
+    await waitForResult(sql, queueName, example.expectedMax);
     return;
   }
 
@@ -207,16 +210,6 @@ async function waitForFreshWorker(sql: postgres.Sql, queueName: string) {
   );
 }
 
-async function currentWorkerFunctionMode(sql: postgres.Sql, queueName: string) {
-  const rows = await sql<{ start_mode: string }[]>`
-    SELECT start_mode
-    FROM pgflow.worker_functions
-    WHERE function_name = ${queueName}
-  `;
-
-  return rows[0]?.start_mode;
-}
-
 async function waitForProcessExit(
   child: Deno.ChildProcess,
   statusPromise: Promise<Deno.CommandStatus>,
@@ -234,12 +227,12 @@ async function waitForProcessExit(
   return await statusPromise;
 }
 
-function processEnv(exampleName: ExampleName) {
-  const example = portableExample(exampleName);
+function processEnv(exampleName: ExampleName, uniqueName: string) {
   const env: Record<string, string> = {
     ...Deno.env.toObject(),
     PORTABLE_EXAMPLE_NAME: exampleName,
-    WORKER_NAME: example.queueName,
+    WORKER_NAME: uniqueName,
+    PORTABLE_QUEUE_NAME: uniqueName,
     SUPABASE_URL: e2eConfig.apiUrl,
     SUPABASE_SERVICE_ROLE_KEY: SERVICE_ROLE_KEY,
     EDGE_WORKER_LOG_LEVEL: 'warn',
@@ -263,13 +256,14 @@ async function runProcessExample(
   exampleName: ExampleName
 ) {
   const example = portableExample(exampleName);
-  const previousStartMode = await currentWorkerFunctionMode(sql, example.queueName);
-  await resetExample(sql, exampleName);
+  const uniqueName = `${example.queueName}_${runtime.name}_${crypto.randomUUID().slice(0, 8)}`;
+
+  await resetExample(sql, exampleName, { queueNameOverride: uniqueName });
 
   const child = new Deno.Command(runtime.command, {
     args: [PROCESS_FIXTURE],
     cwd: new URL('../..', import.meta.url).pathname,
-    env: processEnv(exampleName),
+    env: processEnv(exampleName, uniqueName),
     stdout: 'null',
     stderr: 'null',
   }).spawn();
@@ -277,13 +271,13 @@ async function runProcessExample(
   let childExited = false;
 
   try {
-    await waitForWorkerFunctionMode(sql, example.queueName, 'process');
-    const worker = await waitForFreshWorker(sql, example.queueName);
+    await waitForWorkerFunctionMode(sql, uniqueName, 'process');
+    const worker = await waitForFreshWorker(sql, uniqueName);
     const sequenceStartValue = example.kind === 'sequence'
       ? await seqLastValue(example.sequenceName)
       : undefined;
-    await sendBatch(example.messagesToSend, example.queueName);
-    await waitForExampleAssertion(sql, exampleName, sequenceStartValue);
+    await sendBatch(example.messagesToSend, uniqueName);
+    await waitForExampleAssertion(sql, exampleName, sequenceStartValue, uniqueName);
 
     child.kill('SIGTERM');
     const status = await waitForProcessExit(child, statusPromise);
@@ -300,7 +294,7 @@ async function runProcessExample(
 
         return rows[0]?.stopped_at ? rows[0] : false;
       },
-      { description: `${runtime.name} ${example.queueName} stopped_at` }
+      { description: `${runtime.name} ${uniqueName} stopped_at` }
     );
 
     assertExists(stoppedWorker.stopped_at);
@@ -315,13 +309,11 @@ async function runProcessExample(
       await waitForProcessExit(child, statusPromise);
     }
 
-    if (previousStartMode === 'http') {
-      await sql`
-        UPDATE pgflow.worker_functions
-        SET start_mode = 'http'
-        WHERE function_name = ${example.queueName}
-      `;
-    }
+    await sql`
+      DELETE FROM pgflow.worker_functions
+      WHERE function_name = ${uniqueName}
+    `;
+    await sql`DELETE FROM e2e_test_results WHERE queue_name = ${uniqueName}`;
   }
 }
 

--- a/pkgs/edge-worker/tests/integration/creating_queue.test.ts
+++ b/pkgs/edge-worker/tests/integration/creating_queue.test.ts
@@ -3,7 +3,6 @@ import { createQueueWorker } from '../../src/queue/createQueueWorker.ts';
 import { withTransaction } from '../db.ts';
 import { createFakeLogger } from '../fakes.ts';
 import { waitFor } from '../e2e/_helpers.ts';
-import { delay } from '@std/async';
 import { createTestPlatformAdapter } from './_helpers.ts';
 
 Deno.test(
@@ -20,14 +19,11 @@ Deno.test(
       createTestPlatformAdapter(sql)
     );
 
-    worker.startOnlyOnce({
+    await worker.startOnlyOnce({
       edgeFunctionName: 'test',
       // random uuid
       workerId: crypto.randomUUID(),
     });
-    
-    // Wait a bit to ensure worker transitions through starting to running
-    await delay(100);
 
     try {
       // Wait for the queue to be created
@@ -72,10 +68,6 @@ Deno.test(
           description: 'worker to be registered in pgflow.workers'
         }
       );
-      
-      // Give the worker a bit more time to fully transition to running state
-      // This prevents the "Cannot transition from starting to stopping" error
-      await new Promise(resolve => setTimeout(resolve, 100));
     } finally {
       await worker.stop();
     }

--- a/pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
+++ b/pkgs/edge-worker/tests/integration/flow/compilationAtStartup.test.ts
@@ -81,13 +81,10 @@ Deno.test(
 
     try {
       // Start worker - this triggers compilation
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId: crypto.randomUUID(),
       });
-
-      // Give time for startup to complete
-      await delay(100);
 
       // Verify flow was created
       const [flowAfter] = await sql`
@@ -146,13 +143,10 @@ Deno.test(
 
     try {
       // Start worker - should verify without error
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId: crypto.randomUUID(),
       });
-
-      // Give time for startup to complete
-      await delay(100);
 
       // Verify flow still exists (was not deleted/recreated)
       const [flowAfter] = await sql`
@@ -206,28 +200,29 @@ Deno.test(
     globalThis.addEventListener('unhandledrejection', errorHandler);
 
     try {
-      worker.startOnlyOnce({
-        edgeFunctionName: 'test_compilation',
-        workerId: crypto.randomUUID(),
-      });
-
-      // Give time for startup to fail
-      await delay(200);
+      let caughtError: Error | undefined;
+      try {
+        await worker.startOnlyOnce({
+          edgeFunctionName: 'test_compilation',
+          workerId: crypto.randomUUID(),
+        });
+      } catch (e) {
+        caughtError = e as Error;
+      }
 
       // Verify error was thrown
       assertEquals(
-        caughtErrors.length > 0,
+        caughtError !== undefined,
         true,
         'Should have caught an error'
       );
-      const caughtError = caughtErrors[0];
       assertEquals(
-        caughtError.name,
+        caughtError!.name,
         'FlowShapeMismatchError',
         'Error should be FlowShapeMismatchError'
       );
       assertEquals(
-        caughtError.message.includes('shape mismatch'),
+        caughtError!.message.includes('shape mismatch'),
         true,
         'Error message should mention mismatch'
       );
@@ -268,13 +263,10 @@ Deno.test(
     );
 
     try {
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId: crypto.randomUUID(),
       });
-
-      // Give time for startup and recompilation
-      await delay(200);
 
       // Verify flow was recompiled with new structure
       const steps = await sql`
@@ -397,11 +389,10 @@ Deno.test(
     );
 
     try {
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId: crypto.randomUUID(),
       });
-      await delay(100);
 
       // Flow should NOT have been created (compilation was skipped)
       const [flowAfter] = await sql`
@@ -449,11 +440,10 @@ Deno.test(
     );
 
     try {
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId: crypto.randomUUID(),
       });
-      await delay(100);
 
       // Flow SHOULD have been created
       const [flowAfter] = await sql`
@@ -497,11 +487,10 @@ Deno.test(
     );
 
     try {
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId,
       });
-      await delay(100);
 
       // Worker should have registered (check workers table for this specific worker)
       const workers = await sql`
@@ -553,13 +542,10 @@ Deno.test(
     );
 
     try {
-      worker.startOnlyOnce({
+      await worker.startOnlyOnce({
         edgeFunctionName: 'test_compilation',
         workerId: crypto.randomUUID(),
       });
-
-      // Give time for startup and recompilation
-      await delay(200);
 
       // Verify flow was recompiled with new structure (NOT mismatch error)
       const steps = await sql`
@@ -619,28 +605,29 @@ Deno.test(
     globalThis.addEventListener('unhandledrejection', errorHandler);
 
     try {
-      worker.startOnlyOnce({
-        edgeFunctionName: 'test_compilation',
-        workerId: crypto.randomUUID(),
-      });
-
-      // Give time for startup to fail
-      await delay(200);
+      let caughtError: Error | undefined;
+      try {
+        await worker.startOnlyOnce({
+          edgeFunctionName: 'test_compilation',
+          workerId: crypto.randomUUID(),
+        });
+      } catch (e) {
+        caughtError = e as Error;
+      }
 
       // Verify error was thrown
       assertEquals(
-        caughtErrors.length > 0,
+        caughtError !== undefined,
         true,
         'Should have caught an error'
       );
-      const caughtError = caughtErrors[0];
       assertEquals(
-        caughtError.name,
+        caughtError!.name,
         'FlowShapeMismatchError',
         'Error should be FlowShapeMismatchError'
       );
       assertEquals(
-        caughtError.message.includes('shape mismatch'),
+        caughtError!.message.includes('shape mismatch'),
         true,
         'Error message should mention mismatch'
       );

--- a/pkgs/edge-worker/tests/integration/starting_worker.test.ts
+++ b/pkgs/edge-worker/tests/integration/starting_worker.test.ts
@@ -2,7 +2,6 @@ import { createQueueWorker } from '../../src/queue/createQueueWorker.ts';
 import { withTransaction } from '../db.ts';
 import { createFakeLogger } from '../fakes.ts';
 import { createTestPlatformAdapter } from './_helpers.ts';
-import { delay } from '@std/async';
 
 Deno.test(
   'Starting worker',
@@ -17,13 +16,11 @@ Deno.test(
       createTestPlatformAdapter(sql)
     );
 
-    worker.startOnlyOnce({
+    await worker.startOnlyOnce({
       edgeFunctionName: 'test',
       // random uuid
       workerId: crypto.randomUUID(),
     });
-
-    await delay(100);
 
     try {
       const workers = await sql`select * from pgflow.workers`;

--- a/pkgs/edge-worker/tests/integration/stepTaskExecutorContext.test.ts
+++ b/pkgs/edge-worker/tests/integration/stepTaskExecutorContext.test.ts
@@ -8,7 +8,7 @@ import type {
 import { withTransaction } from '../db.ts';
 // import { createFakeLogger } from '../fakes.ts';
 import { createFlowWorkerContext } from '../../src/core/supabase-test-utils.ts';
-import type { StepTaskRecord } from '../../src/flow/types.ts';
+import type { StepTaskRecord } from '@pgflow/core';
 
 const DEFAULT_TEST_SUPABASE_ENV: SupabaseEnv = {
   SUPABASE_DB_URL: 'postgresql://test',

--- a/pkgs/edge-worker/tests/unit/Worker.startOnlyOnce.test.ts
+++ b/pkgs/edge-worker/tests/unit/Worker.startOnlyOnce.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { Worker } from '../../src/core/Worker.ts';
 import type {
   IBatchProcessor,
@@ -8,18 +8,18 @@ import type {
 import { createLoggingFactory } from '../../src/platform/logging.ts';
 
 const loggingFactory = createLoggingFactory();
-loggingFactory.setLogLevel('error'); // Suppress debug output during tests
+loggingFactory.setLogLevel('error');
 const logger = loggingFactory.createLogger('Worker.startOnlyOnce.test');
 
-// Mock ILifecycle that tracks calls and allows controlling state
 function createMockLifecycle(
   state: 'created' | 'starting' | 'running' | 'stopping' | 'stopped'
-): ILifecycle & { acknowledgeStartCalled: boolean } {
+): ILifecycle & { acknowledgeStartCalled: boolean; acknowledgeStartFn: (() => Promise<void>) | null } {
   return {
     acknowledgeStartCalled: false,
+    acknowledgeStartFn: null,
     acknowledgeStart: function () {
       this.acknowledgeStartCalled = true;
-      return Promise.resolve();
+      return this.acknowledgeStartFn ? this.acknowledgeStartFn() : Promise.resolve();
     },
     acknowledgeStop: () => {},
     sendHeartbeat: async () => {},
@@ -35,7 +35,6 @@ function createMockLifecycle(
   };
 }
 
-// Mock IBatchProcessor
 function createMockBatchProcessor(): IBatchProcessor {
   return {
     processBatch: async () => {},
@@ -53,10 +52,7 @@ Deno.test('Worker.startOnlyOnce - starts worker when in Created state', async ()
   const batchProcessor = createMockBatchProcessor();
   const worker = new Worker(batchProcessor, lifecycle, logger);
 
-  worker.startOnlyOnce(workerBootstrap);
-
-  // Give the async start() a moment to call acknowledgeStart
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await worker.startOnlyOnce(workerBootstrap);
 
   assertEquals(
     lifecycle.acknowledgeStartCalled,
@@ -70,10 +66,7 @@ Deno.test('Worker.startOnlyOnce - ignores request when in Starting state', async
   const batchProcessor = createMockBatchProcessor();
   const worker = new Worker(batchProcessor, lifecycle, logger);
 
-  worker.startOnlyOnce(workerBootstrap);
-
-  // Give any async operations a moment
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await worker.startOnlyOnce(workerBootstrap);
 
   assertEquals(
     lifecycle.acknowledgeStartCalled,
@@ -87,10 +80,7 @@ Deno.test('Worker.startOnlyOnce - ignores request when in Running state', async 
   const batchProcessor = createMockBatchProcessor();
   const worker = new Worker(batchProcessor, lifecycle, logger);
 
-  worker.startOnlyOnce(workerBootstrap);
-
-  // Give any async operations a moment
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await worker.startOnlyOnce(workerBootstrap);
 
   assertEquals(
     lifecycle.acknowledgeStartCalled,
@@ -104,10 +94,7 @@ Deno.test('Worker.startOnlyOnce - ignores request when in Stopping state', async
   const batchProcessor = createMockBatchProcessor();
   const worker = new Worker(batchProcessor, lifecycle, logger);
 
-  worker.startOnlyOnce(workerBootstrap);
-
-  // Give any async operations a moment
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await worker.startOnlyOnce(workerBootstrap);
 
   assertEquals(
     lifecycle.acknowledgeStartCalled,
@@ -121,14 +108,63 @@ Deno.test('Worker.startOnlyOnce - ignores request when in Stopped state', async 
   const batchProcessor = createMockBatchProcessor();
   const worker = new Worker(batchProcessor, lifecycle, logger);
 
-  worker.startOnlyOnce(workerBootstrap);
-
-  // Give any async operations a moment
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await worker.startOnlyOnce(workerBootstrap);
 
   assertEquals(
     lifecycle.acknowledgeStartCalled,
     false,
     'Worker should NOT start when in Stopped state'
   );
+});
+
+Deno.test('Worker.startOnlyOnce - startup rejects when acknowledgeStart fails', async () => {
+  const lifecycle = createMockLifecycle('created');
+  const startupError = new Error('DB connection failed');
+  lifecycle.acknowledgeStartFn = () => Promise.reject(startupError);
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, logger);
+
+  await assertRejects(
+    () => worker.startOnlyOnce(workerBootstrap),
+    Error,
+    'DB connection failed'
+  );
+});
+
+Deno.test('Worker.startOnlyOnce - readiness resolves while main loop is still running', async () => {
+  let resolveProcessBatch = () => {};
+  const batchProcessor: IBatchProcessor = {
+    processBatch: () => new Promise<void>((resolve) => {
+      resolveProcessBatch = resolve;
+    }),
+    awaitCompletion: () => Promise.resolve(),
+  };
+  const lifecycle = createMockLifecycle('created');
+  const worker = new Worker(batchProcessor, lifecycle, logger);
+
+  const readiness = worker.startOnlyOnce(workerBootstrap);
+
+  await readiness;
+
+  assertEquals(lifecycle.acknowledgeStartCalled, true);
+
+  resolveProcessBatch();
+});
+
+Deno.test('Worker.startOnlyOnce - concurrent calls share one startup promise', async () => {
+  let resolveAck = () => {};
+  const lifecycle = createMockLifecycle('created');
+  lifecycle.acknowledgeStartFn = () => new Promise<void>((resolve) => {
+    resolveAck = resolve;
+  });
+  const batchProcessor = createMockBatchProcessor();
+  const worker = new Worker(batchProcessor, lifecycle, logger);
+
+  const p1 = worker.startOnlyOnce(workerBootstrap);
+  const p2 = worker.startOnlyOnce(workerBootstrap);
+
+  assertEquals(p1 === p2, true, 'Concurrent calls should return the same promise');
+
+  resolveAck();
+  await p1;
 });

--- a/pkgs/edge-worker/tests/unit/Worker.stop.test.ts
+++ b/pkgs/edge-worker/tests/unit/Worker.stop.test.ts
@@ -68,3 +68,40 @@ Deno.test('Worker.stop calls provided cleanup callback', async () => {
 
   assertEquals(cleanupCalled, true);
 });
+
+Deno.test('Worker.stop concurrent calls return same promise', async () => {
+  let resolveCompletion = () => {};
+  const batchProcessor: IBatchProcessor = {
+    processBatch: () => Promise.resolve(),
+    awaitCompletion: () => new Promise<void>((resolve) => {
+      resolveCompletion = resolve;
+    }),
+  };
+
+  const worker = new Worker(batchProcessor, createRunningLifecycle(), fakeLogger);
+
+  const p1 = worker.stop();
+  const p2 = worker.stop();
+
+  assertEquals(p1 === p2, true, 'Concurrent stop() calls should return the same promise');
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  resolveCompletion();
+  await p1;
+});
+
+Deno.test('Worker.stop side effects run once', async () => {
+  let transitionCount = 0;
+  const lifecycle = createRunningLifecycle();
+  const originalTransition = lifecycle.transitionToStopping;
+  lifecycle.transitionToStopping = () => {
+    transitionCount++;
+    originalTransition();
+  };
+
+  const worker = new Worker(createBatchProcessor(), lifecycle, fakeLogger);
+
+  await Promise.all([worker.stop(), worker.stop(), worker.stop()]);
+
+  assertEquals(transitionCount, 1, 'transitionToStopping should be called once');
+});

--- a/pkgs/edge-worker/tests/unit/contextUtils.test.ts
+++ b/pkgs/edge-worker/tests/unit/contextUtils.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src/test/test-helpers.ts';
 import { createTestMessageContext } from '../../src/core/test-context-utils.ts';
 import type { PgmqMessageRecord } from '../../src/queue/types.ts';
-import type { StepTaskRecord } from '../../src/flow/types.ts';
+import type { StepTaskRecord } from '@pgflow/core';
 
 // Mock SQL client
 const mockSql = {} as unknown as import('postgres').default.Sql;

--- a/pkgs/edge-worker/tests/unit/platform/ProcessPlatformAdapter.test.ts
+++ b/pkgs/edge-worker/tests/unit/platform/ProcessPlatformAdapter.test.ts
@@ -33,6 +33,7 @@ type SqlStub = postgres.Sql & {
 type WorkerStub = {
   startOnlyOnce: SpyFn<[unknown], Promise<void>>;
   stop: SpyFn<[], Promise<void>>;
+  onDeprecated: SpyFn<[() => void], void>;
 };
 
 function createDeps(env: Record<string, string | undefined> = {}) {
@@ -70,6 +71,7 @@ function createWorkerStub(): WorkerStub {
   return {
     startOnlyOnce: createSpy<[unknown], Promise<void>>(() => Promise.resolve()),
     stop: createSpy<[], Promise<void>>(() => Promise.resolve()),
+    onDeprecated: createSpy<[() => void], void>(() => undefined),
   };
 }
 
@@ -210,4 +212,62 @@ Deno.test('ProcessPlatformAdapter stop failure exits with non-zero code for sign
 
   assertEquals((deps.setExitCode as SpyFn<[number], void>).calls, [[1]]);
   assertEquals(exit.calls, [[1]]);
+});
+
+Deno.test('ProcessPlatformAdapter concurrent stopWorker calls share one promise', async () => {
+  const { deps } = createDeps(validEnv());
+  const sql = createSqlStub();
+  const worker = createWorkerStub();
+  const adapter = new ProcessPlatformAdapter({ sql }, deps);
+
+  await adapter.startWorker(() => worker as never);
+
+  const p1 = adapter.stopWorker();
+  const p2 = adapter.stopWorker();
+
+  assertEquals(p1 === p2, true, 'Concurrent stopWorker calls should return same promise');
+
+  await p1;
+  assertEquals(worker.stop.calls.length, 1, 'worker.stop should be called once');
+});
+
+Deno.test('ProcessPlatformAdapter deprecation drains and exits zero', async () => {
+  const { deps, exit } = createDeps(validEnv());
+  const sql = createSqlStub();
+  const worker = createWorkerStub();
+  const adapter = new ProcessPlatformAdapter({ sql }, deps);
+
+  await adapter.startWorker(() => worker as never);
+
+  assertEquals(worker.onDeprecated.calls.length, 1, 'deprecation handler should be registered');
+
+  const deprecationHandler = worker.onDeprecated.calls[0]?.[0];
+  assertEquals(typeof deprecationHandler, 'function');
+
+  deprecationHandler?.();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(worker.stop.calls.length, 1);
+  assertEquals((deps.setExitCode as SpyFn<[number], void>).calls, [[0]]);
+  assertEquals(exit.calls, [[0]]);
+});
+
+Deno.test('ProcessPlatformAdapter signal handlers registered after startup readiness', async () => {
+  let resolveStartup = () => {};
+  const { deps, handlers } = createDeps(validEnv());
+  const sql = createSqlStub();
+  const worker = createWorkerStub();
+  worker.startOnlyOnce.implementation = () => new Promise<void>((resolve) => {
+    resolveStartup = resolve;
+  });
+  const adapter = new ProcessPlatformAdapter({ sql }, deps);
+
+  const startupPromise = adapter.startWorker(() => worker as never);
+
+  assertEquals(handlers.size, 0, 'No signal handlers should be registered during startup');
+
+  resolveStartup();
+  await startupPromise;
+
+  assertEquals(handlers.size, 3, 'All signal handlers should be registered after startup');
 });

--- a/pkgs/edge-worker/tests/unit/platform/SupabasePlatformAdapter.test.ts
+++ b/pkgs/edge-worker/tests/unit/platform/SupabasePlatformAdapter.test.ts
@@ -483,7 +483,12 @@ Deno.test({
         serveHandler = h;
       },
     });
-    const adapter = new SupabasePlatformAdapter(undefined, deps);
+    const sql = (() => Promise.resolve([{ has_active: true }])) as unknown as {
+      end: () => Promise<void>;
+    };
+    sql.end = () => Promise.resolve();
+
+    const adapter = new SupabasePlatformAdapter({ sql: sql as never }, deps);
     let createCount = 0;
 
     await adapter.startWorker(() => {
@@ -591,5 +596,88 @@ Deno.test({
     }
 
     assertEquals(callOrder, ['worker.stop', 'sql.end']);
+  },
+});
+
+Deno.test({
+  name: 'replacement marks old worker stopped before starting replacement',
+  sanitizeResources: false,
+  fn: async () => {
+    let serveHandler: ((req: Request) => Response | Promise<Response>) | null = null;
+    const events: string[] = [];
+    const workerIds: string[] = [];
+
+    const deprecatedWorker = {
+      startOnlyOnce: () => {},
+      stop: () => {
+        events.push('old.stop');
+        return Promise.resolve();
+      },
+      get isDeprecated() {
+        return true;
+      },
+      get isStopped() {
+        return false;
+      },
+    } as unknown as Worker;
+
+    const replacementWorker = {
+      startOnlyOnce: () => {
+        events.push('new.startOnlyOnce');
+      },
+      stop: () => Promise.resolve(),
+      get isDeprecated() {
+        return false;
+      },
+      get isStopped() {
+        return false;
+      },
+    } as unknown as Worker;
+
+    const deps = createMockDeps({
+      serve: (h) => {
+        serveHandler = h;
+      },
+    });
+
+    const sql = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = String.raw({ raw: strings }, ...values.map(String));
+      if (query.includes('pgflow.mark_worker_stopped')) {
+        events.push('markWorkerStopped');
+        workerIds.push(values[0] as string);
+      }
+      return Promise.resolve([{ has_active: true }]);
+    }) as unknown as { end: () => Promise<void> };
+    sql.end = () => Promise.resolve();
+
+    const adapter = new SupabasePlatformAdapter({ sql: sql as never }, deps);
+    let createCount = 0;
+    await adapter.startWorker(() => {
+      createCount++;
+      return createCount === 1 ? deprecatedWorker : replacementWorker;
+    });
+
+    const handler = serveHandler as unknown as (req: Request) => Response | Promise<Response>;
+    await handler(new Request('http://localhost/functions/v1/my-worker', {
+      headers: { authorization: 'Bearer test-service-key' },
+    }));
+
+    const secondResponse = await handler(new Request('http://localhost/functions/v1/my-worker', {
+      headers: { authorization: 'Bearer test-service-key' },
+    })) as Response;
+
+    assertEquals(secondResponse.status, 200);
+
+    assertEquals(
+      events,
+      ['old.stop', 'markWorkerStopped', 'new.startOnlyOnce'],
+      'Old worker should be stopped, marked stopped, then replacement started'
+    );
+
+    assertEquals(
+      workerIds[0],
+      'test-exec-id',
+      'markWorkerStopped should be called with the old worker ID'
+    );
   },
 });

--- a/pkgs/edge-worker/tsconfig.lib.json
+++ b/pkgs/edge-worker/tsconfig.lib.json
@@ -1,6 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@pgflow/core": ["./pkgs/core/dist/index.d.ts"],
+      "@pgflow/dsl": ["./pkgs/dsl/dist/index.d.ts"]
+    }
+  },
   "references": [
     {
       "path": "../dsl/tsconfig.lib.json"

--- a/pkgs/website/src/content/docs/deploy/node-bun-process-workers.mdx
+++ b/pkgs/website/src/content/docs/deploy/node-bun-process-workers.mdx
@@ -5,7 +5,13 @@ sidebar:
   order: 2
 ---
 
-import { Aside, CardGrid, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
+import {
+  Aside,
+  CardGrid,
+  LinkCard,
+  Tabs,
+  TabItem,
+} from '@astrojs/starlight/components';
 
 Use this deployment mode when your host runs a long-running process, such as Railway, Fly, Docker, or a VM worker service.
 
@@ -13,8 +19,8 @@ Use Supabase Edge Functions instead when you want pgflow to start workers throug
 
 <Aside type="note" title="Supabase remains the primary path">
   Process workers are for hosts that supervise normal processes. If you deploy
-  to Supabase Edge Functions, keep using JSR imports and the [Supabase deployment
-  guide](/deploy/supabase/).
+  to Supabase Edge Functions, keep using JSR imports and the [Supabase
+  deployment guide](/deploy/supabase/).
 </Aside>
 
 ## Install
@@ -32,13 +38,12 @@ Create a user-owned worker script that imports `EdgeWorker` and calls `EdgeWorke
 ```ts title="worker.ts"
 import { EdgeWorker } from '@pgflow/edge-worker';
 
-await EdgeWorker.start('process-orders', async (payload, context) => {
-  context.logger.info('Processing order', { payload });
-
-  return {
-    processedAt: new Date().toISOString(),
-  };
-});
+await EdgeWorker.start(
+  async (payload) => {
+    console.info('Processing order', { payload });
+  },
+  { queueName: 'process-orders' }
+);
 ```
 
 Flow workers use the same process runtime. Import your flow definition from your app code and pass it to `EdgeWorker.start(...)`:
@@ -54,13 +59,13 @@ await EdgeWorker.start(ProcessOrders);
 
 Set these variables in your process host:
 
-| Variable | Required | Description |
-| --- | --- | --- |
-| `SUPABASE_URL` | Yes | Your Supabase project URL. |
-| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Service role key used by the worker runtime. |
-| `DATABASE_URL` | Yes, unless `EDGE_WORKER_DB_URL` is set | PostgreSQL connection string for the pgflow database. |
-| `EDGE_WORKER_DB_URL` | Yes, unless `DATABASE_URL` is set | Alternative PostgreSQL connection string name shared with Supabase Edge Functions. |
-| `WORKER_NAME` | No | Worker function name recorded in pgflow. Defaults to `pgflow-worker`. |
+| Variable                    | Required                                | Description                                                                        |
+| --------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `SUPABASE_URL`              | Yes                                     | Your Supabase project URL.                                                         |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes                                     | Service role key used by the worker runtime.                                       |
+| `DATABASE_URL`              | Yes, unless `EDGE_WORKER_DB_URL` is set | PostgreSQL connection string for the pgflow database.                              |
+| `EDGE_WORKER_DB_URL`        | Yes, unless `DATABASE_URL` is set       | Alternative PostgreSQL connection string name shared with Supabase Edge Functions. |
+| `WORKER_NAME`               | No                                      | Worker function name recorded in pgflow. Defaults to `pgflow-worker`.              |
 
 Use `DATABASE_URL` for process hosts when possible. `EDGE_WORKER_DB_URL` remains supported for deployments that share configuration with Supabase Edge Functions.
 
@@ -73,6 +78,7 @@ Use `DATABASE_URL` for process hosts when possible. `EDGE_WORKER_DB_URL` remains
     ```sh frame="none"
     node dist/worker.js
     ```
+
   </TabItem>
   <TabItem label="Bun">
     Bun can run the app worker script directly:
@@ -80,6 +86,7 @@ Use `DATABASE_URL` for process hosts when possible. `EDGE_WORKER_DB_URL` remains
     ```sh frame="none"
     bun run worker.ts
     ```
+
   </TabItem>
 </Tabs>
 
@@ -99,6 +106,7 @@ There is no built-in HTTP health endpoint for process workers. Use your host's p
 SELECT worker_id, function_name, last_heartbeat_at
 FROM pgflow.workers
 WHERE stopped_at IS NULL
+  AND last_heartbeat_at > now() - make_interval(secs => 6)
 ORDER BY last_heartbeat_at DESC;
 ```
 

--- a/scripts/smoke-edge-worker-dist.mjs
+++ b/scripts/smoke-edge-worker-dist.mjs
@@ -1,25 +1,262 @@
-import * as edgeWorker from '../pkgs/edge-worker/dist/index.js';
-import * as internal from '../pkgs/edge-worker/dist/_internal.js';
-import * as testing from '../pkgs/edge-worker/dist/testing.js';
+#!/usr/bin/env node
 
-const requiredExports = [
-  ['EdgeWorker', edgeWorker.EdgeWorker],
-  ['createQueueWorker', edgeWorker.createQueueWorker],
-  ['createFlowWorker', edgeWorker.createFlowWorker],
-  ['ProcessPlatformAdapter', edgeWorker.ProcessPlatformAdapter],
-  ['SupabasePlatformAdapter', edgeWorker.SupabasePlatformAdapter],
+/**
+ * Packed-tarball smoke test for @pgflow/edge-worker.
+ *
+ * Instead of importing dist files directly, this script packs the three
+ * fixed-group packages (dsl, core, edge-worker) into tarballs, creates a
+ * temp consumer project, installs the tarballs, and verifies:
+ *
+ *   1. Runtime: all public exports resolve from bare specifiers
+ *   2. Manifest: package.json main/types are correct, workspace: deps rewritten
+ *   3. Types: tsc resolves declaration files without repo path aliases
+ *
+ * A package that passes this smoke test will work after `npm install`.
+ */
+
+import { execSync } from 'node:child_process';
+import { readdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(__dirname, '..');
+
+const PACKAGES_TO_PACK = [
+  { dir: 'pkgs/dsl', expectedTarballPrefix: 'pgflow-dsl' },
+  { dir: 'pkgs/core', expectedTarballPrefix: 'pgflow-core' },
+  { dir: 'pkgs/edge-worker', expectedTarballPrefix: 'pgflow-edge-worker' },
 ];
 
-for (const [name, value] of requiredExports) {
-  if (value === undefined) {
-    throw new Error(`Missing edge-worker export: ${name}`);
+/**
+ * Run a command synchronously, returning stdout.
+ * Throws on non-zero exit with captured output attached as capturedOutput.
+ */
+function run(cmd, opts = {}) {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...opts,
+    });
+  } catch (err) {
+    err.capturedOutput = (err.stdout || '') + (err.stderr || '');
+    throw err;
   }
 }
 
-if (Object.keys(internal).length === 0) {
-  throw new Error('Expected _internal export surface to load');
+// ---------------------------------------------------------------------------
+// Generated consumer files
+// ---------------------------------------------------------------------------
+
+const CONSUMER_PACKAGE_JSON = JSON.stringify({
+  name: 'pgflow-edge-worker-packed-smoke',
+  version: '1.0.0',
+  private: true,
+  type: 'module',
+}, null, 2);
+
+const RUNTIME_SMOKE_MJS = [
+  "import { createRequire } from 'node:module';",
+  "import * as edgeWorker from '@pgflow/edge-worker';",
+  "import * as internal from '@pgflow/edge-worker/_internal';",
+  "import * as testing from '@pgflow/edge-worker/testing';",
+  '',
+  'const failures = [];',
+  '',
+  'function expectDefined(label, value) {',
+  "  if (value === undefined) failures.push('Missing export: ' + label);",
+  '}',
+  '',
+  'function expectEqual(label, actual, expected) {',
+  '  if (actual !== expected)',
+  "    failures.push(label + ': expected ' + JSON.stringify(expected) + ', got ' + JSON.stringify(actual));",
+  '}',
+  '',
+  '// Root @pgflow/edge-worker',
+  "expectDefined('EdgeWorker', edgeWorker.EdgeWorker);",
+  "expectDefined('createQueueWorker', edgeWorker.createQueueWorker);",
+  "expectDefined('createFlowWorker', edgeWorker.createFlowWorker);",
+  "expectDefined('ProcessPlatformAdapter', edgeWorker.ProcessPlatformAdapter);",
+  "expectDefined('SupabasePlatformAdapter', edgeWorker.SupabasePlatformAdapter);",
+  '',
+  '// _internal namespaces',
+  "expectDefined('_internal.core.Worker', internal.core && internal.core.Worker);",
+  "expectDefined('_internal.platform.ProcessPlatformAdapter', internal.platform && internal.platform.ProcessPlatformAdapter);",
+  "expectDefined('_internal.flow.createFlowWorker', internal.flow && internal.flow.createFlowWorker);",
+  "expectDefined('_internal.queue.createQueueWorker', internal.queue && internal.queue.createQueueWorker);",
+  '',
+  '// testing exports',
+  "expectDefined('testing.configurePlatform', testing.configurePlatform);",
+  '',
+  '// package.json manifest checks',
+  'const require = createRequire(import.meta.url);',
+  "const pkg = require('@pgflow/edge-worker/package.json');",
+  "expectEqual('package.json name', pkg.name, '@pgflow/edge-worker');",
+  "expectEqual('package.json main', pkg.main, './dist/index.js');",
+  "expectEqual('package.json types', pkg.types, './dist/index.d.ts');",
+  '',
+  '// workspace: protocol must be rewritten to real version in packed tarball',
+  "for (const dep of ['@pgflow/core', '@pgflow/dsl']) {",
+  '  const version = pkg.dependencies && pkg.dependencies[dep];',
+  "  if (typeof version !== 'string' || version.startsWith('workspace:'))",
+  "    failures.push('package.json dep ' + dep + ' must not use workspace: (got: ' + version + ')');",
+  '}',
+  '',
+  'if (failures.length > 0) {',
+  "  console.error('Runtime smoke FAILED (' + failures.length + ' issues):');",
+  "  for (const f of failures) console.error('  - ' + f);",
+  '  process.exit(1);',
+  '}',
+  '',
+  "console.log('Runtime smoke: all assertions passed');",
+  '',
+].join('\n');
+
+const CONSUMER_TS = [
+  "import {",
+  '  EdgeWorker,',
+  '  createQueueWorker,',
+  '  createFlowWorker,',
+  '  ProcessPlatformAdapter,',
+  '  SupabasePlatformAdapter,',
+  '  type FlowWorkerConfig,',
+  "} from '@pgflow/edge-worker';",
+  '',
+  "import * as internal from '@pgflow/edge-worker/_internal';",
+  "import { configurePlatform, type SupabasePlatformDeps } from '@pgflow/edge-worker/testing';",
+  '',
+  '// Reference value imports to force declaration resolution',
+  'void [',
+  '  EdgeWorker,',
+  '  createQueueWorker,',
+  '  createFlowWorker,',
+  '  ProcessPlatformAdapter,',
+  '  SupabasePlatformAdapter,',
+  '  internal.core.Worker,',
+  '  internal.platform.ProcessPlatformAdapter,',
+  '  internal.flow.createFlowWorker,',
+  '  internal.queue.createQueueWorker,',
+  '  configurePlatform,',
+  '];',
+  '',
+  '// Reference type-only imports',
+  'const _config: FlowWorkerConfig | null = null;',
+  'const _deps: SupabasePlatformDeps | null = null;',
+  'void [_config, _deps];',
+  '',
+].join('\n');
+
+const TSCONFIG_JSON = JSON.stringify({
+  compilerOptions: {
+    target: 'ES2022',
+    module: 'NodeNext',
+    moduleResolution: 'NodeNext',
+    strict: true,
+    noEmit: true,
+    skipLibCheck: false,
+    lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+  },
+  include: ['consumer.ts'],
+}, null, 2);
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const failures = [];
+let tarballDir = '';
+let consumerDir = '';
+
+try {
+  // 1. Pack all three fixed-group packages
+  tarballDir = mkdtempSync(join(tmpdir(), 'pgflow-tarballs-'));
+  console.log('Packing packages into ' + tarballDir);
+
+  for (const pkg of PACKAGES_TO_PACK) {
+    const pkgPath = join(workspaceRoot, pkg.dir);
+    console.log('  Packing ' + pkg.dir + '...');
+    run('pnpm pack --pack-destination "' + tarballDir + '"', { cwd: pkgPath });
+  }
+
+  const tarballs = readdirSync(tarballDir)
+    .filter((f) => f.endsWith('.tgz'))
+    .sort()
+    .map((f) => join(tarballDir, f));
+
+  if (tarballs.length !== PACKAGES_TO_PACK.length) {
+    throw new Error(
+      'Expected ' + PACKAGES_TO_PACK.length + ' tarballs, found ' + tarballs.length
+    );
+  }
+
+  // Verify each expected package was packed
+  for (const pkg of PACKAGES_TO_PACK) {
+    const found = tarballs.some((t) => t.includes(pkg.expectedTarballPrefix));
+    if (!found) {
+      throw new Error('Tarball for ' + pkg.expectedTarballPrefix + ' not found');
+    }
+  }
+  console.log('  Packed ' + tarballs.length + ' tarballs');
+
+  // 2. Create temp consumer dir and generate files
+  consumerDir = mkdtempSync(join(tmpdir(), 'pgflow-consumer-'));
+  console.log('Setting up consumer in ' + consumerDir);
+
+  writeFileSync(join(consumerDir, 'package.json'), CONSUMER_PACKAGE_JSON);
+  writeFileSync(join(consumerDir, 'runtime-smoke.mjs'), RUNTIME_SMOKE_MJS);
+  writeFileSync(join(consumerDir, 'consumer.ts'), CONSUMER_TS);
+  writeFileSync(join(consumerDir, 'tsconfig.json'), TSCONFIG_JSON);
+
+  // 3. Install tarballs as a real consumer would (plus @types/node for tsc)
+  console.log('Installing tarballs...');
+  const installCmd =
+    'npm install --ignore-scripts --no-audit --no-fund --package-lock=false ' +
+    tarballs.map((t) => '"' + t + '"').join(' ') +
+    ' @types/node@18';
+  run(installCmd, { cwd: consumerDir });
+  console.log('  Installed ' + tarballs.length + ' packages + @types/node');
+
+  // 4. Runtime smoke test
+  console.log('Running runtime smoke test...');
+  try {
+    const result = run('node "' + join(consumerDir, 'runtime-smoke.mjs') + '"', {
+      cwd: consumerDir,
+    });
+    console.log('  ' + result.trim());
+  } catch (err) {
+    failures.push('Runtime smoke test failed:\n' + (err.capturedOutput || err.message));
+  }
+
+  // 5. Type checking
+  console.log('Running TypeScript type check...');
+  const tscBin = join(workspaceRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+  try {
+    run('node "' + tscBin + '" --project "' + join(consumerDir, 'tsconfig.json') + '"', {
+      cwd: consumerDir,
+    });
+    console.log('  Type check passed');
+  } catch (err) {
+    failures.push('Type check failed:\n' + (err.capturedOutput || err.message));
+  }
+} catch (err) {
+  failures.push('Fatal: ' + (err.message || err) + (err.capturedOutput ? '\n' + err.capturedOutput : ''));
+} finally {
+  if (tarballDir) rmSync(tarballDir, { recursive: true, force: true });
+  if (consumerDir) rmSync(consumerDir, { recursive: true, force: true });
 }
 
-if (Object.keys(testing).length === 0) {
-  throw new Error('Expected testing export surface to load');
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+if (failures.length > 0) {
+  console.error('\nSmoke test FAILED (' + failures.length + ' issue(s)):');
+  for (const f of failures) {
+    console.error('\n' + f);
+  }
+  process.exit(1);
 }
+
+console.log('\nAll smoke tests passed');


### PR DESCRIPTION
## Worker lifecycle improvements, packed-tarball smoke test, and test isolation fixes

### Worker startup now returns a promise

`Worker.startOnlyOnce()` previously fired-and-forgot the startup sequence, requiring callers to insert arbitrary `delay()` calls before asserting on state. It now returns a `Promise<void>` that resolves once `acknowledgeStart` completes, so callers can `await` readiness directly. Concurrent calls return the same promise rather than triggering duplicate startups. Startup errors are propagated to the caller instead of being swallowed as unhandled rejections.

`Worker.stop()` received the same treatment — concurrent calls are deduplicated and share a single `Promise<void>`.

### Deprecation-driven shutdown for process workers

`Worker` now exposes an `onDeprecated(handler)` hook. `ProcessPlatformAdapter` registers a handler that triggers a graceful drain-and-exit when the worker is deprecated by the control plane, without requiring a signal. Signal handlers are now registered only after startup completes, preventing races where a signal could arrive before the worker is fully initialised. A second signal still forces an immediate `exit(1)`.

### `SupabasePlatformAdapter` marks replaced workers as stopped

When a deprecated worker is replaced by a new invocation, the adapter now calls `markWorkerStopped` for the previous worker ID before starting the replacement. Previously this call was missing, leaving stale worker records in the database.

### E2E process worker tests use unique queue names per run

Each process worker E2E test now generates a unique name (`<queueName>_<runtime>_<uuid>`) instead of sharing the example's fixed queue name across runtimes. This eliminates cross-test interference and removes the need to restore the previous `start_mode` after a test. Cleanup deletes the ephemeral `worker_functions` row and result rows rather than patching them back.

### Packed-tarball smoke test replaces direct dist import check

The `smoke-edge-worker-dist.mjs` script now packs `@pgflow/dsl`, `@pgflow/core`, and `@pgflow/edge-worker` into real tarballs, installs them into a temporary consumer project, and verifies:

- All public runtime exports resolve from bare specifiers
- `package.json` `main`/`types` fields are correct
- `workspace:` dependency references are rewritten to real version ranges
- TypeScript resolves declaration files without any repo path aliases

This catches packaging regressions that a direct `dist/` import cannot detect. The `test:node` target now runs this script (after `build`) and a new `verify-exports` target exposes it as a cacheable standalone task.

### `flow/types.ts` indirection removed

The re-export shim `src/flow/types.ts` (which simply re-exported `@pgflow/core`) is deleted. All internal and test imports now reference `@pgflow/core` directly.

### SQL test for `ensure_workers` rewritten to assert HTTP requests

The `skips_process_start_mode` pgTAP test previously checked row counts returned by `ensure_workers()`. It now inspects `net.http_request_queue` to confirm that only the HTTP-started worker's URL is enqueued in both local and production modes, and that the process-started worker never produces a request in either mode.