### PR TITLE
fix: drop commented import from flows index template

### DIFF
--- a/.changeset/fix-flows-index-comment.md
+++ b/.changeset/fix-flows-index-comment.md
@@ -1,0 +1,5 @@
+---
+"pgflow": patch
+---
+
+Fix freshly installed projects failing to start: the generated `supabase/flows/index.ts` contained a commented-out example import that the Supabase CLI's text-based import scanner treats as a real import, aborting `supabase start` with `failed to read file: supabase/flows/my-flow.ts`.

--- a/pkgs/cli/__tests__/commands/install/create-flows-directory.test.ts
+++ b/pkgs/cli/__tests__/commands/install/create-flows-directory.test.ts
@@ -54,6 +54,9 @@ describe('createFlowsDirectory', () => {
     expect(indexContent).toContain("export { GreetUser } from './greet-user.ts';");
     // Should have documenting comment
     expect(indexContent).toContain('Re-export all flows');
+    // No commented-out imports: the Supabase CLI regex-scans file text and
+    // fails `supabase start` on any import of a non-existent file
+    expect(indexContent).not.toContain('my-flow');
   });
 
   it('should create greet-user.ts with named export', async () => {

--- a/pkgs/cli/src/commands/install/create-flows-directory.ts
+++ b/pkgs/cli/src/commands/install/create-flows-directory.ts
@@ -4,7 +4,10 @@ import { log, confirm } from '@clack/prompts';
 import chalk from 'chalk';
 
 const INDEX_TS_TEMPLATE = `// Re-export all flows from this directory
-// Example: export { MyFlow } from './my-flow.ts';
+//
+// Do not add commented-out import examples: the Supabase CLI scans file
+// text for import statements without parsing comments, so an example that
+// names a missing file breaks "supabase start" with "failed to read file".
 
 export { GreetUser } from './greet-user.ts';
 `;

--- a/pkgs/website/src/content/docs/reference/manual-installation.mdx
+++ b/pkgs/website/src/content/docs/reference/manual-installation.mdx
@@ -136,7 +136,8 @@ Create `supabase/flows/index.ts` to export your flows:
 
 ```typescript title="supabase/flows/index.ts"
 // Re-export all flows from this directory
-// Example: export { MyFlow } from './my-flow.ts';
+// (Do not keep commented-out import examples here — the Supabase CLI's
+// import scanner treats them as real imports and `supabase start` fails)
 
 export { GreetUser } from './greet-user.ts';
 ```


### PR DESCRIPTION
## Why

`pgflow install` scaffolded `supabase/flows/index.ts` with a commented-out
example import:

```ts
// Example: export { MyFlow } from './my-flow.ts';
```

The Supabase CLI resolves each function's import graph with a **regex over raw
file text** (`importPathPattern` in `apps/cli/src/shared/functions/deploy.ts`) —
it does not strip comments. The commented example matches the pattern, the
walker tries to read `supabase/flows/my-flow.ts`, gets ENOENT, and
`supabase start` aborts on a fresh project:

```
failed to read file: open supabase/flows/my-flow.ts: no such file or directory
```

Reproduced in isolation: fresh `supabase init` + the comment in a transitive
file → `supabase start` exits with the error above; deleting only that comment
line → full stack boots.

## What

- `flows/index.ts` template: drop the commented example import, replace with a
  short warning comment that itself contains no import-shaped text
- manual-installation docs: same change in the copy-paste snippet
- regression test: generated `index.ts` must not reference `my-flow`

## Verification

- `vitest create-flows-directory.test.ts` — 7/7 (new assertion caught an
  earlier draft of this fix that quoted the forbidden pattern in its own
  warning comment)
- ran supabase CLI's exact `importPathPattern` over the generated file: only
  `./greet-user.ts` matches, which exists
- E2E with the locally built CLI: fresh project → `pgflow install` →
  `supabase start` boots the full stack (previously failed at bind-mount
  resolution)
