### PR TITLE
chore: drop machine-local claude-symlink hook from lefthook

### DIFF
--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -3,16 +3,3 @@
 This document contains setup instructions specific to local development environments.
 
 > **Note**: This is a starting point and will be expanded with more comprehensive setup instructions in the future.
-
-## Claude Symlink Hook
-
-Claude Code skills and configuration are stored in a separate private repository (`pgflow-dev/claude`). If you have access to this repository and need the `.claude/` directory to be symlinked on branch changes, configure the following:
-
-1. Add to your `.envrc.local`:
-   ```bash
-   export CLAUDE_SYMLINK_SCRIPT="/path/to/your/claude/symlink.sh"
-   ```
-
-2. Run `direnv allow` to reload the environment
-
-The `post-checkout` hook in `lefthook.yml` will automatically run this script whenever you switch branches.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,16 +43,6 @@ post-checkout:
             pnpm install --frozen-lockfile
           fi
         fi
-    'claude-symlink':
-      run: |
-        # Only run for branch checkouts (not file checkouts)
-        if [ "{3}" = "1" ]; then
-          if [ -n "$CLAUDE_SYMLINK_SCRIPT" ] && [ -f "$CLAUDE_SYMLINK_SCRIPT" ]; then
-            "$CLAUDE_SYMLINK_SCRIPT" --yes "$PWD"
-          elif [ -z "$CLAUDE_SYMLINK_SCRIPT" ]; then
-            echo "\033[33mWarning: CLAUDE_SYMLINK_SCRIPT not set. See LOCAL_DEV.md for setup instructions.\033[0m"
-          fi
-        fi
 
 pre-push:
   scripts:


### PR DESCRIPTION
## What

Removes the `post-checkout: claude-symlink` command from `lefthook.yml` and the matching setup section from `LOCAL_DEV.md`.

## Why

That hook was opt-in local automation gated on `CLAUDE_SYMLINK_SCRIPT` (a private config repo). In the public repo it could only ever print a warning on every branch checkout for anyone without the env var. It now runs in the local Worktrunk setup as a worktree-creation (`post-start`) hook.

Everything else in `lefthook.yml` stays: commit/push hooks have no worktrunk equivalent, and `pnpm-install-on-deps-change` must keep firing on in-worktree branch checkouts (`git checkout` / `gt`), which worktrunk hooks never see.

Pure deletion — 23 lines across 2 files, no behavior change for contributors.