### PR TITLE
fix: publish snapshots with pnpm

### DIFF
--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -340,10 +340,9 @@ NPM_SUCCESS=false
 JSR_SUCCESS=true  # Default true (only set false if JSR package exists and fails)
 JSR_PUBLISHED_VERSION=""  # Track JSR version if published
 
-# Publish to npm (token is read from NPM_TOKEN env var via .npmrc)
-# GITHUB_ACTIONS=true skips changeset's npm profile check which fails with automation tokens
+# Publish to npm (pnpm rewrites workspace:* dependencies before publishing)
 echo -e "${BOLD}Publishing to npm...${NC}"
-if GITHUB_ACTIONS=true pnpm exec changeset publish --tag snapshot ; then
+if pnpm publish --recursive --tag snapshot --no-git-checks ; then
   echo -e "${GREEN}✓ npm packages published${NC}"
   NPM_SUCCESS=true
 else


### PR DESCRIPTION
## Summary

- publish npm snapshots with pnpm so `workspace:*` dependencies become real versions
- skip git checks because snapshot versioning changes package manifests before publish

## Verification

- `bash -n scripts/snapshot-release.sh`
- `pnpm smoke:edge-worker:dist`
- snapshot version bump plus recursive `pnpm publish --dry-run` for all five packages
- packed `@pgflow/edge-worker` manifest contains real snapshot versions for `@pgflow/core` and `@pgflow/dsl`
