### PR TITLE
ci(windows): fix smoke install on release branches + 0.15.1 news article

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -4,6 +4,13 @@ name: Windows Smoke
 # `npm install pgflow` must succeed on Windows with lifecycle scripts enabled,
 # and the npm-created pgflow.cmd shim must run. The rest of CI runs on Ubuntu
 # and invokes `node dist/index.js` directly, so it never exercises this.
+#
+# The packed CLI depends on @pgflow/core (workspace:* becomes an exact version
+# after `pnpm pack`), and @pgflow/core depends on @pgflow/dsl. On the Version
+# Packages branch those versions are bumped but not yet published on npm, so
+# all three tarballs (dsl, core, cli) are packed locally and installed in one
+# `npm install` command. That makes npm resolve @pgflow/core and @pgflow/dsl
+# from the local tarballs in both branch shapes (see #669).
 on:
   workflow_dispatch:
   pull_request:
@@ -32,23 +39,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Build CLI
-        run: pnpm nx build cli
+      - name: Build CLI and its workspace dependencies
+        run: pnpm nx run-many -t build --projects=dsl,core,cli
 
-      - name: Pack CLI tarball
+      - name: Pack tarballs
         shell: bash
-        working-directory: pkgs/cli
-        run: pnpm pack
+        run: |
+          (cd pkgs/dsl && pnpm pack)
+          (cd pkgs/core && pnpm pack)
+          (cd pkgs/cli && pnpm pack)
 
-      # Install the tarball into a clean directory with lifecycle scripts
+      # Install the tarballs into a clean directory with lifecycle scripts
       # enabled (no --ignore-scripts): this is the step that failed in #610.
-      - name: Install tarball into a clean directory
+      # All three tarballs go into ONE npm install so npm resolves the
+      # @pgflow/core and @pgflow/dsl dependencies from the local tarballs.
+      - name: Install tarballs into a clean directory
         shell: bash
         run: |
           SMOKE_DIR="$RUNNER_TEMP/pgflow-smoke"
           mkdir -p "$SMOKE_DIR"
           cd "$SMOKE_DIR"
-          npm install "$GITHUB_WORKSPACE/pkgs/cli"/pgflow-*.tgz
+          npm install \
+            "$GITHUB_WORKSPACE/pkgs/dsl"/pgflow-dsl-*.tgz \
+            "$GITHUB_WORKSPACE/pkgs/core"/pgflow-core-*.tgz \
+            "$GITHUB_WORKSPACE/pkgs/cli"/pgflow-*.tgz
 
       - name: Run npm-created pgflow.cmd shim
         shell: bash

--- a/pkgs/website/src/content/docs/news/pgflow-0-15-1-task-lifecycle-hardening.mdx
+++ b/pkgs/website/src/content/docs/news/pgflow-0-15-1-task-lifecycle-hardening.mdx
@@ -1,0 +1,57 @@
+---
+title: 'pgflow 0.15.1: Reliable Task Finalization and Recovery'
+description: 'Tasks now reach a terminal state on every completion path: skipped steps, failed runs, correct stalled recovery, and a Windows install fix'
+date: 2026-09-04
+authors:
+  - jumski
+tags:
+  - bugfix
+  - patch
+featured: false
+---
+
+This patch release hardens the task lifecycle. Tasks now reach a terminal state on every completion path, stalled-task recovery uses the right timeout, claimed tasks keep their queue visibility before handlers run, and `npm install pgflow` works again on Windows.
+
+## Tasks Under Skipped Steps
+
+When a step was skipped via `whenExhausted: 'skip'` or `'skip-cascade'` (or skipped by a cascade), sibling task rows stayed `queued` or `started` forever. The step was skipped, but its task rows never ended. This was reported in [#638](https://github.com/pgflow-dev/pgflow/issues/638).
+
+Task rows under a skipped step are now terminalized as `skipped`. Two ordering details make this safe:
+
+- Tasks are terminalized before their queue messages are archived, preserving the task-before-queue lock order.
+- `start_tasks` only returns rows it actually claimed, so workers no longer execute tasks that a concurrent skip already marked `skipped`.
+
+## Tasks on Failed Runs
+
+When a run failed, unfinished task rows on that run stayed active. A late step callback or the stalled-task recovery job could then "finish" a task after its run had already failed. This was reported in [#645](https://github.com/pgflow-dev/pgflow/issues/645).
+
+Unfinished tasks are now marked `cancelled` when their run fails, and late callbacks and stalled recovery can no longer revive them.
+
+## Stalled-Task Recovery Uses the Step Timeout
+
+Stalled tasks were requeued only after their *flow* timeout expired, so recovery for a short step inside a long flow waited far longer than necessary. This was reported in [#621](https://github.com/pgflow-dev/pgflow/issues/621).
+
+Requeue now uses the effective step timeout: the step timeout when set, otherwise the flow timeout.
+
+## Claim Visibility Before Handlers Run
+
+`start_tasks()` claimed tasks but applied the PGMQ visibility extension in a way PostgreSQL could skip, so a claimed task sometimes kept only the initial read visibility. A handler that ran longer than that window made the queue message visible again, so a second worker could pick up the same task. This was reported in [#656](https://github.com/pgflow-dev/pgflow/issues/656).
+
+The visibility update is now structurally required (a referenced CTE instead of an unreferenced `SELECT` CTE), so every claimed task keeps the effective timeout (`coalesce(step timeout, flow timeout) + 2`) before handlers run, and a visibility-update failure rolls back the whole claim.
+
+## Windows Install Fixed
+
+The CLI package's postinstall script ran `chmod` on its bin file, which broke `npm install pgflow` on Windows. This was reported in [#610](https://github.com/pgflow-dev/pgflow/issues/610).
+
+The postinstall script is gone. npm sets the executable bit for `bin` files automatically, so a plain `npm install pgflow` works on Windows again.
+
+## Automatic Repair of Existing Data
+
+The single consolidated migration `20260904095427_pgflow_task_lifecycle_hardening` repairs existing task rows in the same order:
+
+1. Active task rows (`queued`/`started`) under skipped steps become `skipped`.
+2. Remaining active task rows on failed runs become `cancelled`.
+
+Completed and genuinely failed tasks keep their outcomes, and all history fields are preserved. No manual action is required.
+
+To pick up these fixes, follow [Update pgflow](/deploy/update-pgflow/).


### PR DESCRIPTION
## Summary

- Fix `windows-package-smoke` on Version Packages branches: the packed CLI pins `@pgflow/core` (and transitively `@pgflow/dsl`) at the bumped, not-yet-published version, so `npm install pgflow-*.tgz` fails with `npm error notarget No matching version found for @pgflow/core@0.15.1`. The job now builds and packs `dsl`, `core`, and `cli`, and installs all three tarballs in one `npm install` so npm resolves both workspace deps locally — on `main`-based PRs and on `changeset-release/main` alike. The #610 intent is unchanged: lifecycle scripts enabled, npm-created `pgflow.cmd --version` shim still runs.
- Add the `0.15.1` release news article covering #638, #645, #621, #656, #610, the automatic historical repair in `20260904095427_pgflow_task_lifecycle_hardening`, and the standard update instructions.

No changeset needed: `@pgflow/website` is ignored in `.changeset/config.json` and workflow changes are not packages; release PR #659 already carries the version bumps.

Prerequisite for merging #659 (epic #666).

## Checks

- `pnpm nx run-many -t build --projects=dsl,core,cli` — pass
- Local smoke: clean dir, one `npm install <dsl.tgz> <core.tgz> <cli.tgz>` with scripts enabled — pass; `node_modules/.bin/pgflow --version` prints banner + version; `@pgflow/core` and `@pgflow/dsl` resolve from local tarballs
- `pnpm nx build website` — pass (136 pages)
- Workflow YAML parse — pass (actionlint not run: unavailable locally)
- `pnpm nx affected --target=prepush --base=origin/main` — 0 affected tasks
