### PR TITLE
fix(core): use effective step timeout for stalled tasks

### DIFF
--- a/.changeset/use-effective-step-timeout.md
+++ b/.changeset/use-effective-step-timeout.md
@@ -1,0 +1,5 @@
+---
+"@pgflow/core": patch
+---
+
+Requeue stalled tasks using the effective step timeout instead of waiting for the flow timeout.

--- a/pkgs/core/supabase/migrations/20260902012951_pgflow_effective_step_timeout.sql
+++ b/pkgs/core/supabase/migrations/20260902012951_pgflow_effective_step_timeout.sql
@@ -1,13 +1,5 @@
--- Requeue stalled tasks that have been in 'started' status longer than their effective
--- timeout (step override with flow fallback) + 30s buffer. This matches the effective
--- timeout used by start_tasks() for PGMQ visibility, without its +2s visibility margin.
--- This handles tasks that got stuck when workers crashed without completing them
-create or replace function pgflow.requeue_stalled_tasks()
-returns int
-language plpgsql
-security definer
-set search_path = ''
-as $$
+-- Modify "requeue_stalled_tasks" function
+CREATE OR REPLACE FUNCTION "pgflow"."requeue_stalled_tasks" () RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET "search_path" = '' AS $$
 declare
   result_count int := 0;
   max_requeues constant int := 3;

--- a/pkgs/core/supabase/migrations/atlas.sum
+++ b/pkgs/core/supabase/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vahrstrzyG/2HD7neJ3HHsQNmR8Mj4LBcp5Ik/HGebc=
+h1:7L7TQAgkuEri2ucryxVs4mSra1W+DJ4Ezl4jehNrfDk=
 20250429164909_pgflow_initial.sql h1:I3n/tQIg5Q5nLg7RDoU3BzqHvFVjmumQxVNbXTPG15s=
 20250517072017_pgflow_fix_poll_for_tasks_to_use_separate_statement_for_polling.sql h1:wTuXuwMxVniCr3ONCpodpVWJcHktoQZIbqMZ3sUHKMY=
 20250609105135_pgflow_add_start_tasks_and_started_status.sql h1:ggGanW4Wyt8Kv6TWjnZ00/qVb3sm+/eFVDjGfT8qyPg=
@@ -22,3 +22,4 @@ h1:vahrstrzyG/2HD7neJ3HHsQNmR8Mj4LBcp5Ik/HGebc=
 20260607175525_pgflow_worker_start_mode.sql h1:PFAfoGaHe5stKF7YAFg6AqBxmRisqDvV60vVpnnVdBE=
 20260827180017_pgflow_terminalize_skipped_tasks.sql h1:Aq4zYSUp707UiDxi08FQeXlRw2lkIonL8O6yi1LfU/g=
 20260902005317_pgflow_failed_run_terminalization.sql h1:agqIyQVyIS95DY8PI9QWg0KyJ3kGVMGrhQ+02FKZ8Xo=
+20260902012951_pgflow_effective_step_timeout.sql h1:+7sOuiyHB3IG0OxdjfZj1/Ush4fy5P2/tp8DASG85lE=

--- a/pkgs/core/supabase/tests/requeue_stalled_tasks/effective_step_timeout.test.sql
+++ b/pkgs/core/supabase/tests/requeue_stalled_tasks/effective_step_timeout.test.sql
@@ -1,0 +1,130 @@
+-- Test: requeue_stalled_tasks uses the effective step timeout
+-- Effective timeout: coalesce(step.opt_timeout, flow.opt_timeout)
+-- Stalled when started_at is strictly older than effective timeout + 30s buffer
+begin;
+select plan(10);
+
+select pgflow_tests.reset_db();
+
+-- ==========================================
+-- Case 1: step timeout 5 overrides flow timeout 60
+-- ==========================================
+select pgflow.create_flow('step_short', null, null, 60);
+select pgflow.add_step('step_short', 'step_a', timeout => 5);
+
+select pgflow.start_flow('step_short', '"x"'::jsonb);
+select pgflow_tests.ensure_worker('step_short');
+select pgflow_tests.read_and_start('step_short', 30, 1);
+
+-- Exactly 35s old: boundary of 5s + 30s buffer, not strictly older
+update pgflow.step_tasks
+set queued_at = now() - interval '39 seconds',
+    started_at = now() - interval '35 seconds'
+where flow_slug = 'step_short';
+
+select is(
+  pgflow.requeue_stalled_tasks(),
+  0,
+  'step 5 / flow 60: exactly 35s old is not requeued (strict boundary)'
+);
+
+select is(
+  (select status from pgflow.step_tasks where flow_slug = 'step_short'),
+  'started',
+  'step 5 / flow 60: boundary task stays started'
+);
+
+-- 36s old: strictly past effective timeout 5s + 30s buffer
+update pgflow.step_tasks
+set queued_at = now() - interval '40 seconds',
+    started_at = now() - interval '36 seconds'
+where flow_slug = 'step_short';
+
+select is(
+  pgflow.requeue_stalled_tasks(),
+  1,
+  'step 5 / flow 60: 36s old requeued per effective step timeout'
+);
+
+select is(
+  (select status from pgflow.step_tasks where flow_slug = 'step_short'),
+  'queued',
+  'step 5 / flow 60: 36s old task becomes queued'
+);
+
+-- ==========================================
+-- Case 2: step timeout 60 overrides flow timeout 5
+-- ==========================================
+select pgflow.create_flow('step_long', null, null, 5);
+select pgflow.add_step('step_long', 'step_a', timeout => 60);
+
+select pgflow.start_flow('step_long', '"x"'::jsonb);
+select pgflow_tests.ensure_worker('step_long');
+select pgflow_tests.read_and_start('step_long', 30, 1);
+
+-- 36s old: past flow timeout 5s + 30s buffer, but effective timeout is 60s
+update pgflow.step_tasks
+set queued_at = now() - interval '40 seconds',
+    started_at = now() - interval '36 seconds'
+where flow_slug = 'step_long';
+
+select is(
+  pgflow.requeue_stalled_tasks(),
+  0,
+  'step 60 / flow 5: 36s old not requeued despite flow timeout 5s'
+);
+
+select is(
+  (select status from pgflow.step_tasks where flow_slug = 'step_long'),
+  'started',
+  'step 60 / flow 5: 36s old task stays started'
+);
+
+-- 91s old: strictly past effective timeout 60s + 30s buffer
+update pgflow.step_tasks
+set queued_at = now() - interval '95 seconds',
+    started_at = now() - interval '91 seconds'
+where flow_slug = 'step_long';
+
+select is(
+  pgflow.requeue_stalled_tasks(),
+  1,
+  'step 60 / flow 5: 91s old requeued per effective step timeout'
+);
+
+select is(
+  (select status from pgflow.step_tasks where flow_slug = 'step_long'),
+  'queued',
+  'step 60 / flow 5: 91s old task becomes queued'
+);
+
+-- ==========================================
+-- Case 3: null step timeout inherits flow timeout 5
+-- ==========================================
+select pgflow.create_flow('step_null', null, null, 5);
+select pgflow.add_step('step_null', 'step_a');
+
+select pgflow.start_flow('step_null', '"x"'::jsonb);
+select pgflow_tests.ensure_worker('step_null');
+select pgflow_tests.read_and_start('step_null', 30, 1);
+
+-- 36s old: effective timeout is inherited flow timeout 5s + 30s buffer
+update pgflow.step_tasks
+set queued_at = now() - interval '40 seconds',
+    started_at = now() - interval '36 seconds'
+where flow_slug = 'step_null';
+
+select is(
+  pgflow.requeue_stalled_tasks(),
+  1,
+  'null step timeout inherits flow 5: 36s old requeued'
+);
+
+select is(
+  (select status from pgflow.step_tasks where flow_slug = 'step_null'),
+  'queued',
+  'null step timeout inherits flow 5: 36s old task becomes queued'
+);
+
+select finish();
+rollback;


### PR DESCRIPTION
## Summary

Fix stalled-task recovery to use the effective step timeout instead of always using the flow timeout.

This PR stacks directly on #663 (`09-01-issue_645_failed_run_terminalization`) and preserves its run, step-state, and task eligibility guards.

## Root cause

`start_tasks()` sets PGMQ visibility from the effective timeout:

```sql
coalesce(step.opt_timeout, flow.opt_timeout) + 2
```

`requeue_stalled_tasks()` used only `flows.opt_timeout`. A short step timeout could therefore make the PGMQ message visible while its task row remained `started` until the longer flow timeout and recovery buffer expired.

## Behavior

Recovery now requires:

```sql
started_at < now()
  - (coalesce(step.opt_timeout, flow.opt_timeout) * interval '1 second')
  - interval '30 seconds'
```

The comparison stays strict. A null step timeout inherits the non-null flow timeout.

The PGMQ-only two-second margin is not added to recovery. Adding it again would change the existing 30-second recovery grace to 32 seconds. The 15-second cron cadence can add up to roughly 15 seconds after eligibility.

The change preserves:

- `run.status = 'started'`, `step_state.status = 'started'`, and `task.status = 'started'`;
- `permanently_stalled_at is null` and `FOR UPDATE OF task SKIP LOCKED` behavior;
- attempts and requeue counters;
- three successful requeues before permanent stall;
- immediate visibility through `set_vt_batch(..., 0)`;
- archive and permanent-stall behavior.

## Tests

Added `effective_step_timeout.test.sql` with deterministic timestamps inside one transaction:

- flow 60 / step 5: exactly 35 seconds stays started; 36 seconds requeues;
- flow 5 / step 60: 36 seconds stays started; 91 seconds requeues;
- flow 5 / null step timeout: 36 seconds requeues through flow fallback.

Before the source fix, the focused test failed 5 of 10 assertions for the expected reason. The short step override returned 0 and stayed `started` at 36 seconds. The long step override requeued at 36 seconds, so its later 91-second call returned 0.

After the source fix:

- focused test: 1 file, 10 tests, pass;
- all stalled-recovery tests: 6 files, 54 tests, pass;
- full pgTAP: 285 files, 1326 tests, pass.

## Migration and release note

Atlas generated `20260901203454_pgflow_temp_effective_step_timeout.sql`. It replaces `pgflow.requeue_stalled_tasks()`, includes the cumulative #645 guards, and performs no backfill.

Added a separate patch changeset for `@pgflow/core`. The fixed release group expands the patch at release time.

## Checks

- `pnpm nx verify-migrations core --skip-nx-cache` — pass
- `pnpm nx gen-types core --skip-nx-cache` — pass; no generated type diff
- `pnpm nx verify-gen-types core --skip-nx-cache` — pass
- `pnpm nx test:pgtap core --skip-nx-cache` — pass; 285 files, 1326 tests
- `pnpm nx test core --skip-nx-cache` — pass
- `pnpm nx lint core --skip-nx-cache` — pass; 0 errors and 2 existing type-test warnings
- `pnpm nx build core --skip-nx-cache` — pass
- `pnpm changeset status` — pass; patch fixed group detected
- `git diff --check` — pass

`pnpm nx fix-sql core` hit the known Sqruff CLI mismatch: `error: unexpected argument '--force' found`. The direct repository fallback, `sqruff --config=.sqruff fix --parsing-errors pkgs/core/schemas/`, processed 37 files and found nothing to fix. Direct Sqruff lint also passed.

Two fresh independent Sol xhigh review rounds returned `APPROVED` with no required findings.

## Out of scope

- #656 and execution of the unreferenced `start_tasks()` visibility CTE;
- #646 worker-side handler cancellation;
- queue identity or per-step queue routing;
- changes to #645 cancellation semantics or parent-state guards;
- configurable recovery buffers or cron cadence;
- migration consolidation and release PR #659.

The stack still contains temporary migrations, so the main-targeted temporary-migration check can fail until the settled release sequence consolidates them. This PR does not consolidate the parent migration.

Fixes #621
