### PR TITLE
fix(cli): remove Windows-breaking postinstall chmod

### DIFF
--- a/.changeset/remove-windows-breaking-postinstall.md
+++ b/.changeset/remove-windows-breaking-postinstall.md
@@ -1,0 +1,5 @@
+---
+"pgflow": patch
+---
+
+Remove the postinstall `chmod` script that broke `npm install pgflow` on Windows; npm sets the executable bit for `bin` files automatically.

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -1,0 +1,55 @@
+name: Windows Smoke
+
+# Regression test for https://github.com/pgflow-dev/pgflow/issues/610:
+# `npm install pgflow` must succeed on Windows with lifecycle scripts enabled,
+# and the npm-created pgflow.cmd shim must run. The rest of CI runs on Ubuntu
+# and invokes `node dist/index.js` directly, so it never exercises this.
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-package-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.20.0'
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+          cache-dependency-path: |
+            **/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build CLI
+        run: pnpm nx build cli
+
+      - name: Pack CLI tarball
+        shell: bash
+        working-directory: pkgs/cli
+        run: pnpm pack
+
+      # Install the tarball into a clean directory with lifecycle scripts
+      # enabled (no --ignore-scripts): this is the step that failed in #610.
+      - name: Install tarball into a clean directory
+        shell: bash
+        run: |
+          SMOKE_DIR="$RUNNER_TEMP/pgflow-smoke"
+          mkdir -p "$SMOKE_DIR"
+          cd "$SMOKE_DIR"
+          npm install "$GITHUB_WORKSPACE/pkgs/cli"/pgflow-*.tgz
+
+      - name: Run npm-created pgflow.cmd shim
+        shell: bash
+        run: "$RUNNER_TEMP/pgflow-smoke/node_modules/.bin/pgflow.cmd" --version

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Run npm-created pgflow.cmd shim
         shell: bash
-        run: "$RUNNER_TEMP/pgflow-smoke/node_modules/.bin/pgflow.cmd" --version
+        run: $RUNNER_TEMP/pgflow-smoke/node_modules/.bin/pgflow.cmd --version

--- a/pkgs/cli/package.json
+++ b/pkgs/cli/package.json
@@ -37,8 +37,5 @@
   },
   "files": [
     "dist"
-  ],
-  "scripts": {
-    "postinstall": "chmod +x dist/index.js || true"
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

- The `pgflow` package's `postinstall` ran `chmod +x dist/index.js || true`. `chmod` and `true` do not exist in Windows cmd.exe, so `npm install pgflow` and `npx pgflow@latest install` failed with `'chmod' is not recognized as an internal or external command`.
- npm sets the executable bit on files declared in the `bin` field during install, so the script was redundant even on Unix. Removal is the whole fix.
- Adds a permanent `windows-latest` smoke workflow as the regression test: build the CLI, `pnpm pack`, install the tarball into a clean directory with lifecycle scripts enabled, run the npm-created `pgflow.cmd --version` shim. The rest of CI runs on Ubuntu and invokes `node dist/index.js` directly, so npm installation and Windows shims were never exercised.
- One `pgflow` patch changeset for the 0.15.1 release group (#666).
- Recreates the minimal removal from #612 against current `main` (#612 was based on v0.13.3).

## Checks

- `pnpm nx build cli` — pass
- `pnpm pack` in `pkgs/cli` — tarball contains `dist/`, no `postinstall` in its `package.json`
- CLI unit tests — 43/43 pass
- `prettier --check` on all three touched files — pass
- Windows smoke job runs in this PR's CI

Closes #610
