### PR TITLE
docs: rewrite 0.15.0 news article around standalone Node/Bun workers

### DIFF
--- a/pkgs/website/src/components/CodeOverlay.astro
+++ b/pkgs/website/src/components/CodeOverlay.astro
@@ -319,7 +319,8 @@
     const button = document.querySelector('.reveal-button') as HTMLElement | null;
     const overlay = document.querySelector('.code-overlay') as HTMLElement | null;
     const scrollableContainer = document.querySelector('.scrollable-content') as HTMLElement | null;
-    const scrollableInner = document.querySelector('.scrollable-inner') as HTMLElement | null;
+    // Cast non-null: the guard below protects runtime; hoisted animateScroll can't inherit the narrowing.
+    const scrollableInner = document.querySelector('.scrollable-inner') as HTMLElement;
 
     if (!button || !overlay || !scrollableContainer || !scrollableInner) return;
 

--- a/pkgs/website/src/content/docs/deploy/node-bun-process-workers.mdx
+++ b/pkgs/website/src/content/docs/deploy/node-bun-process-workers.mdx
@@ -69,12 +69,11 @@ Set these variables in your process host:
 
 Use `DATABASE_URL` for process hosts when possible. `EDGE_WORKER_DB_URL` remains supported for deployments that share configuration with Supabase Edge Functions. If both are set, `DATABASE_URL` takes priority.
 
-<Aside type="caution" title="Apply the worker start mode migration first">
-  Apply the pgflow migration that adds `worker_functions.start_mode` and the
-  two-argument `track_worker_function` before the first process worker
-  deployment. Process workers require this migration; existing HTTP Edge
-  workers remain compatible with databases that only have the one-argument
-  function.
+<Aside type="caution" title="Update your pgflow schema first">
+  Process workers need the pgflow 0.15.0 database migrations (`start_mode`).
+  Run `npx pgflow@latest install` and apply new migrations before your first
+  process worker deployment — see
+  [Update pgflow](/deploy/update-pgflow/).
 </Aside>
 
 ## Run The Worker

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 pgflow workers are no longer tied to Supabase Edge Functions. This release publishes `@pgflow/edge-worker` to npm and adds a process runtime that runs workers as long-lived Node or Bun processes — on Railway, Fly.io, Docker, or any VM.
 
-<Aside type="warning" title="Supabase is still required">
+<Aside type="caution" title="Supabase is still required">
 A standalone worker still needs a Supabase project. pgflow runs on your Supabase Postgres database: flows, runs, task queues, and the control plane (worker registration, heartbeats, deprecation) all live there. What changed is only *where the worker process runs* — instead of Supabase hosting it as an Edge Function, it runs as your own long-lived process on an external service and connects back to Supabase. If you don't need long-running or custom runtimes, Edge Function workers continue to work as before.
 </Aside>
 

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -40,6 +40,8 @@ Process workers handle `SIGTERM`, `SIGINT`, and `SIGQUIT` with graceful drain: t
 
 See the [Node/Bun Process Workers guide](/deploy/node-bun-process-workers/) for deployment recipes and configuration.
 
+Already using pgflow? 0.15.0 ships a database migration — follow [Update pgflow](/deploy/update-pgflow/) before deploying process workers.
+
 ## Supabase Edge Function improvements
 
 Edge Function workers also got lifecycle hardening in this release:

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -15,8 +15,8 @@ import { Aside } from '@astrojs/starlight/components';
 
 pgflow workers are no longer tied to Supabase Edge Functions. This release publishes `@pgflow/edge-worker` to npm and adds a process runtime that runs workers as long-lived Node or Bun processes — on Railway, Fly.io, Docker, or any VM.
 
-<Aside type="caution" title="Supabase is still required">
-A standalone worker still needs a Supabase project. pgflow runs on your Supabase Postgres database: flows, runs, task queues, and the control plane (worker registration, heartbeats, deprecation) all live there. What changed is only *where the worker process runs* — instead of Supabase hosting it as an Edge Function, it runs as your own long-lived process on an external service and connects back to Supabase. If you don't need long-running or custom runtimes, Edge Function workers continue to work as before.
+<Aside type="note" title="Supabase is still required">
+A standalone worker still needs a Supabase project. pgflow runs on your Supabase Postgres database: flows, runs, task queues, and worker management all live there. What changed is only *where the worker process runs* — instead of Supabase hosting it as an Edge Function, it runs as your own long-lived process on an external service and connects back to Supabase. If you don't need long-running or custom runtimes, Edge Function workers continue to work as before.
 </Aside>
 
 ## Run a worker with Node or Bun

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -1,7 +1,7 @@
 ---
 draft: true
-title: 'pgflow 0.15.0: Portable Workers with Node and Bun Support'
-description: 'Run pgflow workers anywhere with the new @pgflow/edge-worker npm package, including long-running Node and Bun processes'
+title: 'pgflow 0.15.0: Standalone Workers with Node and Bun'
+description: 'Run pgflow workers as long-lived Node or Bun processes on any hosting platform with the new @pgflow/edge-worker npm package'
 date: 2026-08-18
 authors:
   - jumski
@@ -14,6 +14,10 @@ featured: false
 import { Aside } from '@astrojs/starlight/components';
 
 pgflow workers are no longer tied to Supabase Edge Functions. This release publishes `@pgflow/edge-worker` to npm and adds a process runtime that runs workers as long-lived Node or Bun processes — on Railway, Fly.io, Docker, or any VM.
+
+<Aside type="warning" title="Supabase is still required">
+A standalone worker still needs a Supabase project. pgflow runs on your Supabase Postgres database: flows, runs, task queues, and the control plane (worker registration, heartbeats, deprecation) all live there. What changed is only *where the worker process runs* — instead of Supabase hosting it as an Edge Function, it runs as your own long-lived process on an external service and connects back to Supabase. If you don't need long-running or custom runtimes, Edge Function workers continue to work as before.
+</Aside>
 
 ## Run a worker with Node or Bun
 

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -1,5 +1,4 @@
 ---
-draft: true
 title: 'pgflow 0.15.0: Standalone Workers with Node and Bun'
 description: 'Run pgflow workers as long-lived Node or Bun processes on any hosting platform with the new @pgflow/edge-worker npm package'
 date: 2026-08-18
@@ -49,7 +48,3 @@ Edge Function workers also got lifecycle hardening in this release:
 - **Bounded shutdown.** Shutdown finishes within a five-second deadline; PostgreSQL connections are force-closed if it expires.
 - **Serialized startup.** Concurrent requests share one startup; none observe a half-started worker.
 - **Retry backoff.** Persistent database failures back off exponentially (100 ms to 5 s) instead of hot-looping.
-
-<Aside type="note">
-Draft — the final changelog lands before publishing.
-</Aside>

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 pgflow workers are no longer tied to Supabase Edge Functions. This release publishes `@pgflow/edge-worker` to npm and adds a process runtime that runs workers as long-lived Node or Bun processes — on Railway, Fly.io, Docker, or any VM.
 
 <Aside type="note" title="Supabase is still required">
-A standalone worker still needs a Supabase project. pgflow runs on your Supabase Postgres database: flows, runs, task queues, and worker management all live there. What changed is only *where the worker process runs* — instead of Supabase hosting it as an Edge Function, it runs as your own long-lived process on an external service and connects back to Supabase. If you don't need long-running or custom runtimes, Edge Function workers continue to work as before.
+Flows, runs, and task queues still live in your Supabase Postgres database — only the worker *process* moved. It runs on your infrastructure and connects back to Supabase. Edge Function workers keep working as before.
 </Aside>
 
 ## Run a worker with Node or Bun
@@ -30,7 +30,7 @@ import { ProcessOrders } from './flows/process-orders.js';
 await EdgeWorker.start(ProcessOrders);
 ```
 
-Process workers handle `SIGTERM`, `SIGINT`, and `SIGQUIT` with graceful drain: tasks finish, the worker row is marked stopped, and connections close before exit. Deprecation via the control plane stops the process cleanly, and `ensure_workers()` can replace it.
+Process workers handle `SIGTERM`, `SIGINT`, and `SIGQUIT` with graceful drain: tasks finish, the worker is marked stopped, and connections close before exit.
 
 See the [Node/Bun Process Workers guide](/deploy/node-bun-process-workers/) for deployment recipes and configuration.
 
@@ -38,10 +38,10 @@ See the [Node/Bun Process Workers guide](/deploy/node-bun-process-workers/) for 
 
 Edge Function workers also got lifecycle hardening in this release:
 
-- **Bounded shutdown.** Shutdown now finishes within a five-second deadline. Worker drain starts before database bookkeeping, and PostgreSQL connections are force-closed if the deadline expires.
-- **Serialized startup.** Concurrent HTTP requests share one worker startup; none can observe a half-started worker, and shutdown permanently closes startup admission.
-- **Retry backoff.** Persistent database failures now back off exponentially (100 ms to 5 s) instead of hot-looping, and the backoff resets after a healthy iteration.
+- **Bounded shutdown.** Shutdown finishes within a five-second deadline; PostgreSQL connections are force-closed if it expires.
+- **Serialized startup.** Concurrent requests share one startup; none observe a half-started worker.
+- **Retry backoff.** Persistent database failures back off exponentially (100 ms to 5 s) instead of hot-looping.
 
 <Aside type="note">
-This article is a draft. The release also bundles additional bug fixes; the final changelog will be updated before publishing.
+Draft — the final changelog lands before publishing.
 </Aside>

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-0-node-bun-workers.mdx
@@ -21,7 +21,13 @@ Flows, runs, and task queues still live in your Supabase Postgres database — o
 
 ## Run a worker with Node or Bun
 
-Install the package, set your connection variables, and start a worker script:
+Install the package with your package manager of choice, set your connection variables, and start a worker script:
+
+```sh frame="none"
+npm add @pgflow/edge-worker
+pnpm add @pgflow/edge-worker
+bun add @pgflow/edge-worker
+```
 
 ```ts title="worker.ts"
 import { EdgeWorker } from '@pgflow/edge-worker';

--- a/pkgs/website/src/pages/demos.astro
+++ b/pkgs/website/src/pages/demos.astro
@@ -4,11 +4,11 @@ import { AuthDemo } from '../components/AuthDemo';
 ---
 
 <StarlightPage
+  hasSidebar={false}
   frontmatter={{
     title: "pgflow Demos",
     description: "Interactive demonstrations of pgflow functionality with authenticated examples.",
     editUrl: false,
-    sidebar: { hidden: true },
     tableOfContents: false,
     lastUpdated: false,
     topic: 'pgflow'


### PR DESCRIPTION
Drop the internal 'portable worker' name, rename the slug, and add a
warning that Supabase (Postgres + control plane) is still required.