### PR TITLE
fix: validate JSR token before publishing snapshots

### DIFF
--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -98,30 +98,34 @@ else
   fi
 fi
 
-# JSR authentication - always validate with dry-run
-JSR_DRY_RUN_CMD="pnpm jsr publish --dry-run --allow-slow-types --allow-dirty"
+# JSR authentication
+# `deno publish --dry-run` exits 0 even with an invalid token (it never
+# contacts the registry), so validate JSR_TOKEN against the JSR API instead
 if [[ -n "${JSR_TOKEN:-}" ]]; then
-  JSR_DRY_RUN_CMD="$JSR_DRY_RUN_CMD --token $JSR_TOKEN"
-fi
-JSR_CHECK=$(cd pkgs/edge-worker && $JSR_DRY_RUN_CMD 2>&1 || true)
-if echo "$JSR_CHECK" | grep -qi "unauthorized\|not logged in\|authentication"; then
-  if [[ -n "${JSR_TOKEN:-}" ]]; then
-    echo -e "  ${YELLOW}!${NC} jsr: JSR_TOKEN set but invalid/expired - opening browser..."
+  if command -v curl >/dev/null \
+    && JSR_HTTP=$(curl -s -o /dev/null -w '%{http_code}' \
+        -H "Authorization: Bearer $JSR_TOKEN" https://api.jsr.io/user) \
+    && [[ "$JSR_HTTP" == "200" ]]; then
+    echo -e "  ${GREEN}✓${NC} jsr: token valid"
   else
-    echo -e "  ${YELLOW}jsr: not logged in - opening browser...${NC}"
-  fi
-  if deno login; then
-    echo -e "  ${GREEN}✓${NC} jsr: authenticated via browser"
-  else
-    echo -e "${RED}Error: JSR login failed${NC}"
+    echo -e "${RED}Error: JSR_TOKEN is invalid or expired (api.jsr.io: ${JSR_HTTP:-unreachable})${NC}"
+    echo -e "Create a fresh token at ${BLUE}https://jsr.io/settings/tokens${NC}"
     exit 1
   fi
 else
-  if [[ -n "${JSR_TOKEN:-}" ]]; then
-    echo -e "  ${GREEN}✓${NC} jsr: authenticated (via token)"
-  else
-    echo -e "  ${GREEN}✓${NC} jsr: authenticated (existing session)"
+  # No token: rely on the cached browser session in $DENO_DIR/auth.json
+  # (default ~/.cache/deno/auth.json). The `jsr` wrapper's deno prompts for
+  # interactive browser auth on first publish and caches the session.
+  DENO_AUTH_FILE="${DENO_DIR:-$HOME/.cache/deno}/auth.json"
+  if [[ ! -f "$DENO_AUTH_FILE" ]]; then
+    echo -e "${YELLOW}jsr: no cached browser session and JSR_TOKEN is unset.${NC}"
+    echo -e "Warm it up once so the session is cached before this script versions anything:"
+    echo -e "  ${BLUE}cd pkgs/edge-worker && pnpm jsr publish --allow-slow-types --allow-dirty${NC}"
+    echo -e "(The publish fails with 'already published' - that is fine, the login persists.)"
+    echo -e "Or create a token at ${BLUE}https://jsr.io/settings/tokens${NC} and export JSR_TOKEN."
+    exit 1
   fi
+  echo -e "  ${GREEN}✓${NC} jsr: using cached browser session ($DENO_AUTH_FILE)"
 fi
 
 echo ""
@@ -360,7 +364,11 @@ if [[ -f pkgs/edge-worker/jsr.json ]]; then
   if [[ -n "${JSR_TOKEN:-}" ]]; then
     JSR_PUBLISH_CMD="$JSR_PUBLISH_CMD --token $JSR_TOKEN"
   fi
-  if ( cd pkgs/edge-worker && $JSR_PUBLISH_CMD ) ; then
+  # jsr's error output echoes the full deno command line, which contains
+  # the token - redact it so logs stay shareable
+  if ( cd pkgs/edge-worker && $JSR_PUBLISH_CMD ) \
+      > >(sed -E 's/jsrp_[A-Za-z0-9]+/jsrp_[REDACTED]/g') \
+      2> >(sed -E 's/jsrp_[A-Za-z0-9]+/jsrp_[REDACTED]/g' >&2) ; then
     echo -e "${GREEN}✓ JSR package published${NC}"
   else
     echo -e "${RED}✗ JSR publish failed${NC}"


### PR DESCRIPTION
## Why

A snapshot run with a stale `JSR_TOKEN` gets past the script's auth pre-check
("✓ jsr: authenticated (via token)"), publishes the npm half successfully, and
then dies on the JSR half:

```
error: Failed to publish @pgflow/edge-worker@...
Caused by:
    1: The provided bearer token is invalid. (invalidBearerToken)
```

Root cause of the false positive: the pre-check ran
`deno publish --dry-run`, which **never contacts the registry**. Verified
locally — with a garbage token:

```
$ pnpm jsr publish --dry-run --allow-slow-types --allow-dirty --token jsrp_fakefakefake
Success Dry run complete
exit=0
```

The result is a half-published snapshot (npm version exists, JSR version
doesn't) and a worktree stuck on the versioned files.

Bonus leak: on publish failure the `jsr` npm wrapper `console.log`s the full
deno command line (`dist/utils.js:272`), including `--token jsrp_…`, so the
token ends up in terminal output, CI logs, and bug reports.

Second dead path: the no-token fallback ran `deno login`, a subcommand that
does not exist in deno 2.1.4 (nor in the `jsr` wrapper's bundled 2.3.7) — it
crashes with `error: Module not found "…/login"`. And since dry-run never
reports auth problems, the fallback triggered "✓ authenticated (existing
session)" even with no session cached at all.

## What

- When `JSR_TOKEN` is set: validate it up front with a real API call
  (`GET https://api.jsr.io/user`, expects 200) and exit 1 with a clear
  "rotate the token" message before any versioning/build/publishing happens
- No-token path: require the cached browser-session file
  (`$DENO_DIR/auth.json`, default `~/.cache/deno/auth.json`) to exist. If
  missing, exit 1 with the one-time warm-up command
  (`cd pkgs/edge-worker && pnpm jsr publish …` — fails with "already
  published", but persists the login) instead of calling the nonexistent
  `deno login`
- Redact `jsrp_…` tokens from the JSR publish output (stdout and stderr)

## Verification

- `bash -n scripts/snapshot-release.sh`
- extracted auth block, run standalone:
  - `JSR_TOKEN=jsrp_fake…` → `Error: JSR_TOKEN is invalid or expired (api.jsr.io: 401)` + exit 1
  - no token, no `~/.cache/deno/auth.json` → guided error + exit 1
  - no token, `auth.json` present → `✓ jsr: using cached browser session` + exit 0
- redaction on the real leaked line from the failing run:
  `--token jsrp_dI7…` → `--token jsrp_[REDACTED]`
