### PR TITLE
test: make Nx own test environments

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,2 +1,8 @@
 # Ignore Supabase Edge Functions from Nx dependency analysis
 # These are Deno runtime functions with their own import resolution
+
+# The committed local-test environment file is git-ignored (root .gitignore
+# `.env*`) but Nx must hash its contents: it is the --env-file for Deno unit,
+# integration, and E2E runs. Re-including it here makes it part of the
+# workspace file map and therefore of every affected input fileset.
+!pkgs/edge-worker/supabase/functions/.env

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,9 +6,9 @@ Nx owns pgflow test setup and cleanup. Start a delivery from a fresh environment
 pnpm nx test-env:fresh edge-worker
 ```
 
-The target runs every `supabase:stop` target in the current Nx workspace. It also removes the edge-worker integration database, its volumes, current-worktree test processes, and the upgrade fixture. It is safe when those resources are already stopped. It never starts a service or targets Supabase projects outside this workspace.
+The target takes the environment lock first. It then previews and locks every pgflow stack resource, the integration database, and the core upgrade fixture before it stops or removes anything. It stops only Nx-owned lifecycle processes from this workspace. If another worktree still holds a resource lock, recovery stops before it changes that resource. Locks live in the repository Git common directory, so sibling worktrees and sandboxes share them.
 
-Run it again after an interrupted database or E2E check. Then run the requested Nx target, which starts its dependencies.
+Run fresh setup again after an interrupted database or E2E check. Then run the requested Nx target. Do not clean Docker containers or process names by hand.
 
 Run one pgTAP file without bypassing migration setup:
 
@@ -22,20 +22,31 @@ Run one edge-worker integration file without bypassing the integration database 
 pnpm nx test:integration:file edge-worker --args=--file=tests/integration/creating_queue.test.ts
 ```
 
-Use full E2E targets. The files share long-lived edge workers and database state, so a single file is not independently isolated. Each E2E target waits for output from its current function-server target, then checks an endpoint-specific status and response body. A stale Kong listener alone cannot satisfy both checks.
+Both focused targets use the local direct-argv Nx executor. `--args=--file=...` stays part of the task hash, but the selector never enters a shell command. The target accepts one existing regular file inside its supported subtree when Nx includes it in its file map. Nonignored in-tree files work before Git tracks them. Git-ignored files work only when `.nxignore` re-includes them. `./` paths work. Empty, missing, absolute, option-like, traversal, quote/substitution, external, ignored, and symlink-escaping selectors fail before the runner starts.
 
-Save complete slow-check output and preserve the exit status before extracting a short summary:
+Use full E2E targets. E2E files share workers and database state.
+
+```bash
+pnpm nx e2e edge-worker
+pnpm nx e2e:portable-runtimes edge-worker
+```
+
+Each E2E invocation holds the edge-worker stack lock through migration materialization, dependency sync, endpoint probe, and the full suite. It prepares the current migration mirror before the running-stack fast path. The runner waits for its own serve output, captures that invocation's exact runtime-container ID, monitors the serve child during the probe and suite, and removes only that captured ID during cleanup. A stale listener, ready-then-exit server, or later replacement container cannot certify success.
+
+Database materialization stores two successful identities in the live database: database content (migrations and seed) and the full stack/setup input (config, setup helpers, lockfile, and Supabase CLI version). A stack/setup change invalidates old evidence, restarts the stack from current configuration, resets content, then writes both identities only after success. Matching identities reuse a healthy environment. `core:verify-migrations` remains uncached; cached tests and generators still hash their runtime, setup, and helper inputs.
+
+One project-id resource lock protects each Supabase stack. Startup, restart, reset, migration materialization, and every live consumer use the same lock through its critical section. The integration database has its own full-suite lock.
+
+Save complete slow-check output and preserve the Nx status:
 
 ```bash
 set -o pipefail
-pnpm nx test:integration edge-worker 2>&1 | tee /tmp/edge-worker-integration.log
+pnpm nx test:integration edge-worker 2>&1 | tee /path/you-retain/edge-worker-integration.log
+status=${PIPESTATUS[0]}
 ```
 
-Stable failure markers:
+Do not use `--skip-nx-cache`. Run lifecycle regressions with:
 
-- Nx: `Failed tasks:` and `Running target ... failed`
-- Deno: `... FAILED`, `FAILED |`, and the `=> ./path:line` block
-- pgTAP: `Result: FAIL`, `Failed test:`, and `Looks like you failed`
-- Vitest: `FAIL`, `Test Files`, and `Tests`
-
-Do not add `--skip-nx-cache` to routine commands. Nx caches test targets only when their declared runtime, test, configuration, migration, argument, and dependency inputs match. Lifecycle targets remain uncached.
+```bash
+pnpm nx test:lifecycle edge-worker
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,41 @@
+# Test lifecycle
+
+Nx owns pgflow test setup and cleanup. Start a delivery from a fresh environment:
+
+```bash
+pnpm nx test-env:fresh edge-worker
+```
+
+The target runs every `supabase:stop` target in the current Nx workspace. It also removes the edge-worker integration database, its volumes, current-worktree test processes, and the upgrade fixture. It is safe when those resources are already stopped. It never starts a service or targets Supabase projects outside this workspace.
+
+Run it again after an interrupted database or E2E check. Then run the requested Nx target, which starts its dependencies.
+
+Run one pgTAP file without bypassing migration setup:
+
+```bash
+pnpm nx test:pgtap:file core --args=--file=supabase/tests/add_step/basic_step_addition.test.sql
+```
+
+Run one edge-worker integration file without bypassing the integration database or package builds:
+
+```bash
+pnpm nx test:integration:file edge-worker --args=--file=tests/integration/creating_queue.test.ts
+```
+
+Use full E2E targets. The files share long-lived edge workers and database state, so a single file is not independently isolated. Each E2E target waits for output from its current function-server target, then checks an endpoint-specific status and response body. A stale Kong listener alone cannot satisfy both checks.
+
+Save complete slow-check output and preserve the exit status before extracting a short summary:
+
+```bash
+set -o pipefail
+pnpm nx test:integration edge-worker 2>&1 | tee /tmp/edge-worker-integration.log
+```
+
+Stable failure markers:
+
+- Nx: `Failed tasks:` and `Running target ... failed`
+- Deno: `... FAILED`, `FAILED |`, and the `=> ./path:line` block
+- pgTAP: `Result: FAIL`, `Failed test:`, and `Looks like you failed`
+- Vitest: `FAIL`, `Test Files`, and `Tests`
+
+Do not add `--skip-nx-cache` to routine commands. Nx caches test targets only when their declared runtime, test, configuration, migration, argument, and dependency inputs match. Lifecycle targets remain uncached.

--- a/nx.json
+++ b/nx.json
@@ -11,13 +11,29 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
+    "productionNoDocs": [
+      "production",
+      "!{projectRoot}/**/*.md"
+    ],
+    "denoRuntime": [{"runtime": "deno --version"}],
+    "supabaseRuntime": [{"runtime": "pnpm exec supabase --version"}],
     "sharedGlobals": [
       "{workspaceRoot}/.github/actions/setup/action.yml",
       "{workspaceRoot}/.github/actions/setup-sqruff/action.yml",
       "{workspaceRoot}/pnpm-lock.yaml",
       "{workspaceRoot}/tsconfig.base.json"
     ],
-    "sqruffConfig": ["{workspaceRoot}/.sqruff"]
+    "sqruffConfig": ["{workspaceRoot}/.sqruff"],
+    "supabaseSetup": [
+      "{projectRoot}/supabase/config.toml",
+      "{workspaceRoot}/scripts/get-enabled-services.mjs",
+      "{workspaceRoot}/scripts/supabase-start.sh",
+      "{workspaceRoot}/scripts/supabase-start-locked.sh",
+      "{workspaceRoot}/scripts/with-supabase-lock.sh",
+      "{workspaceRoot}/scripts/ensure-migrations.sh",
+      "{workspaceRoot}/scripts/ensure-migrations-body.sh",
+      "{workspaceRoot}/scripts/lock-dir.sh"
+    ]
   },
   "nxCloudId": "676490227393fa777407053a",
   "plugins": [

--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -76,7 +76,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "command": "supabase stop --no-backup"
+        "command": "../../scripts/with-supabase-lock.sh . pnpm exec supabase stop --no-backup"
       }
     }
   }

--- a/pkgs/cli/project.json
+++ b/pkgs/cli/project.json
@@ -69,6 +69,15 @@
     },
     "supabase:ci-marker": {
       "executor": "nx:noop"
+    },
+    "supabase:stop": {
+      "executor": "nx:run-commands",
+      "local": true,
+      "cache": false,
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "supabase stop --no-backup"
+      }
     }
   }
 }

--- a/pkgs/client/project.json
+++ b/pkgs/client/project.json
@@ -88,8 +88,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": ["supabase stop --no-backup"],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . pnpm exec supabase stop --no-backup"
       }
     },
     "supabase:status": {
@@ -116,13 +115,7 @@
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "mkdir -p supabase/migrations/",
-          "rm -f supabase/migrations/*.sql",
-          "cp ../core/supabase/migrations/*.sql supabase/migrations/",
-          "cp ../core/supabase/seed.sql supabase/"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu 'mkdir -p supabase/migrations/; rm -f supabase/migrations/*.sql; cp ../core/supabase/migrations/*.sql supabase/migrations/; cp ../core/supabase/seed.sql supabase/'"
       }
     },
     "supabase:reset": {
@@ -132,11 +125,7 @@
       "dependsOn": ["supabase:prepare"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "supabase db reset"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . ../../scripts/ensure-migrations-body.sh . --force-reset"
       }
     },
     "e2e": {
@@ -146,12 +135,7 @@
       "dependsOn": ["supabase:prepare", "build"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "psql 'postgresql://postgres:postgres@localhost:50522/postgres' -c 'SELECT pgflow_tests.reset_db()'",
-          "vitest run __tests__/e2e/ --config vitest.e2e.config.ts --poolOptions.threads.singleThread"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/ensure-migrations-body.sh .; psql \"postgresql://postgres:postgres@localhost:50522/postgres\" -c \"SELECT pgflow_tests.reset_db()\"; vitest run __tests__/e2e/ --config vitest.e2e.config.ts --poolOptions.threads.singleThread'"
       }
     },
     "test:unit": {
@@ -176,12 +160,7 @@
       "dependsOn": ["supabase:prepare", "build"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "psql 'postgresql://postgres:postgres@localhost:50522/postgres' -c 'SELECT pgflow_tests.reset_db()'",
-          "node scripts/performance-benchmark.mjs"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/ensure-migrations-body.sh .; psql \"postgresql://postgres:postgres@localhost:50522/postgres\" -c \"SELECT pgflow_tests.reset_db()\"; node scripts/performance-benchmark.mjs'"
       }
     },
     "test:types:vitest": {

--- a/pkgs/core/project.json
+++ b/pkgs/core/project.json
@@ -9,13 +9,23 @@
     "migrations": ["{projectRoot}/supabase/migrations/**/*.sql"],
     "atlasSetup": [
       "{projectRoot}/atlas/atlas.hcl",
+      "{projectRoot}/atlas/supabase-baseline-schema.sql",
       "{projectRoot}/supabase/migrations/atlas.sum",
       "{projectRoot}/scripts/atlas-verify-schemas-synced"
     ],
     "databaseTypes": ["{projectRoot}/src/database-types.ts"],
+    "supabaseSetup": [
+      "{projectRoot}/supabase/config.toml",
+      "{workspaceRoot}/scripts/get-enabled-services.mjs",
+      "{workspaceRoot}/scripts/supabase-start.sh",
+      "{workspaceRoot}/scripts/supabase-start-locked.sh"
+    ],
+    "supabaseReset": ["supabaseSetup", "{projectRoot}/supabase/seed.sql"],
     "pgtapTests": [
       "{projectRoot}/supabase/tests/**/*.sql",
-      "{projectRoot}/scripts/run-test-with-colors"
+      "{projectRoot}/supabase/seed.sql",
+      "{projectRoot}/scripts/run-test-with-colors",
+      "{projectRoot}/scripts/colorize-pgtap-output.awk"
     ],
     "upgradeFixture": [
       "{projectRoot}/supabase/upgrade_fixture/**",
@@ -30,11 +40,7 @@
     },
     "verify-schemas-synced": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "schemas",
-        "migrations",
-        "atlasSetup"
-      ],
+      "inputs": ["schemas", "migrations", "atlasSetup", "supabaseSetup"],
       "outputs": ["{projectRoot}/.nx-inputs/verify-schemas-synced.txt"],
       "options": {
         "cwd": "{projectRoot}",
@@ -50,7 +56,7 @@
     "verify-migrations": {
       "executor": "nx:run-commands",
       "dependsOn": ["verify-schemas-synced"],
-      "inputs": ["migrations"],
+      "inputs": ["migrations", "supabaseReset"],
       "outputs": ["{projectRoot}/.nx-inputs/verify-migrations.txt"],
       "options": {
         "cwd": "{projectRoot}",
@@ -132,9 +138,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh ."
-        ],
+        "commands": ["../../scripts/supabase-start-locked.sh ."],
         "parallel": false
       }
     },
@@ -174,8 +178,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": ["supabase stop --no-backup", "supabase start"],
-        "parallel": false
+        "command": "../../scripts/supabase-start-locked.sh --restart ."
       }
     },
     "supabase:reset": {
@@ -204,7 +207,13 @@
       "executor": "nx:run-commands",
       "local": true,
       "dependsOn": ["verify-migrations"],
-      "inputs": ["schemas", "migrations", "pgtapTests", "upgradeFixture"],
+      "inputs": [
+        "schemas",
+        "migrations",
+        "supabaseSetup",
+        "pgtapTests",
+        "upgradeFixture"
+      ],
       "cache": true,
       "options": {
         "cwd": "{projectRoot}",
@@ -212,6 +221,24 @@
           "../../scripts/supabase-start-locked.sh .",
           "scripts/run-test-with-colors",
           "scripts/run-upgrade-fixture"
+        ],
+        "parallel": false
+      }
+    },
+    "test:pgtap:file": {
+      "executor": "nx:run-commands",
+      "local": true,
+      "dependsOn": ["verify-migrations"],
+      "inputs": ["schemas", "migrations", "supabaseSetup", "pgtapTests"],
+      "cache": true,
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [
+          {
+            "command": "../../scripts/supabase-start-locked.sh .",
+            "forwardAllArgs": false
+          },
+          "test -n \"{args.file}\" || (echo 'Usage: pnpm nx test:pgtap:file core --args=--file=supabase/tests/<file>.test.sql' >&2; exit 1); scripts/run-test-with-colors \"{args.file}\""
         ],
         "parallel": false
       }
@@ -229,7 +256,7 @@
     "gen-types": {
       "executor": "nx:run-commands",
       "dependsOn": ["verify-migrations"],
-      "inputs": ["migrations"],
+      "inputs": ["migrations", "supabaseSetup"],
       "outputs": ["{projectRoot}/src/database-types.ts"],
       "options": {
         "cwd": "{projectRoot}",
@@ -248,7 +275,7 @@
     "verify-gen-types": {
       "executor": "nx:run-commands",
       "dependsOn": ["verify-migrations"],
-      "inputs": ["migrations", "databaseTypes"],
+      "inputs": ["migrations", "supabaseSetup", "databaseTypes"],
       "outputs": ["{projectRoot}/.nx-inputs/verify-gen-types.txt"],
       "options": {
         "cwd": "{projectRoot}",

--- a/pkgs/core/project.json
+++ b/pkgs/core/project.json
@@ -14,12 +14,6 @@
       "{projectRoot}/scripts/atlas-verify-schemas-synced"
     ],
     "databaseTypes": ["{projectRoot}/src/database-types.ts"],
-    "supabaseSetup": [
-      "{projectRoot}/supabase/config.toml",
-      "{workspaceRoot}/scripts/get-enabled-services.mjs",
-      "{workspaceRoot}/scripts/supabase-start.sh",
-      "{workspaceRoot}/scripts/supabase-start-locked.sh"
-    ],
     "supabaseReset": ["supabaseSetup", "{projectRoot}/supabase/seed.sql"],
     "pgtapTests": [
       "{projectRoot}/supabase/tests/**/*.sql",
@@ -40,34 +34,24 @@
     },
     "verify-schemas-synced": {
       "executor": "nx:run-commands",
-      "inputs": ["schemas", "migrations", "atlasSetup", "supabaseSetup"],
+      "inputs": ["schemas", "migrations", "atlasSetup", "supabaseSetup", "supabaseRuntime"],
       "outputs": ["{projectRoot}/.nx-inputs/verify-schemas-synced.txt"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "mkdir -p .nx-inputs",
-          "scripts/atlas-verify-schemas-synced > .nx-inputs/verify-schemas-synced.txt 2>&1 || (cat .nx-inputs/verify-schemas-synced.txt && exit 1)"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/supabase-start.sh .; mkdir -p .nx-inputs; scripts/atlas-verify-schemas-synced > .nx-inputs/verify-schemas-synced.txt 2>&1 || { cat .nx-inputs/verify-schemas-synced.txt; exit 1; }'"
       },
       "cache": true
     },
     "verify-migrations": {
       "executor": "nx:run-commands",
       "dependsOn": ["verify-schemas-synced"],
-      "inputs": ["migrations", "supabaseReset"],
-      "outputs": ["{projectRoot}/.nx-inputs/verify-migrations.txt"],
+      "inputs": ["migrations", "supabaseReset", "supabaseRuntime"],
+      "local": true,
+      "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "mkdir -p .nx-inputs",
-          "supabase db reset > .nx-inputs/verify-migrations.txt 2>&1 || (cat .nx-inputs/verify-migrations.txt && exit 1)"
-        ],
-        "parallel": false
-      },
-      "cache": true
+        "command": "../../scripts/with-supabase-lock.sh . ../../scripts/ensure-migrations-body.sh ."
+      }
     },
     "build": {
       "executor": "@nx/js:tsc",
@@ -158,8 +142,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": ["supabase stop --no-backup"],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . pnpm exec supabase stop --no-backup"
       }
     },
     "supabase:status": {
@@ -187,11 +170,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "supabase db reset"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . ../../scripts/ensure-migrations-body.sh . --force-reset"
       }
     },
     "test": {
@@ -211,37 +190,32 @@
         "schemas",
         "migrations",
         "supabaseSetup",
+        "supabaseRuntime",
         "pgtapTests",
         "upgradeFixture"
       ],
       "cache": true,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "scripts/run-test-with-colors",
-          "scripts/run-upgrade-fixture"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/ensure-migrations-body.sh .; scripts/run-test-with-colors; scripts/run-upgrade-fixture'"
       }
     },
     "test:pgtap:file": {
-      "executor": "nx:run-commands",
+      "executor": "@pgflow/nx-executors:focused-file",
       "local": true,
       "dependsOn": ["verify-migrations"],
-      "inputs": ["schemas", "migrations", "supabaseSetup", "pgtapTests"],
-      "cache": true,
-      "options": {
-        "cwd": "{projectRoot}",
-        "commands": [
-          {
-            "command": "../../scripts/supabase-start-locked.sh .",
-            "forwardAllArgs": false
-          },
-          "test -n \"{args.file}\" || (echo 'Usage: pnpm nx test:pgtap:file core --args=--file=supabase/tests/<file>.test.sql' >&2; exit 1); scripts/run-test-with-colors \"{args.file}\""
-        ],
-        "parallel": false
-      }
+      "inputs": [
+        "schemas",
+        "migrations",
+        "supabaseSetup",
+        "supabaseRuntime",
+        "pgtapTests",
+        "{workspaceRoot}/scripts/require-test-file.sh",
+        "{workspaceRoot}/scripts/nx-file-visible.cjs",
+        "{projectRoot}/scripts/run-pgtap-file",
+        "{workspaceRoot}/tools/nx-executors/**"
+      ],
+      "cache": true
     },
     "test:unit": {
       "executor": "@nx/vite:test",
@@ -256,39 +230,22 @@
     "gen-types": {
       "executor": "nx:run-commands",
       "dependsOn": ["verify-migrations"],
-      "inputs": ["migrations", "supabaseSetup"],
+      "inputs": ["migrations", "supabaseSetup", "supabaseRuntime"],
       "outputs": ["{projectRoot}/src/database-types.ts"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "echo 'Generating database types...'",
-          "supabase gen types --local --schema pgflow --schema pgmq > src/database-types.ts",
-          "echo 'Verifying generated types...'",
-          "grep -q 'pgflow' src/database-types.ts || (echo 'ERROR: Generated types file does not contain pgflow schema!' && exit 1)",
-          "[ -s src/database-types.ts ] || (echo 'ERROR: Generated types file is empty!' && exit 1)"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/ensure-migrations-body.sh .; echo \"Generating database types...\"; supabase gen types --local --schema pgflow --schema pgmq > src/database-types.ts; grep -q pgflow src/database-types.ts || { echo \"ERROR: Generated types file does not contain pgflow schema!\"; exit 1; }; test -s src/database-types.ts || { echo \"ERROR: Generated types file is empty!\"; exit 1; }'"
       },
       "cache": true
     },
     "verify-gen-types": {
       "executor": "nx:run-commands",
       "dependsOn": ["verify-migrations"],
-      "inputs": ["migrations", "supabaseSetup", "databaseTypes"],
+      "inputs": ["migrations", "supabaseSetup", "supabaseRuntime", "databaseTypes"],
       "outputs": ["{projectRoot}/.nx-inputs/verify-gen-types.txt"],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "mkdir -p .nx-inputs",
-          "echo 'Verifying database types are up-to-date...'",
-          "cp src/database-types.ts .nx-inputs/database-types.ts.backup",
-          "supabase gen types --local --schema pgflow --schema pgmq > .nx-inputs/database-types.ts.new",
-          "diff .nx-inputs/database-types.ts.backup .nx-inputs/database-types.ts.new > .nx-inputs/verify-gen-types.txt 2>&1 || (echo 'ERROR: Database types are out of date! Run \"nx gen-types core\" to update them.' && echo '=============================================' && echo 'Diff between current and generated types:' && echo '=============================================' && diff -u .nx-inputs/database-types.ts.backup .nx-inputs/database-types.ts.new || true && echo '=============================================' && exit 1)",
-          "echo 'Database types are up-to-date' > .nx-inputs/verify-gen-types.txt"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/ensure-migrations-body.sh .; mkdir -p .nx-inputs; cp src/database-types.ts .nx-inputs/database-types.ts.backup; supabase gen types --local --schema pgflow --schema pgmq > .nx-inputs/database-types.ts.new; if ! diff .nx-inputs/database-types.ts.backup .nx-inputs/database-types.ts.new > .nx-inputs/verify-gen-types.txt 2>&1; then echo \"ERROR: Database types are out of date! Run nx gen-types core to update them.\"; diff -u .nx-inputs/database-types.ts.backup .nx-inputs/database-types.ts.new || true; exit 1; fi; echo \"Database types are up-to-date\" > .nx-inputs/verify-gen-types.txt'"
       },
       "cache": true
     },

--- a/pkgs/core/scripts/run-pgtap-file
+++ b/pkgs/core/scripts/run-pgtap-file
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Runs one pgTAP file while the caller owns the core stack resource lock.
+set -euo pipefail
+
+[[ $# -eq 1 ]] || {
+  echo "Usage: $0 <supabase/tests/file.test.sql>" >&2
+  exit 2
+}
+
+scripts_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts
+"$scripts_dir/require-test-file.sh" supabase/tests "$1"
+"$scripts_dir/ensure-migrations-body.sh" .
+exec scripts/run-test-with-colors "$1"

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -34,6 +34,8 @@
     "test:nx-deno": {
       "executor": "@axhxrx/nx-deno:test",
       "local": true,
+      "cache": true,
+      "inputs": ["default", "^productionNoDocs", "denoRuntime"],
       "outputs": ["{workspaceRoot}/coverage/pkgs/edge-worker"],
       "options": {
         "coverageDirectory": "coverage/pkgs/edge-worker",
@@ -92,8 +94,7 @@
       "cache": false,
       "options": {
         "cwd": "pkgs/edge-worker",
-        "commands": ["supabase stop --no-backup"],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . pnpm exec supabase stop --no-backup"
       }
     },
     "supabase:status": {
@@ -122,14 +123,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "mkdir -p supabase/migrations/",
-          "rm -f supabase/migrations/*.sql",
-          "cp ../core/supabase/migrations/*.sql supabase/migrations/",
-          "../../scripts/supabase-start-locked.sh .",
-          "supabase db reset"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-supabase-lock.sh . ../../scripts/ensure-migrations-body.sh . --force-reset"
       }
     },
     "db:ensure": {
@@ -147,7 +141,7 @@
       "dependsOn": ["^build"],
       "executor": "nx:run-commands",
       "local": true,
-      "inputs": ["default", "^production"],
+      "inputs": ["testInputs", "^productionNoDocs", "denoRuntime"],
       "options": {
         "cwd": "pkgs/edge-worker",
         "commands": [
@@ -169,8 +163,8 @@
       "cache": true,
       "dependsOn": ["build"],
       "inputs": [
-        "production",
-        "^production",
+        "productionNoDocs",
+        "^productionNoDocs",
         "{workspaceRoot}/scripts/smoke-edge-worker-dist.mjs"
       ],
       "options": {
@@ -187,71 +181,110 @@
       }
     },
     "test:integration": {
-      "dependsOn": ["db:ensure", "^build"],
+      "dependsOn": ["^verify-migrations", "^build"],
       "executor": "nx:run-commands",
-      "local": true,
-      "cache": true,
-      "inputs": ["testInputs", "^production"],
-      "options": {
-        "cwd": "pkgs/edge-worker",
-        "command": "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/integration/"
-      }
-    },
-    "test:integration:file": {
-      "dependsOn": ["db:ensure", "^build"],
-      "executor": "nx:run-commands",
-      "local": true,
-      "cache": true,
-      "inputs": ["testInputs", "^production"],
-      "options": {
-        "cwd": "pkgs/edge-worker",
-        "command": "test -n \"{args.file}\" || (echo 'Usage: pnpm nx test:integration:file edge-worker --args=--file=tests/integration/<file>.test.ts' >&2; exit 1); deno test --config deno.test.json --allow-all --env=supabase/functions/.env \"{args.file}\""
-      }
-    },
-    "serve:functions:e2e": {
-      "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
-      "continuous": true,
-      "local": true,
-      "cache": false,
-      "options": {
-        "cwd": "pkgs/edge-worker",
-        "readyWhen": "Serving functions on http://",
-        "command": "../../scripts/supabase-start-locked.sh . && ./scripts/sync-e2e-deps.sh && supabase functions serve --env-file supabase/functions/.env --import-map supabase/functions/deno.json --no-verify-jwt"
-      }
-    },
-    "e2e": {
-      "executor": "nx:run-commands",
-      "dependsOn": ["serve:functions:e2e"],
       "local": true,
       "cache": true,
       "inputs": [
         "testInputs",
-        "^production",
-        "{workspaceRoot}/scripts/wait-for-function.sh"
+        "^productionNoDocs",
+        "denoRuntime",
+        "supabaseSetup",
+        "{workspaceRoot}/scripts/with-integration-lock.sh"
       ],
       "options": {
         "cwd": "pkgs/edge-worker",
-        "commands": [
-          "../../scripts/wait-for-function.sh http://127.0.0.1:50321/functions/v1/auth_test 401 '\"message\":\"Unauthorized\"'",
-          "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/e2e/"
-        ],
-        "parallel": false
+        "command": "../../scripts/with-integration-lock.sh ./scripts/run-integration.sh"
+      }
+    },
+    "test:integration:file": {
+      "dependsOn": ["^verify-migrations", "^build"],
+      "executor": "@pgflow/nx-executors:focused-file",
+      "local": true,
+      "cache": true,
+      "inputs": [
+        "testInputs",
+        "^productionNoDocs",
+        "denoRuntime",
+        "supabaseSetup",
+        "{workspaceRoot}/scripts/with-integration-lock.sh",
+        "{workspaceRoot}/scripts/require-test-file.sh",
+        "{workspaceRoot}/scripts/nx-file-visible.cjs",
+        "{projectRoot}/scripts/run-integration.sh",
+        "{workspaceRoot}/tools/nx-executors/**"
+      ]
+    },
+    "e2e": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
+      "local": true,
+      "cache": true,
+      "inputs": [
+        "testInputs",
+        "^productionNoDocs",
+        "denoRuntime",
+        "supabaseRuntime",
+        "supabaseSetup",
+        "{workspaceRoot}/scripts/run-e2e.sh",
+        "{workspaceRoot}/scripts/functions-server.sh",
+        "{workspaceRoot}/scripts/ensure-migrations.sh",
+        "{workspaceRoot}/scripts/wait-for-function.sh",
+        "{projectRoot}/scripts/sync-e2e-deps.sh"
+      ],
+      "options": {
+        "cwd": "pkgs/edge-worker",
+        "command": "../../scripts/run-e2e.sh tests/e2e"
       }
     },
     "e2e:portable-runtimes": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build", "serve:functions:e2e"],
+      "dependsOn": ["build"],
       "local": true,
       "cache": false,
-      "inputs": ["default", "^production"],
+      "inputs": [
+        "testInputs",
+        "^productionNoDocs",
+        "denoRuntime",
+        "supabaseRuntime",
+        "supabaseSetup",
+        "{workspaceRoot}/scripts/run-e2e.sh",
+        "{workspaceRoot}/scripts/functions-server.sh",
+        "{workspaceRoot}/scripts/ensure-migrations.sh",
+        "{workspaceRoot}/scripts/wait-for-function.sh",
+        "{projectRoot}/scripts/sync-e2e-deps.sh"
+      ],
       "options": {
         "cwd": "pkgs/edge-worker",
-        "commands": [
-          "../../scripts/wait-for-function.sh http://127.0.0.1:50321/functions/v1/auth_test 401 '\"message\":\"Unauthorized\"'",
-          "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/e2e-portable-runtimes/"
-        ],
-        "parallel": false
+        "command": "../../scripts/run-e2e.sh tests/e2e-portable-runtimes"
+      }
+    },
+    "test:lifecycle": {
+      "executor": "nx:run-commands",
+      "local": true,
+      "cache": true,
+      "inputs": [
+        "{workspaceRoot}/scripts/test-lifecycle.sh",
+        "{workspaceRoot}/scripts/lock-dir.sh",
+        "{workspaceRoot}/scripts/with-supabase-lock.sh",
+        "{workspaceRoot}/scripts/with-integration-lock.sh",
+        "{workspaceRoot}/scripts/require-test-file.sh",
+        "{workspaceRoot}/scripts/nx-file-visible.cjs",
+        "{workspaceRoot}/scripts/test-env-fresh.sh",
+        "{workspaceRoot}/pkgs/client/project.json",
+        "{workspaceRoot}/scripts/functions-server.sh",
+        "{workspaceRoot}/scripts/supabase-start.sh",
+        "{workspaceRoot}/scripts/get-enabled-services.mjs",
+        "{workspaceRoot}/scripts/ensure-migrations.sh",
+        "{workspaceRoot}/scripts/ensure-migrations-body.sh",
+        "{workspaceRoot}/scripts/run-e2e.sh",
+        "{projectRoot}/scripts/ensure-db-core",
+        "{projectRoot}/scripts/run-integration.sh",
+        "{workspaceRoot}/pkgs/core/scripts/run-pgtap-file",
+        "{workspaceRoot}/tools/nx-executors/**"
+      ],
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "command": "scripts/test-lifecycle.sh"
       }
     },
     "test": {
@@ -262,7 +295,7 @@
       "executor": "nx:run-commands",
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
+      "inputs": ["production", "^productionNoDocs", "denoRuntime"],
       "options": {
         "cwd": "{projectRoot}",
         "command": "deno check --config deno.test.json src/examples/*.example.ts tests/types/*.test-d.ts"

--- a/pkgs/edge-worker/project.json
+++ b/pkgs/edge-worker/project.json
@@ -3,9 +3,21 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "pkgs/edge-worker",
   "projectType": "library",
+  "namedInputs": {
+    "testInputs": ["default", "!{projectRoot}/**/*.md"]
+  },
   "targets": {
     "supabase:ci-marker": {
       "executor": "nx:noop"
+    },
+    "test-env:fresh": {
+      "executor": "nx:run-commands",
+      "local": true,
+      "cache": false,
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "command": "scripts/test-env-fresh.sh"
+      }
     },
     "build": {
       "executor": "@nx/js:tsc",
@@ -100,8 +112,7 @@
       "cache": false,
       "options": {
         "cwd": "pkgs/edge-worker",
-        "commands": ["supabase stop --no-backup", "supabase start"],
-        "parallel": false
+        "command": "../../scripts/supabase-start-locked.sh --restart ."
       }
     },
     "supabase:reset": {
@@ -179,13 +190,22 @@
       "dependsOn": ["db:ensure", "^build"],
       "executor": "nx:run-commands",
       "local": true,
-      "inputs": ["default", "^production"],
+      "cache": true,
+      "inputs": ["testInputs", "^production"],
       "options": {
         "cwd": "pkgs/edge-worker",
-        "commands": [
-          "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/integration/"
-        ],
-        "parallel": false
+        "command": "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/integration/"
+      }
+    },
+    "test:integration:file": {
+      "dependsOn": ["db:ensure", "^build"],
+      "executor": "nx:run-commands",
+      "local": true,
+      "cache": true,
+      "inputs": ["testInputs", "^production"],
+      "options": {
+        "cwd": "pkgs/edge-worker",
+        "command": "test -n \"{args.file}\" || (echo 'Usage: pnpm nx test:integration:file edge-worker --args=--file=tests/integration/<file>.test.ts' >&2; exit 1); deno test --config deno.test.json --allow-all --env=supabase/functions/.env \"{args.file}\""
       }
     },
     "serve:functions:e2e": {
@@ -204,11 +224,16 @@
       "executor": "nx:run-commands",
       "dependsOn": ["serve:functions:e2e"],
       "local": true,
-      "inputs": ["default", "^production"],
+      "cache": true,
+      "inputs": [
+        "testInputs",
+        "^production",
+        "{workspaceRoot}/scripts/wait-for-function.sh"
+      ],
       "options": {
         "cwd": "pkgs/edge-worker",
         "commands": [
-          "timeout 120 bash -c 'echo \"Waiting for functions server (port 50321)...\"; until nc -z localhost 50321 2>/dev/null; do sleep 0.5; done; echo \" Ready!\"' || (echo 'TIMEOUT: Functions server not available on port 50321 after 120s' && exit 1)",
+          "../../scripts/wait-for-function.sh http://127.0.0.1:50321/functions/v1/auth_test 401 '\"message\":\"Unauthorized\"'",
           "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/e2e/"
         ],
         "parallel": false
@@ -223,7 +248,7 @@
       "options": {
         "cwd": "pkgs/edge-worker",
         "commands": [
-          "deno run --allow-net=localhost:50321 \"data:application/typescript,console.log(%22Waiting%20for%20functions%20server%20(port%2050321)...%22)%3B%20const%20deadline%20%3D%20Date.now()%20%2B%20120_000%3B%20while%20(Date.now()%20%3C%20deadline)%20%7B%20try%20%7B%20const%20conn%20%3D%20await%20Deno.connect(%7B%20hostname%3A%20%22localhost%22%2C%20port%3A%2050321%20%7D)%3B%20conn.close()%3B%20console.log(%22%20Ready!%22)%3B%20Deno.exit(0)%3B%20%7D%20catch%20%7B%20await%20new%20Promise((resolve)%20%3D%3E%20setTimeout(resolve%2C%20500))%3B%20%7D%20%7D%20console.error(%22TIMEOUT%3A%20Functions%20server%20not%20available%20on%20port%2050321%20after%20120s%22)%3B%20Deno.exit(1)%3B\"",
+          "../../scripts/wait-for-function.sh http://127.0.0.1:50321/functions/v1/auth_test 401 '\"message\":\"Unauthorized\"'",
           "deno test --config deno.test.json --allow-all --env=supabase/functions/.env tests/e2e-portable-runtimes/"
         ],
         "parallel": false

--- a/pkgs/edge-worker/scripts/ensure-db
+++ b/pkgs/edge-worker/scripts/ensure-db
@@ -1,28 +1,43 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Clean up any existing containers
-echo "Shutting down existing database containers..."
-docker compose -f tests/db/compose.yaml down --volumes --remove-orphans
+COMPOSE_FILE=tests/db/compose.yaml
+MIGRATIONS_FILE=tests/db/migrations/pgflow.sql
 
-# Clean migrations
-echo "Cleaning migrations..."
-rm -f tests/db/migrations/*.sql || true
+exec 9>/tmp/pgflow-test-environment.lock
+flock --shared 9
 
-# Copy migrations
-echo "Copying migrations..."
+echo "Preparing integration database migrations..."
+rm -f tests/db/migrations/*.sql
 ./scripts/concatenate-migrations.sh
+migration_hash=$(sed '/^-- Generated on /d' "$MIGRATIONS_FILE" | sha256sum | cut -d' ' -f1)
+config_hash=$(PGFLOW_MIGRATIONS_HASH="$migration_hash" docker compose -f "$COMPOSE_FILE" config --hash db | awk '$1 == "db" { print $2 }')
+[[ -n "$config_hash" ]] || { echo "Could not compute the integration database config hash." >&2; exit 1; }
+container=$(docker compose -f "$COMPOSE_FILE" ps -q db)
 
-# Start fresh containers
-echo "Starting database..."
-docker compose -f tests/db/compose.yaml up --detach
+if [[ -n "$container" \
+  && "$(docker inspect "$container" --format '{{.State.Running}}')" == "true" \
+  && "$(docker inspect "$container" --format '{{index .Config.Labels "dev.pgflow.migrations-hash"}}')" == "$migration_hash" \
+  && "$(docker inspect "$container" --format '{{index .Config.Labels "com.docker.compose.config-hash"}}')" == "$config_hash" \
+  ]] \
+  && docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; then
+  echo "Integration database is already ready."
+  exit 0
+fi
 
-# Wait for database to be ready
-echo "Waiting for database to be available..."
-./scripts/wait-for-localhost 5432
+echo "Starting a fresh integration database..."
+docker compose -f "$COMPOSE_FILE" down --volumes --remove-orphans
+PGFLOW_MIGRATIONS_HASH="$migration_hash" docker compose -f "$COMPOSE_FILE" up --detach
+container=$(docker compose -f "$COMPOSE_FILE" ps -q db)
 
-# Additional pause to ensure database is fully initialized
-echo "Waiting for database initialization..."
-sleep 5
+for _ in $(seq 1 100); do
+  if docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; then
+    sleep 5
+    echo "Integration database is ready."
+    exit 0
+  fi
+  sleep 0.1
+done
 
-echo "Database is ready!"
+echo "Integration database did not become ready." >&2
+exit 1

--- a/pkgs/edge-worker/scripts/ensure-db
+++ b/pkgs/edge-worker/scripts/ensure-db
@@ -1,43 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE_FILE=tests/db/compose.yaml
-MIGRATIONS_FILE=tests/db/migrations/pgflow.sql
+# Standalone entry point for integration database setup. Takes the exclusive
+# integration resource lock (plus the shared environment lock) and runs the
+# core setup, so a standalone ensure cannot race a full or focused
+# integration suite using the same resource.
 
-exec 9>/tmp/pgflow-test-environment.lock
-flock --shared 9
-
-echo "Preparing integration database migrations..."
-rm -f tests/db/migrations/*.sql
-./scripts/concatenate-migrations.sh
-migration_hash=$(sed '/^-- Generated on /d' "$MIGRATIONS_FILE" | sha256sum | cut -d' ' -f1)
-config_hash=$(PGFLOW_MIGRATIONS_HASH="$migration_hash" docker compose -f "$COMPOSE_FILE" config --hash db | awk '$1 == "db" { print $2 }')
-[[ -n "$config_hash" ]] || { echo "Could not compute the integration database config hash." >&2; exit 1; }
-container=$(docker compose -f "$COMPOSE_FILE" ps -q db)
-
-if [[ -n "$container" \
-  && "$(docker inspect "$container" --format '{{.State.Running}}')" == "true" \
-  && "$(docker inspect "$container" --format '{{index .Config.Labels "dev.pgflow.migrations-hash"}}')" == "$migration_hash" \
-  && "$(docker inspect "$container" --format '{{index .Config.Labels "com.docker.compose.config-hash"}}')" == "$config_hash" \
-  ]] \
-  && docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; then
-  echo "Integration database is already ready."
-  exit 0
-fi
-
-echo "Starting a fresh integration database..."
-docker compose -f "$COMPOSE_FILE" down --volumes --remove-orphans
-PGFLOW_MIGRATIONS_HASH="$migration_hash" docker compose -f "$COMPOSE_FILE" up --detach
-container=$(docker compose -f "$COMPOSE_FILE" ps -q db)
-
-for _ in $(seq 1 100); do
-  if docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; then
-    sleep 5
-    echo "Integration database is ready."
-    exit 0
-  fi
-  sleep 0.1
-done
-
-echo "Integration database did not become ready." >&2
-exit 1
+cd "$(dirname "$0")/.."
+exec ../../scripts/with-integration-lock.sh scripts/ensure-db-core

--- a/pkgs/edge-worker/scripts/ensure-db-core
+++ b/pkgs/edge-worker/scripts/ensure-db-core
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Core integration database setup. Invoked under the exclusive integration
+# resource lock (scripts/with-integration-lock.sh), which also holds the
+# shared environment lock, so this file takes no locks itself.
+#
+# Database identity is certified twice: container labels record WHAT should
+# be applied, and a fingerprint stored in the live database records that
+# initialization actually completed with that content. The official postgres
+# image runs init scripts on a socket-only temporary server and only then
+# starts the real TCP server, so pg_isready over TCP (-h 127.0.0.1) is the
+# readiness signal that 950_pgflow.sql finished; a fixed sleep is not.
+#
+# `--self-test` exercises the control flow with stubbed docker/compose.
+
+COMPOSE_FILE=tests/db/compose.yaml
+MIGRATIONS_FILE=tests/db/migrations/pgflow.sql
+DB_READY_TIMEOUT_SEC=${PGFLOW_DB_READY_TIMEOUT_SEC:-180}
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+concatenate_migrations() { ./scripts/concatenate-migrations.sh; }
+
+prepare_migrations() {
+  echo "Preparing integration database migrations..."
+  rm -f tests/db/migrations/*.sql
+  concatenate_migrations
+  migration_hash=$(sed '/^-- Generated on /d' "$MIGRATIONS_FILE" | sha256sum | cut -d' ' -f1)
+  config_hash=$(PGFLOW_MIGRATIONS_HASH="$migration_hash" compose config --hash db | awk '$1 == "db" { print $2 }')
+  [[ -n "$config_hash" ]] || { echo "Could not compute the integration database config hash." >&2; return 1; }
+  container=$(compose ps -q db)
+}
+
+db_fingerprint() {
+  docker exec "$container" psql -U postgres -d postgres -tA -c \
+    "SELECT value FROM public.pgflow_setup_fingerprint WHERE key = 'migrations'" 2>/dev/null || true
+}
+
+write_db_fingerprint() {
+  docker exec "$container" psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q -c "
+    CREATE TABLE IF NOT EXISTS public.pgflow_setup_fingerprint (
+      key text PRIMARY KEY,
+      value text NOT NULL
+    );
+    INSERT INTO public.pgflow_setup_fingerprint (key, value)
+    VALUES ('migrations', '$migration_hash')
+    ON CONFLICT (key) DO UPDATE SET value = excluded.value;
+  "
+}
+
+container_running() {
+  [[ "$(docker inspect "$container" --format '{{.State.Running}}' 2>/dev/null || true)" == "true" ]]
+}
+
+container_label() { # container_label <label>
+  docker inspect "$container" --format "{{index .Config.Labels \"$1\"}}" 2>/dev/null || true
+}
+
+container_logs() {
+  docker logs --tail 50 "$container" >&2 2>/dev/null || true
+}
+
+tcp_ready() {
+  docker exec "$container" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1
+}
+
+wait_for_database() {
+  echo "Waiting for the integration database to become ready (TCP)..."
+  local deadline=$((SECONDS + DB_READY_TIMEOUT_SEC))
+  while ((SECONDS < deadline)); do
+    if ! container_running; then
+      echo "Integration database container exited during initialization. Last logs:" >&2
+      container_logs
+      return 1
+    fi
+    if tcp_ready; then
+      write_db_fingerprint || {
+        echo "Writing the integration database fingerprint failed." >&2
+        return 1
+      }
+      echo "Integration database is ready."
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "Integration database did not become ready within ${DB_READY_TIMEOUT_SEC}s." >&2
+  container_logs
+  return 1
+}
+
+ensure_db() {
+  # Note: container_running and tcp_ready must run as commands in an if/&&
+  # chain, never as bare words inside [[ ]] - there they are nonempty
+  # strings (always true) and the reuse decision would skip the live checks.
+  if [[ -n "$container" ]] \
+    && container_running \
+    && [[ "$(container_label dev.pgflow.migrations-hash)" == "$migration_hash" ]] \
+    && [[ "$(container_label com.docker.compose.config-hash)" == "$config_hash" ]] \
+    && tcp_ready \
+    && [[ "$(db_fingerprint)" == "$migration_hash" ]]; then
+    echo "Integration database is already ready."
+    return 0
+  fi
+
+  echo "Starting a fresh integration database..."
+  compose down --volumes --remove-orphans
+  PGFLOW_MIGRATIONS_HASH="$migration_hash" compose up --detach
+  container=$(compose ps -q db)
+  wait_for_database
+}
+
+self_test() {
+  local failures=0 status STUB_DIR DOCKER_CALLS
+  STUB_DIR=$(mktemp -d)
+  DOCKER_CALLS=$(mktemp)
+
+  migration_hash=aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111
+  config_hash=cccc3333
+  container=stub-container-id
+  concatenate_migrations() { :; }
+
+  docker() {
+    echo "docker $*" >>"$DOCKER_CALLS"
+    case "$*" in
+      compose*" ps -q db") echo stub-container-id ;;
+      compose*" up "*) [[ -f "$STUB_DIR/up-starts" ]] && touch "$STUB_DIR/running" ;;
+      compose*) : ;;
+      *"--format {{index .Config.Labels \"dev.pgflow.migrations-hash\"}}"*) cat "$STUB_DIR/label-hash" 2>/dev/null ;;
+      *"--format {{index .Config.Labels \"com.docker.compose.config-hash\"}}"*) cat "$STUB_DIR/label-config" 2>/dev/null ;;
+      *"{{.State.Running}}"*) [[ -f "$STUB_DIR/running" ]] && echo true || echo false ;;
+      *pg_isready*) [[ -f "$STUB_DIR/tcp-ready" ]] && return 0 || return 1 ;;
+      *"WHERE key = 'migrations'"*) cat "$STUB_DIR/db-fingerprint" 2>/dev/null ;;
+      *ON_ERROR_STOP*)
+        [[ -f "$STUB_DIR/write-fails" ]] && return 1
+        echo "$migration_hash" >"$STUB_DIR/db-fingerprint"
+        ;;
+    esac
+  }
+
+  expect_status() {
+    local name=$1 want=$2
+    shift 2
+    : >"$DOCKER_CALLS"
+    set +e
+    "$@" >/dev/null 2>&1
+    status=$?
+    set -e
+    if [[ "$status" == "$want" ]]; then
+      echo "ok   $name"
+    else
+      echo "FAIL $name (expected $want, got $status)"
+      failures=$((failures + 1))
+    fi
+  }
+  calls_match() {
+    if grep -qE "$2" "$DOCKER_CALLS"; then
+      echo "ok   $1"
+    else
+      echo "FAIL $1 (wanted /$2/ in: $(paste -sd';' <"$DOCKER_CALLS"))"
+      failures=$((failures + 1))
+    fi
+  }
+  calls_absent() {
+    if grep -qE "$2" "$DOCKER_CALLS"; then
+      echo "FAIL $1 (unwanted /$2/ in: $(paste -sd';' <"$DOCKER_CALLS"))"
+      failures=$((failures + 1))
+    else
+      echo "ok   $1"
+    fi
+  }
+
+  # Reuse: labels + TCP + live fingerprint all match -> no recreation. The
+  # reuse decision must actually invoke the running-state and TCP-readiness
+  # checks (they are commands in the if chain, not strings).
+  echo "$migration_hash" >"$STUB_DIR/label-hash"
+  echo "$config_hash" >"$STUB_DIR/label-config"
+  echo "$migration_hash" >"$STUB_DIR/db-fingerprint"
+  touch "$STUB_DIR/running" "$STUB_DIR/tcp-ready"
+  expect_status "reuse on complete identity match" 0 ensure_db
+  calls_match "reuse checks the live fingerprint" "WHERE key = 'migrations'"
+  calls_match "reuse verifies the container is running" '\{\{.State.Running}}'
+  calls_match "reuse probes TCP readiness" 'pg_isready'
+  calls_absent "reuse does not recreate" 'compose.* (down|up) '
+
+  # Running check fails (stopped leftover container) -> recreate and reach
+  # readiness through the fresh path.
+  rm -f "$STUB_DIR/running" "$STUB_DIR/db-fingerprint"
+  touch "$STUB_DIR/up-starts" "$STUB_DIR/tcp-ready"
+  expect_status "stopped container recreates" 0 ensure_db
+  calls_match "recreation after stopped container" 'compose.* up '
+  rm -f "$STUB_DIR/up-starts"
+
+  # Labels match but the live fingerprint is missing -> recreate; a container
+  # label created before initialization is not success evidence.
+  rm -f "$STUB_DIR/db-fingerprint"
+  expect_status "label without live fingerprint recreates" 0 ensure_db
+  calls_match "recreation performed" 'compose.* up '
+
+  # Initialization crash: container exits during the wait -> fast failure
+  # with logs, not a silent 180s timeout.
+  rm -f "$STUB_DIR/running" "$STUB_DIR/tcp-ready" "$STUB_DIR/db-fingerprint"
+  expect_status "container exit during initialization fails fast" 1 ensure_db
+  calls_match "failure dumps container logs" 'docker logs'
+
+  # Readiness timeout with a running but never-ready container.
+  touch "$STUB_DIR/running"
+  DB_READY_TIMEOUT_SEC=1
+  expect_status "readiness timeout fails" 1 ensure_db
+
+  # Fingerprint write failure after readiness propagates.
+  touch "$STUB_DIR/tcp-ready" "$STUB_DIR/write-fails"
+  expect_status "fingerprint write failure propagates" 1 ensure_db
+
+  rm -rf "$STUB_DIR" "$DOCKER_CALLS"
+  if [[ "$failures" -eq 0 ]]; then
+    echo "ensure-db-core self-test passed."
+    return 0
+  fi
+  echo "$failures ensure-db-core self-test check(s) failed." >&2
+  return 1
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+elif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  prepare_migrations
+  ensure_db
+fi

--- a/pkgs/edge-worker/scripts/run-integration.sh
+++ b/pkgs/edge-worker/scripts/run-integration.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Runs edge-worker integration tests together with their database setup under
+# one exclusive integration resource lock, so migration preparation, live
+# setup, and the whole suite form a single critical section across full,
+# focused, and standalone ensure paths.
+#
+# Invoked through scripts/with-integration-lock.sh (which holds the locks for
+# this command's whole lifetime):
+#   with-integration-lock.sh ./scripts/run-integration.sh [file]
+# An optional file argument is validated (scripts/require-test-file.sh)
+# before any setup runs.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [tests/integration/<file>.test.ts]" >&2
+  exit 2
+fi
+if [[ $# -eq 1 ]]; then
+  ../../scripts/require-test-file.sh tests/integration "$1"
+fi
+
+./scripts/ensure-db-core
+exec deno test --config deno.test.json --allow-all --env=supabase/functions/.env "${1:-tests/integration}"

--- a/pkgs/edge-worker/tests/db/compose.yaml
+++ b/pkgs/edge-worker/tests/db/compose.yaml
@@ -1,9 +1,13 @@
+name: pgflow-edge-worker-tests
+
 services:
   db:
     # Must match image in pkgs/core/atlas/atlas.hcl for baseline compatibility
     image: jumski/atlas-postgres-pgflow:17.6.1.054
     ports:
       - '5432:5432'
+    labels:
+      dev.pgflow.migrations-hash: '${PGFLOW_MIGRATIONS_HASH:-unset}'
     volumes:
       - ./migrations/pgflow.sql:/docker-entrypoint-initdb.d/950_pgflow.sql
     environment:

--- a/pkgs/website/project.json
+++ b/pkgs/website/project.json
@@ -72,7 +72,7 @@
       "cache": false,
       "options": {
         "cwd": "pkgs/website",
-        "command": "supabase start"
+        "command": "../../scripts/supabase-start-locked.sh ."
       }
     },
     "supabase:stop": {
@@ -108,10 +108,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "../../scripts/supabase-start-locked.sh .",
-          "astro dev"
-        ]
+        "commands": ["../../scripts/supabase-start-locked.sh .", "astro dev"]
       }
     }
   }

--- a/pkgs/website/project.json
+++ b/pkgs/website/project.json
@@ -81,7 +81,7 @@
       "cache": false,
       "options": {
         "cwd": "pkgs/website",
-        "command": "supabase stop --no-backup"
+        "command": "../../scripts/with-supabase-lock.sh . pnpm exec supabase stop --no-backup"
       }
     },
     "supabase:status": {
@@ -99,7 +99,7 @@
       "cache": false,
       "options": {
         "cwd": "pkgs/website",
-        "command": "supabase studio"
+        "command": "../../scripts/with-supabase-lock.sh . pnpm exec supabase studio"
       }
     },
     "dev:full": {
@@ -108,7 +108,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "commands": ["../../scripts/supabase-start-locked.sh .", "astro dev"]
+        "command": "../../scripts/with-supabase-lock.sh . bash -ceu '../../scripts/supabase-start.sh .; astro dev'"
       }
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,8 @@ importers:
         specifier: ^4.20.3
         version: 4.47.0(@cloudflare/workers-types@4.20251118.0)
 
+  tools/nx-executors: {}
+
 packages:
 
   '@adobe/css-tools@4.3.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'pkgs/*'
   - 'apps/*'
+  - 'tools/*'
   - '!pkgs/*/dist'
   - '!**/dist/**'
 

--- a/scripts/ensure-migrations-body.sh
+++ b/scripts/ensure-migrations-body.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Lock-assuming migration materialization body. Call it only through
+# scripts/with-supabase-lock.sh; the public ensure-migrations.sh entry point
+# acquires that lock before it reaches this file.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/ensure-migrations.sh
+source "$script_dir/ensure-migrations.sh"
+
+run_ensure_migrations_body "$@"

--- a/scripts/ensure-migrations.sh
+++ b/scripts/ensure-migrations.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+# Public entry point for migration materialization. It acquires the stack lock
+# and runs the lock-assuming body in ensure-migrations-body.sh.
+set -euo pipefail
+
+SCRIPTS_DIR=${SCRIPTS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}
+# shellcheck source=scripts/supabase-start.sh
+source "$SCRIPTS_DIR/supabase-start.sh"
+
+declare -a required_services=()
+REALTIME_ROUTE_API_URL=
+REALTIME_ROUTE_ANON_KEY=
+
+compute_database_fingerprint() {
+  {
+    printf '%s\n' '-- migrations'
+    while IFS= read -r migration; do
+      printf '%s\n' "-- $migration"
+      cat "$migration"
+    done < <(find supabase/migrations -maxdepth 1 -type f -name '*.sql' -print | LC_ALL=C sort)
+    if [[ -f supabase/seed.sql ]]; then
+      printf '%s\n' '-- supabase/seed.sql'
+      cat supabase/seed.sql
+    fi
+  } | sha256sum | cut -d' ' -f1
+}
+
+compute_stack_fingerprint() {
+  local root setup
+  root=$(git -C "$PROJECT_DIR" rev-parse --show-toplevel)
+  {
+    printf '%s\n' '-- supabase/config.toml'
+    cat supabase/config.toml
+    for setup in \
+      "$SCRIPTS_DIR/supabase-start.sh" \
+      "$SCRIPTS_DIR/get-enabled-services.mjs" \
+      "$SCRIPTS_DIR/ensure-migrations.sh" \
+      "$SCRIPTS_DIR/ensure-migrations-body.sh"; do
+      printf '%s\n' "-- $setup"
+      cat "$setup"
+    done
+    if [[ -f scripts/prepare-supabase.sh ]]; then
+      printf '%s\n' '-- scripts/prepare-supabase.sh'
+      cat scripts/prepare-supabase.sh
+    fi
+    printf '%s\n' '-- pnpm-lock.yaml'
+    cat "$root/pnpm-lock.yaml"
+    printf '%s\n' '-- supabase-cli-version'
+    pnpm exec supabase --version
+  } | sha256sum | cut -d' ' -f1
+}
+
+read_applied_fingerprint() { # read_applied_fingerprint <key>
+  local key=$1 attempt
+  for attempt in 1 2 3; do
+    docker exec "$container" psql -U postgres -d postgres -tA -c \
+      "SELECT value FROM public.pgflow_setup_fingerprint WHERE key = '$key'" \
+      2>/dev/null && return 0
+    [[ "$attempt" == 3 ]] || sleep 2
+  done
+  return 1
+}
+
+invalidate_applied_fingerprints() {
+  docker exec "$container" psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q -c \
+    'DROP TABLE IF EXISTS public.pgflow_setup_fingerprint'
+}
+
+write_applied_fingerprints() {
+  docker exec "$container" psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q -c "
+    CREATE TABLE public.pgflow_setup_fingerprint (
+      key text PRIMARY KEY,
+      value text NOT NULL
+    );
+    INSERT INTO public.pgflow_setup_fingerprint (key, value)
+    VALUES
+      ('database-content', '$expected_database'),
+      ('stack-setup', '$expected_stack')
+    ON CONFLICT (key) DO UPDATE SET value = excluded.value;
+  "
+}
+
+reset_database() {
+  pnpm exec supabase db reset
+}
+
+has_required_service() { # has_required_service <service>
+  local expected=$1 service
+  for service in "${required_services[@]}"; do
+    [[ "$service" == "$expected" ]] && return 0
+  done
+  return 1
+}
+
+read_supabase_status_value() { # read_supabase_status_value <name> <status-output>
+  local name=$1 status=$2
+  sed -nE "s/^${name}=\"?([^\"[:space:]]+)\"?$/\1/p" <<<"$status" | head -1
+}
+
+load_realtime_route_config() {
+  local status
+  status=$(timeout 10 pnpm exec supabase status -o env 2>/dev/null) || {
+    echo "Could not read the configured Supabase API route for '$project_id'." >&2
+    return 1
+  }
+  REALTIME_ROUTE_API_URL=$(read_supabase_status_value API_URL "$status")
+  REALTIME_ROUTE_ANON_KEY=$(read_supabase_status_value ANON_KEY "$status")
+  [[ -n "$REALTIME_ROUTE_API_URL" ]] || {
+    echo "Could not read the configured Supabase Realtime route for '$project_id'." >&2
+    return 1
+  }
+}
+
+probe_realtime_kong_route() {
+  PGFLOW_REALTIME_API_URL="$REALTIME_ROUTE_API_URL" \
+    PGFLOW_REALTIME_ANON_KEY="$REALTIME_ROUTE_ANON_KEY" /usr/bin/python3 - <<'PY'
+import os
+import socket
+import sys
+from urllib.parse import urlencode, urlparse
+
+api = urlparse(os.environ["PGFLOW_REALTIME_API_URL"])
+key = os.environ["PGFLOW_REALTIME_ANON_KEY"]
+if api.scheme != "http" or not api.hostname:
+    sys.exit(1)
+port = api.port or 80
+host = api.hostname if port == 80 else f"{api.hostname}:{port}"
+if key:
+    path = f"{api.path.rstrip('/')}/realtime/v1/websocket?{urlencode({'apikey': key, 'vsn': '1.0.0'})}"
+    request = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}\r\n"
+        "Connection: Upgrade\r\n"
+        "Upgrade: websocket\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+    ).encode()
+    expected_status = b"101"
+else:
+    # Auth-disabled stacks have no local API key. This hits Kong's configured
+    # Realtime HTTP route to the same realtime:4000 upstream.
+    path = f"{api.path.rstrip('/')}/realtime/v1/api/ping"
+    request = f"GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n".encode()
+    expected_status = b"200"
+try:
+    with socket.create_connection((api.hostname, port), timeout=2) as sock:
+        sock.settimeout(2)
+        sock.sendall(request)
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+except OSError:
+    sys.exit(1)
+status = response.split(b"\r\n", 1)[0].split()
+sys.exit(0 if len(status) >= 2 and status[1] == expected_status else 1)
+PY
+}
+
+wait_for_realtime_kong_route() {
+  local deadline=$((SECONDS + 60))
+  load_realtime_route_config || return 1
+  until probe_realtime_kong_route; do
+    if ((SECONDS >= deadline)); then
+      echo "Supabase Realtime route for '$project_id' did not become ready within 60s." >&2
+      return 1
+    fi
+    sleep 0.5
+  done
+}
+
+wait_for_post_reset_services() {
+  wait_for_required_services || return 1
+  if has_required_service realtime && has_required_service kong; then
+    wait_for_realtime_kong_route
+  fi
+}
+
+restart_stack() {
+  "$SCRIPTS_DIR/supabase-start.sh" --restart "$PROJECT_DIR"
+}
+
+ensure_migrations() {
+  local applied_database applied_stack invalidated=false
+  applied_database=$(read_applied_fingerprint database-content || true)
+  applied_stack=$(read_applied_fingerprint stack-setup || true)
+
+  if [[ "$applied_stack" != "$expected_stack" ]]; then
+    echo "Stack setup for '$project_id' changed; restarting from the current configuration..."
+    # Remove success evidence before the restart. A failed A -> B -> A setup
+    # cannot later reuse an old certificate.
+    invalidate_applied_fingerprints
+    invalidated=true
+    restart_stack
+    applied_database=
+    applied_stack=
+  fi
+
+  if [[ "$FORCE_RESET" != true \
+    && "$applied_database" == "$expected_database" \
+    && "$applied_stack" == "$expected_stack" ]]; then
+    echo "Database migrations for '$project_id' are current (fingerprint match)."
+    return 0
+  fi
+
+  if [[ "$invalidated" != true ]]; then
+    invalidate_applied_fingerprints
+  fi
+  if [[ "$FORCE_RESET" == true ]]; then
+    echo "Forcing a reset of the '$project_id' database..."
+  elif [[ -n "$applied_database" ]]; then
+    echo "Database content for '$project_id' changed; resetting..."
+  else
+    echo "No applied database fingerprint found for '$project_id'; resetting..."
+  fi
+
+  reset_database || {
+    echo "Resetting the '$project_id' database failed; no fingerprint was written." >&2
+    return 1
+  }
+  wait_for_post_reset_services || {
+    echo "Supabase services for '$project_id' did not become ready after database reset; no fingerprint was written." >&2
+    return 1
+  }
+  write_applied_fingerprints || {
+    echo "Writing applied fingerprints for '$project_id' failed." >&2
+    return 1
+  }
+  echo "Database migrations for '$project_id' applied and fingerprinted."
+}
+
+parse_arguments() {
+  FORCE_RESET=false
+  PROJECT_DIR=
+  while (($#)); do
+    case "$1" in
+      --force-reset) FORCE_RESET=true ;;
+      -*) echo "Unknown option: $1" >&2; return 2 ;;
+      *)
+        [[ -z "$PROJECT_DIR" ]] || {
+          echo "Usage: $0 [--force-reset] <project-dir>" >&2
+          return 2
+        }
+        PROJECT_DIR=$1
+        ;;
+    esac
+    shift
+  done
+  [[ -n "$PROJECT_DIR" && -d "$PROJECT_DIR" ]] || {
+    echo "Usage: $0 [--force-reset] <project-dir>" >&2
+    return 2
+  }
+  PROJECT_DIR=$(realpath "$PROJECT_DIR")
+}
+
+run_ensure_migrations_body() {
+  SCRIPTS_DIR=${SCRIPTS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}
+  parse_arguments "$@"
+
+  cd "$PROJECT_DIR"
+  project_id=$(sed -nE 's/^[[:space:]]*project_id[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' supabase/config.toml | head -1)
+  [[ -n "$project_id" ]] || {
+    echo "Could not read project_id from $PROJECT_DIR/supabase/config.toml." >&2
+    return 1
+  }
+  container="supabase_db_${project_id}"
+  mapfile -t required_services < <(node "$SCRIPTS_DIR/get-enabled-services.mjs" supabase/config.toml)
+  ((${#required_services[@]})) || {
+    echo "Could not determine required services from $PROJECT_DIR/supabase/config.toml." >&2
+    return 1
+  }
+
+  # This runs edge-worker migration preparation before the running-stack fast
+  # path and before either fingerprint reads the generated mirror.
+  "$SCRIPTS_DIR/supabase-start.sh" "$PROJECT_DIR"
+  expected_database=$(compute_database_fingerprint)
+  expected_stack=$(compute_stack_fingerprint)
+  [[ "$expected_database" =~ ^[0-9a-f]{64}$ && "$expected_stack" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "Could not compute the database or stack fingerprint." >&2
+    return 1
+  }
+
+  ensure_migrations
+}
+
+project_dir_from_arguments() {
+  local argument project_dir=
+  for argument in "$@"; do
+    [[ "$argument" == --force-reset ]] && continue
+    [[ "$argument" != -* ]] || return 1
+    [[ -z "$project_dir" ]] || return 1
+    project_dir=$argument
+  done
+  [[ -n "$project_dir" && -d "$project_dir" ]] || return 1
+  realpath "$project_dir"
+}
+
+run_ensure_migrations() {
+  local project_dir
+  project_dir=$(project_dir_from_arguments "$@") || {
+    echo "Usage: $0 [--force-reset] <project-dir>" >&2
+    exit 2
+  }
+  SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  exec "$SCRIPTS_DIR/with-supabase-lock.sh" "$project_dir" \
+    "$SCRIPTS_DIR/ensure-migrations-body.sh" "$@"
+}
+
+self_test() {
+  local root status reset_line restart_line health_line route_line write_line failures=0
+  root=$(mktemp -d)
+  SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  PROJECT_DIR=$root
+  project_id=selftest
+  container=supabase_db_selftest
+  expected_database=database-a
+  expected_stack=stack-a
+  FORCE_RESET=false
+
+  docker() {
+    echo "docker $*" >>"$root/calls"
+    case "$*" in
+      *"WHERE key = 'database-content'"*) [[ -f "$root/database" ]] && cat "$root/database" || return 1 ;;
+      *"WHERE key = 'stack-setup'"*) [[ -f "$root/stack" ]] && cat "$root/stack" || return 1 ;;
+      *"DROP TABLE IF EXISTS"*) rm -f "$root/database" "$root/stack" ;;
+      *"ON CONFLICT"*)
+        [[ -f "$root/write-fails" ]] && return 1
+        printf '%s\n' "$expected_database" >"$root/database"
+        printf '%s\n' "$expected_stack" >"$root/stack"
+        ;;
+    esac
+  }
+  pnpm() {
+    echo "pnpm $*" >>"$root/calls"
+    [[ -f "$root/reset-fails" ]] && return 1
+    return 0
+  }
+  restart_stack() {
+    echo restart_stack >>"$root/calls"
+    [[ -f "$root/restart-fails" ]] && return 1
+    return 0
+  }
+  required_services=(db realtime kong)
+  wait_for_required_services() {
+    echo wait_for_required_services >>"$root/calls"
+    [[ ! -f "$root/health-fails" ]]
+  }
+  wait_for_realtime_kong_route() {
+    echo wait_for_realtime_kong_route >>"$root/calls"
+    [[ ! -f "$root/route-fails" ]]
+  }
+
+  expect_status() {
+    local name=$1 want=$2
+    shift 2
+    : >"$root/calls"
+    if "$@" >/dev/null 2>&1; then status=0; else status=$?; fi
+    if [[ "$status" == "$want" ]]; then
+      echo "ok   $name"
+    else
+      echo "FAIL $name (expected exit $want, got $status)"
+      failures=$((failures + 1))
+    fi
+  }
+  calls_match() {
+    if grep -qE "$2" "$root/calls"; then
+      echo "ok   $1"
+    else
+      echo "FAIL $1 (wanted /$2/ in: $(paste -sd';' <"$root/calls"))"
+      failures=$((failures + 1))
+    fi
+  }
+  calls_absent() {
+    if grep -qE "$2" "$root/calls"; then
+      echo "FAIL $1 (unwanted /$2/ in: $(paste -sd';' <"$root/calls"))"
+      failures=$((failures + 1))
+    else
+      echo "ok   $1"
+    fi
+  }
+
+  printf '%s\n' "$expected_database" >"$root/database"
+  printf '%s\n' "$expected_stack" >"$root/stack"
+  expect_status "reuse on complete identity match" 0 ensure_migrations
+  calls_match "reuse reads database identity" "database-content"
+  calls_match "reuse reads stack identity" "stack-setup"
+  calls_absent "reuse does not reset" "^pnpm exec supabase db reset$"
+  calls_absent "reuse does not restart" "^restart_stack$"
+
+  expected_stack=stack-b
+  expect_status "stack mismatch restarts then resets" 0 ensure_migrations
+  calls_match "stack mismatch invalidates old evidence" "DROP TABLE IF EXISTS"
+  calls_match "stack mismatch restarts" "^restart_stack$"
+  calls_match "stack mismatch resets content" "^pnpm exec supabase db reset$"
+  reset_line=$(grep -nE '^pnpm exec supabase db reset$' "$root/calls" | head -1 | cut -d: -f1)
+  restart_line=$(grep -nE '^restart_stack$' "$root/calls" | head -1 | cut -d: -f1)
+  health_line=$(grep -nE '^wait_for_required_services$' "$root/calls" | head -1 | cut -d: -f1)
+  route_line=$(grep -nE '^wait_for_realtime_kong_route$' "$root/calls" | head -1 | cut -d: -f1)
+  write_line=$(grep -nE 'ON CONFLICT' "$root/calls" | head -1 | cut -d: -f1)
+  if [[ -n "$restart_line" && -n "$reset_line" && -n "$health_line" && -n "$route_line" && -n "$write_line" \
+    && "$restart_line" -lt "$reset_line" && "$reset_line" -lt "$health_line" \
+    && "$health_line" -lt "$route_line" && "$route_line" -lt "$write_line" ]]; then
+    echo "ok   restart, reset, health, route, then success write"
+  else
+    echo "FAIL restart, reset, health, route, then success write"
+    failures=$((failures + 1))
+  fi
+
+  expected_database=database-b
+  expect_status "database mismatch resets" 0 ensure_migrations
+  calls_match "database mismatch invalidates old evidence" "DROP TABLE IF EXISTS"
+  calls_match "database mismatch resets" "^pnpm exec supabase db reset$"
+
+  expected_database=database-a
+  expect_status "A-to-B-to-A content change resets again" 0 ensure_migrations
+  calls_match "return to A resets instead of trusting stale evidence" "^pnpm exec supabase db reset$"
+
+  expected_database=database-c
+  touch "$root/route-fails"
+  expect_status "post-reset Realtime route failure propagates" 1 ensure_migrations
+  calls_match "route failure follows reset" "^pnpm exec supabase db reset$"
+  calls_match "route failure waits for service health" "^wait_for_required_services$"
+  calls_match "route failure probes the configured Realtime route" "^wait_for_realtime_kong_route$"
+  calls_absent "route failure does not write a fingerprint" "ON CONFLICT"
+  [[ ! -e "$root/database" && ! -e "$root/stack" ]] && echo "ok   failed route barrier leaves no success evidence" || {
+    echo "FAIL failed route barrier leaves no success evidence"
+    failures=$((failures + 1))
+  }
+  rm -f "$root/route-fails"
+
+  expected_database=database-d
+  touch "$root/reset-fails"
+  expect_status "reset failure propagates" 1 ensure_migrations
+  calls_absent "reset failure does not write a fingerprint" "ON CONFLICT"
+  calls_absent "reset failure does not wait for services" "wait_for_required_services"
+  [[ ! -e "$root/database" && ! -e "$root/stack" ]] && echo "ok   failed reset leaves no success evidence" || {
+    echo "FAIL failed reset leaves no success evidence"
+    failures=$((failures + 1))
+  }
+  rm -f "$root/reset-fails"
+
+  expected_database=database-e
+  touch "$root/write-fails"
+  expect_status "fingerprint write failure propagates" 1 ensure_migrations
+  rm -f "$root/write-fails"
+
+  rm -rf "$root"
+  if [[ "$failures" -eq 0 ]]; then
+    echo "ensure-migrations self-test passed."
+    return 0
+  fi
+  echo "$failures ensure-migrations self-test check(s) failed." >&2
+  return 1
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+elif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  run_ensure_migrations "$@"
+fi

--- a/scripts/functions-server.sh
+++ b/scripts/functions-server.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+# Function-server lifecycle management for edge-worker E2E runs. The caller
+# owns the stack resource lock for this helper's complete lifetime.
+set -euo pipefail
+
+FUNCTIONS_SERVER_PID=
+FUNCTIONS_SERVER_LOG=
+FUNCTIONS_SERVER_CONTAINER_NAME=
+FUNCTIONS_SERVER_PREVIOUS_CONTAINER_ID=
+FUNCTIONS_SERVER_CONTAINER_ID=
+FUNCTIONS_SERVER_TIMEOUT_SEC=${PGFLOW_SERVE_TIMEOUT_SEC:-120}
+FUNCTIONS_SERVER_READY_LINE="Serving functions on http://"
+FUNCTIONS_SERVER_WAITED=false
+FUNCTIONS_SERVER_EXIT_STATUS=
+FUNCTIONS_SERVER_COMMAND_PID=
+FUNCTIONS_SERVER_COMMAND_WAITED=false
+FUNCTIONS_SERVER_COMMAND_EXIT_STATUS=
+
+process_alive() { # process_alive <pid>
+  [[ -n "${1:-}" ]] && kill -0 "$1" 2>/dev/null
+}
+
+process_group_alive() { # process_group_alive <leader-pid>
+  [[ -n "${1:-}" ]] && kill -0 -- "-$1" 2>/dev/null
+}
+
+current_container_id() { # current_container_id <container-name>
+  local id status
+  if id=$(docker inspect --format '{{.Id}}' "$1" 2>/dev/null); then
+    [[ "$id" =~ ^[0-9a-f]{64}$ ]] || {
+      echo "Function runtime container '$1' returned an invalid id." >&2
+      return 2
+    }
+    printf '%s\n' "$id"
+    return 0
+  else
+    status=$?
+    return "$status"
+  fi
+}
+
+observe_functions_server_container() {
+  local id status
+  [[ -n "$FUNCTIONS_SERVER_CONTAINER_NAME" ]] || return 0
+  if id=$(current_container_id "$FUNCTIONS_SERVER_CONTAINER_NAME"); then
+    # The first post-start ID is immutable ownership. Later replacements can
+    # never be removed by this invocation's cleanup.
+    if [[ -z "$FUNCTIONS_SERVER_CONTAINER_ID" && "$id" != "$FUNCTIONS_SERVER_PREVIOUS_CONTAINER_ID" ]]; then
+      FUNCTIONS_SERVER_CONTAINER_ID=$id
+    fi
+    return 0
+  fi
+  status=$?
+  # A missing runtime before creation or after cleanup is safe. Any malformed
+  # successful inspect result already failed in current_container_id.
+  [[ "$status" == 1 ]] && return 0
+  return "$status"
+}
+
+start_functions_server() { # start_functions_server <runtime-container> <serve-command...>
+  local id
+  [[ $# -ge 2 ]] || {
+    echo "Usage: start_functions_server <runtime-container> <serve-command...>" >&2
+    return 2
+  }
+  FUNCTIONS_SERVER_CONTAINER_NAME=$1
+  shift
+  FUNCTIONS_SERVER_LOG=$(mktemp "${TMPDIR:-/tmp}/pgflow-functions-serve.XXXXXX.log")
+  FUNCTIONS_SERVER_PREVIOUS_CONTAINER_ID=
+  FUNCTIONS_SERVER_CONTAINER_ID=
+  FUNCTIONS_SERVER_WAITED=false
+  FUNCTIONS_SERVER_EXIT_STATUS=
+  FUNCTIONS_SERVER_COMMAND_PID=
+  FUNCTIONS_SERVER_COMMAND_WAITED=false
+  FUNCTIONS_SERVER_COMMAND_EXIT_STATUS=
+
+  # Record only the preexisting ID. A later different ID is the current
+  # invocation's runtime and is safe to remove even if readiness never emits.
+  if id=$(current_container_id "$FUNCTIONS_SERVER_CONTAINER_NAME"); then
+    FUNCTIONS_SERVER_PREVIOUS_CONTAINER_ID=$id
+  fi
+
+  echo "Starting function server (log: $FUNCTIONS_SERVER_LOG)..."
+  setsid "$@" >"$FUNCTIONS_SERVER_LOG" 2>&1 &
+  FUNCTIONS_SERVER_PID=$!
+}
+
+functions_server_alive() {
+  process_alive "$FUNCTIONS_SERVER_PID"
+}
+
+functions_server_exit_status() {
+  [[ -n "$FUNCTIONS_SERVER_PID" ]] || return 0
+  if [[ "$FUNCTIONS_SERVER_WAITED" != true ]]; then
+    if wait "$FUNCTIONS_SERVER_PID"; then
+      FUNCTIONS_SERVER_EXIT_STATUS=0
+    else
+      FUNCTIONS_SERVER_EXIT_STATUS=$?
+    fi
+    FUNCTIONS_SERVER_WAITED=true
+  fi
+  return "$FUNCTIONS_SERVER_EXIT_STATUS"
+}
+
+functions_server_failure() {
+  local status
+  functions_server_alive && return 1
+  if functions_server_exit_status; then
+    echo "Function server exited after startup with status 0." >&2
+    return 1
+  else
+    status=$?
+    echo "Function server exited after startup with status $status." >&2
+    return "$status"
+  fi
+}
+
+wait_for_functions_server() {
+  echo "Waiting for the function server startup output..."
+  local deadline=$((SECONDS + FUNCTIONS_SERVER_TIMEOUT_SEC))
+  until grep -qF "$FUNCTIONS_SERVER_READY_LINE" "$FUNCTIONS_SERVER_LOG" 2>/dev/null; do
+    observe_functions_server_container || return 1
+    if ! functions_server_alive; then
+      [[ -n "$FUNCTIONS_SERVER_CONTAINER_ID" ]] || \
+        echo "No new function runtime container was observed before server exit." >&2
+      echo "Function server exited before becoming ready. Server log:" >&2
+      cat "$FUNCTIONS_SERVER_LOG" >&2
+      return 1
+    fi
+    if ((SECONDS >= deadline)); then
+      [[ -n "$FUNCTIONS_SERVER_CONTAINER_ID" ]] || \
+        echo "No new function runtime container was observed before startup timeout." >&2
+      echo "TIMEOUT: function server did not report readiness within ${FUNCTIONS_SERVER_TIMEOUT_SEC}s. Server log:" >&2
+      cat "$FUNCTIONS_SERVER_LOG" >&2
+      return 1
+    fi
+    sleep 0.2
+  done
+
+  observe_functions_server_container || return 1
+  if ! functions_server_alive; then
+    echo "Function server exited immediately after becoming ready. Server log:" >&2
+    cat "$FUNCTIONS_SERVER_LOG" >&2
+    return 1
+  fi
+  [[ -n "$FUNCTIONS_SERVER_CONTAINER_ID" ]] || {
+    echo "No new runtime container appeared for this function-server invocation." >&2
+    return 1
+  }
+  echo "Function server reported readiness from container $FUNCTIONS_SERVER_CONTAINER_ID."
+}
+
+stop_process_group() { # stop_process_group <leader-pid>
+  local pid=$1
+  process_group_alive "$pid" || return 0
+  kill -TERM -- "-$pid" 2>/dev/null || true
+  for _ in $(seq 1 50); do
+    process_group_alive "$pid" || return 0
+    sleep 0.1
+  done
+  kill -KILL -- "-$pid" 2>/dev/null || true
+}
+
+start_monitored_command() { # start_monitored_command <command...>
+  [[ -z "$FUNCTIONS_SERVER_COMMAND_PID" ]] || {
+    echo "A function-server command is already running." >&2
+    return 1
+  }
+  setsid "$@" &
+  FUNCTIONS_SERVER_COMMAND_PID=$!
+  FUNCTIONS_SERVER_COMMAND_WAITED=false
+  FUNCTIONS_SERVER_COMMAND_EXIT_STATUS=
+}
+
+monitored_command_exit_status() {
+  [[ -n "$FUNCTIONS_SERVER_COMMAND_PID" ]] || return 0
+  if [[ "$FUNCTIONS_SERVER_COMMAND_WAITED" != true ]]; then
+    if wait "$FUNCTIONS_SERVER_COMMAND_PID"; then
+      FUNCTIONS_SERVER_COMMAND_EXIT_STATUS=0
+    else
+      FUNCTIONS_SERVER_COMMAND_EXIT_STATUS=$?
+    fi
+    FUNCTIONS_SERVER_COMMAND_WAITED=true
+  fi
+  return "$FUNCTIONS_SERVER_COMMAND_EXIT_STATUS"
+}
+
+clear_monitored_command() {
+  FUNCTIONS_SERVER_COMMAND_PID=
+  FUNCTIONS_SERVER_COMMAND_WAITED=false
+  FUNCTIONS_SERVER_COMMAND_EXIT_STATUS=
+}
+
+stop_monitored_command() {
+  [[ -n "$FUNCTIONS_SERVER_COMMAND_PID" ]] || return 0
+  # The leader remains unreaped until the following wait, so its process-group
+  # ID cannot be reused while this cleanup signals its children.
+  stop_process_group "$FUNCTIONS_SERVER_COMMAND_PID"
+  monitored_command_exit_status || true
+  clear_monitored_command
+}
+
+remove_owned_functions_container() {
+  local status
+  [[ -n "$FUNCTIONS_SERVER_CONTAINER_ID" ]] || return 0
+  if docker rm -f "$FUNCTIONS_SERVER_CONTAINER_ID" >/dev/null 2>&1; then
+    echo "Removed owned function runtime container $FUNCTIONS_SERVER_CONTAINER_ID."
+    return 0
+  else
+    status=$?
+  fi
+  # Container IDs never identify a replacement. If it disappeared already,
+  # cleanup completed without touching any later runtime.
+  if ! docker inspect "$FUNCTIONS_SERVER_CONTAINER_ID" >/dev/null 2>&1; then
+    echo "Owned function runtime container $FUNCTIONS_SERVER_CONTAINER_ID was already gone."
+    return 0
+  fi
+  echo "Failed to remove owned function runtime container $FUNCTIONS_SERVER_CONTAINER_ID." >&2
+  return "$status"
+}
+
+stop_functions_server() {
+  local failed=0
+  # Capture a runtime created just before a timeout or early child exit.
+  observe_functions_server_container || failed=1
+  stop_monitored_command
+  [[ -n "$FUNCTIONS_SERVER_PID" ]] && stop_process_group "$FUNCTIONS_SERVER_PID"
+  observe_functions_server_container || failed=1
+  functions_server_exit_status || true
+  remove_owned_functions_container || failed=1
+  return "$failed"
+}
+
+run_with_functions_server() { # run_with_functions_server <command...>
+  local command_status server_status
+  start_monitored_command "$@"
+
+  while process_alive "$FUNCTIONS_SERVER_COMMAND_PID"; do
+    observe_functions_server_container || {
+      stop_monitored_command
+      return 1
+    }
+    if ! functions_server_alive; then
+      if functions_server_failure; then server_status=0; else server_status=$?; fi
+      stop_monitored_command
+      [[ "$server_status" == 0 ]] && return 1
+      return "$server_status"
+    fi
+    sleep 0.1
+  done
+
+  if monitored_command_exit_status; then command_status=0; else command_status=$?; fi
+  clear_monitored_command
+  if ! functions_server_alive; then
+    if functions_server_failure; then server_status=0; else server_status=$?; fi
+    [[ "$server_status" == 0 ]] && return 1
+    return "$server_status"
+  fi
+  return "$command_status"
+}
+
+self_test() {
+  local failures=0 status tmp old_id new_id replacement_id docker_mode=false docker_rm_fails=false
+  tmp=$(mktemp -d)
+  old_id=$(printf 'b%.0s' {1..64})
+  new_id=$(printf 'a%.0s' {1..64})
+  replacement_id=$(printf 'c%.0s' {1..64})
+
+  docker() {
+    printf '%s\n' "$*" >>"$tmp/docker-calls"
+    case "$1" in
+      inspect)
+        case "$docker_mode" in
+          old) printf '%s\n' "$old_id" ;;
+          new|rm-fails) printf '%s\n' "$new_id" ;;
+          replacement) printf '%s\n' "$replacement_id" ;;
+          none) return 1 ;;
+          invalid) printf '%s\n' invalid-id ;;
+        esac
+        ;;
+      rm)
+        [[ "$docker_rm_fails" == true ]] && return 1
+        docker_mode=none
+        ;;
+    esac
+  }
+
+  begin_server() { # begin_server <command...>
+    docker_mode=old
+    start_functions_server supabase_edge_runtime_selftest "$@"
+    docker_mode=new
+  }
+  expect_status() {
+    local name=$1 want=$2
+    shift 2
+    if "$@"; then status=0; else status=$?; fi
+    if [[ "$status" == "$want" ]]; then
+      echo "ok   $name"
+    else
+      echo "FAIL $name (expected exit $want, got $status)"
+      failures=$((failures + 1))
+    fi
+  }
+
+  begin_server bash -c 'exit 7'
+  expect_status "early server exit fails" 1 wait_for_functions_server
+  if [[ "$FUNCTIONS_SERVER_CONTAINER_ID" == "$new_id" ]]; then
+    echo "ok   early exit captures a newly created runtime before cleanup"
+  else
+    echo "FAIL early exit did not capture a newly created runtime"
+    failures=$((failures + 1))
+  fi
+  expect_status "early-exit cleanup removes the captured runtime" 0 stop_functions_server
+
+  FUNCTIONS_SERVER_TIMEOUT_SEC=1
+  begin_server bash -c 'exec 1>&- 2>&-; exec sleep 30'
+  expect_status "startup deadline fails" 1 wait_for_functions_server
+  if [[ "$FUNCTIONS_SERVER_CONTAINER_ID" == "$new_id" ]]; then
+    echo "ok   timeout captures a newly created runtime before cleanup"
+  else
+    echo "FAIL timeout did not capture a newly created runtime"
+    failures=$((failures + 1))
+  fi
+  expect_status "timeout cleanup removes the captured runtime" 0 stop_functions_server
+
+  FUNCTIONS_SERVER_TIMEOUT_SEC=10
+  begin_server bash -c '
+    echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"
+    trap "exit 0" TERM
+    sleep 30 &
+    echo $! > "'"$tmp"'/server-child.pid"
+    wait'
+  expect_status "ready server passes startup" 0 wait_for_functions_server
+  stop_functions_server
+  if kill -0 "$(cat "$tmp/server-child.pid")" 2>/dev/null; then
+    echo "FAIL server cleanup left a process-group child alive"
+    failures=$((failures + 1))
+  else
+    echo "ok   server cleanup stops a process-group child after leader handling"
+  fi
+
+  begin_server bash -c '
+    echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"
+    sleep 0.2
+    exit 7'
+  expect_status "ready-then-exit fails the monitored command" 7 \
+    run_with_functions_server bash -c 'sleep 1'
+  stop_functions_server
+
+  begin_server bash -c 'echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"; exec sleep 30'
+  expect_status "probe failure status survives" 0 wait_for_functions_server
+  expect_status "probe failure returns its status" 9 \
+    run_with_functions_server bash -c 'exit 9'
+  stop_functions_server
+
+  begin_server bash -c 'echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"; exec sleep 30'
+  expect_status "suite failure status survives" 0 wait_for_functions_server
+  expect_status "suite failure returns its status" 11 \
+    run_with_functions_server bash -c 'exit 11'
+  stop_functions_server
+
+  : >"$tmp/docker-calls"
+  begin_server bash -c 'echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"; exec sleep 30'
+  expect_status "container owner reaches readiness" 0 wait_for_functions_server
+  stop_functions_server
+  if grep -qx "rm -f $new_id" "$tmp/docker-calls" \
+    && ! grep -qx 'rm -f supabase_edge_runtime_selftest' "$tmp/docker-calls"; then
+    echo "ok   cleanup removes only the captured runtime container id"
+  else
+    echo "FAIL cleanup did not remove only the captured runtime container id"
+    failures=$((failures + 1))
+  fi
+
+  : >"$tmp/docker-calls"
+  begin_server bash -c 'echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"; exec sleep 30'
+  expect_status "first owned runtime reaches readiness" 0 wait_for_functions_server
+  docker_mode=replacement
+  expect_status "later runtime observation succeeds" 0 observe_functions_server_container
+  if [[ "$FUNCTIONS_SERVER_CONTAINER_ID" == "$new_id" ]]; then
+    echo "ok   later runtime replacement cannot transfer container ownership"
+  else
+    echo "FAIL later runtime replacement changed owned container id"
+    failures=$((failures + 1))
+  fi
+  stop_functions_server
+  if grep -qx "rm -f $new_id" "$tmp/docker-calls" \
+    && ! grep -qx "rm -f $replacement_id" "$tmp/docker-calls"; then
+    echo "ok   B-to-C replacement cleanup removes B and never C"
+  else
+    echo "FAIL B-to-C replacement cleanup did not preserve B ownership"
+    failures=$((failures + 1))
+  fi
+
+  begin_server bash -c 'echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"; exec sleep 30'
+  expect_status "cleanup-failure server reaches readiness" 0 wait_for_functions_server
+  docker_rm_fails=true
+  docker_mode=rm-fails
+  expect_status "container cleanup failure fails a successful invocation" 1 stop_functions_server
+  docker_rm_fails=false
+  expect_status "failed cleanup can remove the same exact id later" 0 stop_functions_server
+
+  (
+    docker_mode=old
+    start_functions_server supabase_edge_runtime_selftest bash -c 'echo "Serving functions on http://127.0.0.1:9999/functions/v1/x"; exec sleep 30'
+    docker_mode=new
+    wait_for_functions_server
+    cleanup_interrupted_suite() {
+      local interrupted_status=$?
+      stop_functions_server || true
+      exit "$interrupted_status"
+    }
+    trap cleanup_interrupted_suite EXIT
+    trap 'exit 143' TERM
+    start_monitored_command bash -c 'sleep 30 & echo $! > "'"$tmp"'/suite-child.pid"; wait'
+    echo ready >"$tmp/interrupted-suite-ready"
+    sleep 30
+  ) &
+  interrupted_suite=$!
+  for _ in $(seq 1 50); do
+    [[ -f "$tmp/interrupted-suite-ready" ]] && break
+    sleep 0.1
+  done
+  if [[ -f "$tmp/interrupted-suite-ready" ]]; then
+    kill -TERM "$interrupted_suite"
+    wait "$interrupted_suite" 2>/dev/null || true
+    if kill -0 "$(cat "$tmp/suite-child.pid")" 2>/dev/null; then
+      echo "FAIL interrupted suite cleanup left its command group alive"
+      failures=$((failures + 1))
+    else
+      echo "ok   interrupted suite cleanup stops the monitored command group"
+    fi
+  else
+    echo "FAIL interrupted suite did not reach the monitored command"
+    failures=$((failures + 1))
+    kill -KILL "$interrupted_suite" 2>/dev/null || true
+    wait "$interrupted_suite" 2>/dev/null || true
+  fi
+
+  rm -rf "$tmp"
+  if [[ "$failures" -eq 0 ]]; then
+    echo "functions-server self-test passed."
+    return 0
+  fi
+  echo "$failures functions-server self-test check(s) failed." >&2
+  return 1
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+elif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  echo "Source this file from scripts/run-e2e.sh (or run --self-test)." >&2
+  exit 2
+fi

--- a/scripts/get-enabled-services.mjs
+++ b/scripts/get-enabled-services.mjs
@@ -18,6 +18,7 @@ const SERVICE_MAP = {
   'inbucket': 'inbucket',          // Email testing
   'storage': 'storage',            // File storage
   'analytics': 'analytics',        // Analytics backend
+  'auth': 'auth',                  // GoTrue authentication
 };
 
 const configPath = process.argv[2];
@@ -31,11 +32,15 @@ const config = parse(toml);
 
 const enabledServices = [];
 
-// Check each service
+// Check each service. Auth has no [auth].enabled flag in some Supabase CLI
+// config versions, but a present [auth] section still starts GoTrue unless it
+// explicitly opts out.
 for (const [configSection, containerName] of Object.entries(SERVICE_MAP)) {
   const serviceConfig = config[configSection];
-  // Service is enabled if: section exists AND enabled is not explicitly false
-  if (serviceConfig && serviceConfig.enabled !== false) {
+  const enabled = configSection === 'auth'
+    ? serviceConfig?.enabled !== false
+    : serviceConfig && serviceConfig.enabled !== false;
+  if (enabled) {
     enabledServices.push(containerName);
   }
 }

--- a/scripts/lock-dir.sh
+++ b/scripts/lock-dir.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Resolves the directory for cross-invocation, cross-worktree pgflow locks.
+#
+# Locks must live on storage shared by every process that can touch the same
+# Docker resources. /tmp is private per sandbox (box mounts it as a tmpfs
+# while Docker stays shared), so a /tmp lock file is NOT coordination between
+# sandboxes. The git common directory (the wrapper repository's .bare for
+# worktree checkouts, .git for plain clones) is shared by every worktree of
+# this repository by construction, so locks placed there coordinate separate
+# invocations, separate sandboxes, and separate worktrees.
+#
+# Open question (tracked, not solved here): whether coordination should be
+# host-global across independent clones of this repository. The fixed Compose
+# project name and ports collide across clones too; a repository-scoped lock
+# cannot cover that. Resolving it needs an ownership decision, not another
+# lock framework.
+set -euo pipefail
+
+common_dir=$(git -C "$(dirname "$0")" rev-parse --path-format=absolute --git-common-dir)
+lock_dir="$common_dir/pgflow-locks"
+mkdir -p "$lock_dir"
+printf '%s\n' "$lock_dir"

--- a/scripts/nx-file-visible.cjs
+++ b/scripts/nx-file-visible.cjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Checks Nx's own fresh workspace file map. Git tracking does not determine
+// cache visibility: nonignored untracked files count, and .nxignore can
+// reinclude a Git-ignored path.
+const path = require('node:path');
+
+const [root, file] = process.argv.slice(2);
+if (!root || !file || path.isAbsolute(file) || file.startsWith('../')) {
+  process.exit(2);
+}
+
+process.env.NX_DAEMON = 'false';
+const { getAllFileDataInContext } = require('nx/src/utils/workspace-context');
+
+getAllFileDataInContext(root)
+  .then((files) => process.exit(files.some((entry) => entry.file === file) ? 0 : 1))
+  .catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });

--- a/scripts/require-test-file.sh
+++ b/scripts/require-test-file.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Validates a focused test-file selector before a runner receives it. The
+# direct-argv Nx executor passes this value as data; this script enforces a
+# canonical supported subtree and checks Nx's effective file visibility.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <subtree> <file>" >&2
+}
+
+[[ $# -eq 2 ]] || {
+  usage
+  exit 2
+}
+subtree=$1
+file=$2
+
+[[ -n "$file" ]] || {
+  echo "ERROR: no test file selected." >&2
+  exit 1
+}
+[[ "$file" != /* ]] || {
+  echo "ERROR: test file must be relative to the package root: $file" >&2
+  exit 1
+}
+# This is selector hygiene, not shell escaping. Quotes, substitutions, and
+# options are data in the direct-argv executor and are rejected here.
+[[ "$file" =~ ^[A-Za-z0-9_./-]+$ ]] || {
+  echo "ERROR: test file contains unsupported characters: $file" >&2
+  exit 1
+}
+
+[[ "$file" != ./* ]] || file=${file#./}
+[[ "$file" == "$subtree"/* ]] || {
+  echo "ERROR: test file must be inside $subtree/: $file" >&2
+  exit 1
+}
+case "$subtree" in
+  supabase/tests) [[ "$file" == *.sql ]] ;;
+  tests/integration) [[ "$file" == *.ts ]] ;;
+  *) true ;;
+esac || {
+  echo "ERROR: test file has an unsupported extension: $file" >&2
+  exit 1
+}
+
+resolved=$(readlink -f -- "$file" 2>/dev/null) || {
+  echo "ERROR: test file not found: $file" >&2
+  exit 1
+}
+subtree_resolved=$(readlink -f -- "$subtree" 2>/dev/null) || {
+  echo "ERROR: test subtree not found: $subtree" >&2
+  exit 1
+}
+[[ "$resolved" == "$subtree_resolved"/* && -f "$resolved" ]] || {
+  echo "ERROR: not a regular file inside $subtree/: $file" >&2
+  exit 1
+}
+
+if repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  repo_file=$(realpath --relative-to="$repo_root" "$resolved")
+  [[ "$repo_file" != ../* ]] || {
+    echo "ERROR: test file is outside the repository: $file" >&2
+    exit 1
+  }
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  if ! node "$script_dir/nx-file-visible.cjs" "$repo_root" "$repo_file"; then
+    echo "ERROR: test file is ignored by Nx and cannot be hashed: $file" >&2
+    exit 1
+  fi
+fi

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Owns one edge-worker E2E invocation: current migration preparation, stack
+# materialization, function serve, readiness, suite, and exact-resource cleanup.
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+test_dir=${1:?Usage: run-e2e.sh <tests-directory>}
+# shellcheck source=scripts/functions-server.sh
+source "$root/scripts/functions-server.sh"
+
+cd "$root/pkgs/edge-worker"
+project_id=$(sed -nE 's/^[[:space:]]*project_id[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' supabase/config.toml | head -1)
+[[ "$project_id" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]] || {
+  echo "Could not read a safe edge-worker project_id." >&2
+  exit 1
+}
+lock_dir=$("$root/scripts/lock-dir.sh")
+
+# Every operation and live consumer of this physical stack uses this same
+# project_id lock. The environment lock always comes first.
+exec 9>"$lock_dir/environment.lock"
+flock --shared 9
+exec 8>"$lock_dir/stack-${project_id}.lock"
+flock 8
+
+# The lock-assuming body starts the stack after edge-worker copies the current
+# core migrations, then fingerprints and applies the live database.
+"$root/scripts/ensure-migrations-body.sh" .
+./scripts/sync-e2e-deps.sh
+
+cleanup() {
+  local status=$? cleanup_status=0
+  trap - EXIT INT TERM
+  if stop_functions_server; then :; else cleanup_status=$?; fi
+  if [[ "$status" == 0 && "$cleanup_status" != 0 ]]; then
+    status=$cleanup_status
+  fi
+  exit "$status"
+}
+# Install cleanup before spawning the serve process or probing its runtime.
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+start_functions_server "supabase_edge_runtime_${project_id}" \
+  pnpm exec supabase functions serve \
+  --env-file supabase/functions/.env \
+  --import-map supabase/functions/deno.json \
+  --no-verify-jwt
+wait_for_functions_server
+
+run_with_functions_server "$root/scripts/wait-for-function.sh" \
+  http://127.0.0.1:50321/functions/v1/auth_test 401 '"message":"Unauthorized"'
+
+set +e
+run_with_functions_server deno test --config deno.test.json --allow-all \
+  --env=supabase/functions/.env "$test_dir"
+status=$?
+set -e
+exit "$status"

--- a/scripts/supabase-start-locked.sh
+++ b/scripts/supabase-start-locked.sh
@@ -1,71 +1,19 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# Public locked entry point for one physical Supabase stack. The stack lock is
+# keyed by config.toml project_id, not by a worktree path.
+set -euo pipefail
 
-# ============================================================================
-# Supabase Start Locked Wrapper Script
-# ============================================================================
-# This script wraps supabase-start.sh with file-based locking using flock(1).
-#
-# PURPOSE:
-#   When multiple Nx targets need Supabase, serialize startup per project while
-#   allowing different projects to start in parallel. A shared environment lock
-#   lets test-env:fresh exclude every startup while it removes owned services.
-#
-# HOW IT WORKS:
-#   1. Acquires a shared pgflow test-environment lock
-#   2. Computes a lock file path based on the project directory
-#   3. Acquires the project's exclusive startup lock
-#   4. Optionally stops Supabase, then runs supabase-start.sh while holding both locks
-#
-# LOCK FILE LOCATIONS:
-#   /tmp/pgflow-test-environment.lock coordinates startup with test-env:fresh.
-#   /tmp/supabase-start-<hash>.lock serializes startup for one project path.
-#
-# Usage: supabase-start-locked.sh [--restart] <project-directory>
-# ============================================================================
-
-RESTART=false
-if [ "${1:-}" = "--restart" ]; then
-  RESTART=true
+restart=()
+if [[ "${1:-}" == "--restart" ]]; then
+  restart=(--restart)
   shift
 fi
-
-# Validate project directory argument
-if [ -z "${1:-}" ]; then
-  echo "Error: Project directory argument is required" >&2
+[[ $# -eq 1 && -d "$1" ]] || {
   echo "Usage: $0 [--restart] <project-directory>" >&2
-  exit 1
-fi
+  exit 2
+}
 
-PROJECT_DIR="$1"
-
-# Validate project directory exists
-if [ ! -d "$PROJECT_DIR" ]; then
-  echo "Error: Project directory not found: $PROJECT_DIR" >&2
-  exit 1
-fi
-
-# Normalize to absolute path to ensure consistent lock naming
-# This prevents "./pkgs/core" and "pkgs/core" from creating different locks
-PROJECT_DIR_ABS=$(realpath "$PROJECT_DIR")
-
-# Create a unique lock file path based on the absolute project directory
-# Using md5sum hash to create a safe filename from the directory path
-PROJECT_LOCK_NAME=$(echo "$PROJECT_DIR_ABS" | md5sum | cut -d' ' -f1)
-LOCK_FILE="/tmp/supabase-start-${PROJECT_LOCK_NAME}.lock"
-
-# Get the directory where this script lives (to find the worker script)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKER_SCRIPT="$SCRIPT_DIR/supabase-start.sh"
-
-# Different projects may start together, but a fresh-environment run excludes all starts.
-exec 9>/tmp/pgflow-test-environment.lock
-flock --shared 9
-exec 8>"$LOCK_FILE"
-flock 8
-
-if [ "$RESTART" = true ]; then
-  (cd "$PROJECT_DIR_ABS" && pnpm exec supabase stop --no-backup)
-fi
-
-exec "$WORKER_SCRIPT" "$PROJECT_DIR_ABS"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+project_dir=$(realpath "$1")
+exec "$script_dir/with-supabase-lock.sh" "$project_dir" \
+  "$script_dir/supabase-start.sh" "${restart[@]}" "$project_dir"

--- a/scripts/supabase-start-locked.sh
+++ b/scripts/supabase-start-locked.sh
@@ -7,46 +7,33 @@ set -e
 # This script wraps supabase-start.sh with file-based locking using flock(1).
 #
 # PURPOSE:
-#   When multiple Nx targets run in parallel and all need Supabase running,
-#   we want to serialize the "ensure started" checks so only ONE process
-#   actually starts Supabase, while others wait and reuse the running instance.
+#   When multiple Nx targets need Supabase, serialize startup per project while
+#   allowing different projects to start in parallel. A shared environment lock
+#   lets test-env:fresh exclude every startup while it removes owned services.
 #
 # HOW IT WORKS:
-#   1. Computes a lock file path based on the project directory
-#   2. Uses flock to acquire an exclusive lock on that file
-#   3. Runs the worker script (supabase-start.sh) while holding the lock
-#   4. Lock is automatically released when this script exits
+#   1. Acquires a shared pgflow test-environment lock
+#   2. Computes a lock file path based on the project directory
+#   3. Acquires the project's exclusive startup lock
+#   4. Optionally stops Supabase, then runs supabase-start.sh while holding both locks
 #
-# WHAT HAPPENS WITH PARALLEL EXECUTION:
-#   Process A (first):
-#     - Acquires lock immediately
-#     - Runs worker → starts Supabase
-#     - Releases lock
+# LOCK FILE LOCATIONS:
+#   /tmp/pgflow-test-environment.lock coordinates startup with test-env:fresh.
+#   /tmp/supabase-start-<hash>.lock serializes startup for one project path.
 #
-#   Process B (milliseconds later):
-#     - Blocks waiting for lock
-#     - A releases lock
-#     - Acquires lock, runs worker → checks status → already running → fast exit
-#     - Releases lock
-#
-# WHY FORM 1 OF FLOCK:
-#   We use: flock <lockfile> <command>
-#   This is simpler than file descriptor manipulation (Form 3) and provides
-#   exactly what we need: serialize execution of the worker script per-project.
-#
-# LOCK FILE LOCATION:
-#   /tmp/supabase-start-<hash>.lock where <hash> is md5sum of absolute project path
-#   - Unique per project (core, client, edge-worker have separate locks)
-#   - Standard /tmp location (cleaned on reboot)
-#   - Linux-specific (fine for our use case)
-#
-# Usage: supabase-start-locked.sh <project-directory>
+# Usage: supabase-start-locked.sh [--restart] <project-directory>
 # ============================================================================
 
+RESTART=false
+if [ "${1:-}" = "--restart" ]; then
+  RESTART=true
+  shift
+fi
+
 # Validate project directory argument
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
   echo "Error: Project directory argument is required" >&2
-  echo "Usage: $0 <project-directory>" >&2
+  echo "Usage: $0 [--restart] <project-directory>" >&2
   exit 1
 fi
 
@@ -71,6 +58,14 @@ LOCK_FILE="/tmp/supabase-start-${PROJECT_LOCK_NAME}.lock"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKER_SCRIPT="$SCRIPT_DIR/supabase-start.sh"
 
-# Use flock (Form 1) to serialize access to the worker script
-# By default, flock blocks until the lock is available, then runs the command
-flock "$LOCK_FILE" "$WORKER_SCRIPT" "$PROJECT_DIR_ABS"
+# Different projects may start together, but a fresh-environment run excludes all starts.
+exec 9>/tmp/pgflow-test-environment.lock
+flock --shared 9
+exec 8>"$LOCK_FILE"
+flock 8
+
+if [ "$RESTART" = true ]; then
+  (cd "$PROJECT_DIR_ABS" && pnpm exec supabase stop --no-backup)
+fi
+
+exec "$WORKER_SCRIPT" "$PROJECT_DIR_ABS"

--- a/scripts/supabase-start.sh
+++ b/scripts/supabase-start.sh
@@ -1,176 +1,181 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# Lock-assuming Supabase stack start body. Public callers use
+# scripts/supabase-start-locked.sh or scripts/with-supabase-lock.sh.
+set -euo pipefail
 
-# ============================================================================
-# Supabase Start Worker Script
-# ============================================================================
-# This script ensures a Supabase instance is running for a given project.
-# It is IDEMPOTENT - safe to call multiple times.
-#
-# This script does NOT handle locking - it assumes the caller (wrapper script)
-# has already acquired a lock to prevent concurrent execution.
-#
-# Usage: supabase-start.sh <project-directory>
-#
-# Behavior:
-#   1. Checks if Supabase is already running (fast path)
-#   2. If running: exits immediately
-#   3. If not running:
-#      a. Runs <project>/scripts/prepare-supabase.sh if it exists (e.g., copy migrations)
-#      b. Cleans up stale containers
-#      c. Starts Supabase fresh
-#
-# Exit codes:
-#   0 - Success (Supabase is running)
-#   1 - Failure (could not start Supabase)
-# ============================================================================
-
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
-
-# Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Check if all required services are running for a specific project
-# This is more reliable than `supabase status` which returns 0 even with stopped services
-# Args: $1 = project_name (e.g., "cli", "edge-worker")
-# Uses REQUIRED_SERVICES array (service names like: db, rest, realtime)
-# Container names follow pattern: supabase_{service}_{project_name}
-check_required_services_running() {
-  local project_name="$1"
-  local running_containers
-  running_containers=$(docker ps --format '{{.Names}}' 2>/dev/null)
-
-  for service in "${REQUIRED_SERVICES[@]}"; do
-    local container_name="supabase_${service}_${project_name}"
-    if ! echo "$running_containers" | grep -qF "$container_name"; then
-      return 1
-    fi
+required_services_running() {
+  local service names
+  names=$(docker ps --format '{{.Names}}' 2>/dev/null || true)
+  for service in "${required_services[@]}"; do
+    grep -qx "supabase_${service}_${project_id}" <<<"$names" || return 1
   done
-  return 0
 }
 
-# Validate project directory argument
-if [ -z "$1" ]; then
-  echo -e "${RED}Error: Project directory argument is required${NC}" >&2
-  echo "Usage: $0 <project-directory>" >&2
-  exit 1
-fi
+required_services_ready() {
+  local service health
+  required_services_running || return 1
+  for service in "${required_services[@]}"; do
+    health=$(docker inspect "supabase_${service}_${project_id}" \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+      2>/dev/null) || return 1
+    [[ "$health" == healthy || "$health" == none ]] || return 1
+  done
+}
 
-PROJECT_DIR="$1"
+wait_for_required_services() {
+  local deadline=$((SECONDS + 60))
+  while ((SECONDS < deadline)); do
+    required_services_ready && return 0
+    sleep 0.5
+  done
+  echo "Supabase services for '$project_id' did not become ready within 60s." >&2
+  return 1
+}
 
-# Validate project directory exists
-if [ ! -d "$PROJECT_DIR" ]; then
-  echo -e "${RED}Error: Project directory not found: $PROJECT_DIR${NC}" >&2
-  exit 1
-fi
+run_supabase_start() {
+  local restart=false project_dir config script_dir prepare_script attempt
+  if [[ "${1:-}" == "--restart" ]]; then
+    restart=true
+    shift
+  fi
+  [[ $# -eq 1 && -d "$1" ]] || {
+    echo "Usage: $0 [--restart] <project-directory>" >&2
+    return 2
+  }
 
-# Convert to absolute path for consistent file lookups after cd
-PROJECT_DIR=$(realpath "$PROJECT_DIR")
+  project_dir=$(realpath "$1")
+  config="$project_dir/supabase/config.toml"
+  [[ -f "$config" ]] || {
+    echo "Supabase config not found: $config" >&2
+    return 1
+  }
+  project_id=$(sed -nE 's/^[[:space:]]*project_id[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$config" | head -1)
+  [[ -n "$project_id" ]] || {
+    echo "Could not read project_id from $config." >&2
+    return 1
+  }
 
-# Change to project directory (Supabase CLI uses current directory)
-cd "$PROJECT_DIR"
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  cd "$project_dir"
+  prepare_script="$project_dir/scripts/prepare-supabase.sh"
 
-# ============================================================================
-# TODO: Future improvement - consolidate project_id and services detection
-# ============================================================================
-# Currently we read project_name from project.json and services from config.toml
-# separately. This could be simplified by having get-enabled-services.mjs return
-# JSON with both values:
-#
-#   {"project_id":"core","services":["db","realtime"]}
-#
-# Then parse with jq:
-#   CONFIG_JSON=$(node "$SCRIPT_DIR/get-enabled-services.mjs" "$CONFIG_TOML")
-#   PROJECT_NAME=$(echo "$CONFIG_JSON" | jq -r '.project_id')
-#   mapfile -t REQUIRED_SERVICES < <(echo "$CONFIG_JSON" | jq -r '.services[]')
-#
-# Benefits:
-#   - Single source of truth (config.toml has project_id)
-#   - Removes project.json dependency for this script
-#   - More extensible JSON output
-# ============================================================================
-
-# Extract project name from project.json (matches project_id in supabase/config.toml)
-if [ ! -f "$PROJECT_DIR/project.json" ]; then
-  echo -e "${RED}Error: project.json not found in $PROJECT_DIR${NC}" >&2
-  exit 1
-fi
-
-PROJECT_NAME=$(jq -r '.name' "$PROJECT_DIR/project.json")
-if [ -z "$PROJECT_NAME" ] || [ "$PROJECT_NAME" = "null" ]; then
-  echo -e "${RED}Error: Could not read 'name' from project.json${NC}" >&2
-  exit 1
-fi
-
-# Get enabled services from config.toml dynamically
-# This reads the actual config and outputs service names for enabled services
-CONFIG_TOML="$PROJECT_DIR/supabase/config.toml"
-if [ ! -f "$CONFIG_TOML" ]; then
-  echo -e "${RED}Error: config.toml not found at $CONFIG_TOML${NC}" >&2
-  exit 1
-fi
-
-# Read enabled service names into array using Node script
-# Service names are like: db, rest, realtime, edge_runtime
-mapfile -t REQUIRED_SERVICES < <(node "$SCRIPT_DIR/get-enabled-services.mjs" "$CONFIG_TOML")
-
-if [ ${#REQUIRED_SERVICES[@]} -eq 0 ]; then
-  echo -e "${RED}Error: Could not determine required services from config.toml${NC}" >&2
-  exit 1
-fi
-
-echo -e "${YELLOW}Checking Supabase status for project '$PROJECT_NAME' in: $PROJECT_DIR${NC}"
-echo -e "${YELLOW}Required services: ${REQUIRED_SERVICES[*]}${NC}"
-
-# Fast path: Check if all required Supabase services are running via docker ps
-# This is more reliable than `supabase status` which returns 0 even with stopped services
-if check_required_services_running "$PROJECT_NAME"; then
-  echo -e "${GREEN}✓ Supabase is already running for project '$PROJECT_NAME' (all required services up)${NC}"
-  exit 0
-fi
-
-# Some or all required services are not running - need to start/restart
-echo -e "${YELLOW}Supabase services not fully running. Starting...${NC}"
-
-# Run package-specific preparation if script exists
-PREPARE_SCRIPT="$PROJECT_DIR/scripts/prepare-supabase.sh"
-if [ -x "$PREPARE_SCRIPT" ]; then
-  echo -e "${YELLOW}Running prepare-supabase.sh...${NC}"
-  "$PREPARE_SCRIPT"
-fi
-
-# Clean up any stale containers first
-# This prevents errors from previous incomplete shutdowns
-echo -e "${YELLOW}Cleaning up any stale containers...${NC}"
-pnpm exec supabase stop --no-backup 2>/dev/null || true
-
-# Wait for ports to be released after stop
-# Docker/kernel may hold ports in TIME_WAIT state briefly
-sleep 2
-
-# Start Supabase with retry logic
-# Retries help with transient port binding issues and Docker race conditions
-MAX_ATTEMPTS=3
-RETRY_DELAY=5
-
-for attempt in $(seq 1 $MAX_ATTEMPTS); do
-  echo -e "${YELLOW}Starting Supabase (attempt $attempt/$MAX_ATTEMPTS)...${NC}"
-
-  if pnpm exec supabase start; then
-    echo -e "${GREEN}✓ Supabase started successfully${NC}"
-    exit 0
+  # Copy the current core-derived edge migrations before the running-stack
+  # fast path. The following ensure fingerprint cannot see an old mirror.
+  if [[ -x "$prepare_script" ]]; then
+    echo "Preparing Supabase for '$project_id'..."
+    "$prepare_script"
   fi
 
-  if [ $attempt -lt $MAX_ATTEMPTS ]; then
-    echo -e "${YELLOW}Start failed, cleaning up and retrying in ${RETRY_DELAY}s...${NC}"
-    pnpm exec supabase stop --no-backup 2>/dev/null || true
-    sleep $RETRY_DELAY
-  fi
-done
+  mapfile -t required_services < <(node "$script_dir/get-enabled-services.mjs" "$config")
+  ((${#required_services[@]})) || {
+    echo "Could not determine required services from $config." >&2
+    return 1
+  }
 
-echo -e "${RED}✗ Failed to start Supabase after $MAX_ATTEMPTS attempts${NC}" >&2
-exit 1
+  if [[ "$restart" == true ]]; then
+    echo "Restarting Supabase stack '$project_id' from the current configuration..."
+    pnpm exec supabase stop --no-backup
+  fi
+
+  if required_services_running; then
+    wait_for_required_services
+    echo "Supabase is already running for '$project_id'."
+    return 0
+  fi
+
+  echo "Starting Supabase stack '$project_id'..."
+  pnpm exec supabase stop --no-backup >/dev/null 2>&1 || true
+  sleep 2
+  for attempt in 1 2 3; do
+    if pnpm exec supabase start; then
+      wait_for_required_services
+      echo "Supabase started for '$project_id'."
+      return 0
+    fi
+    if [[ "$attempt" != 3 ]]; then
+      echo "Supabase start failed; retrying in 5s..." >&2
+      pnpm exec supabase stop --no-backup >/dev/null 2>&1 || true
+      sleep 5
+    fi
+  done
+
+  echo "Failed to start Supabase stack '$project_id'." >&2
+  return 1
+}
+
+supabase_start_self_test() {
+  local root edge core failures=0
+  root=$(mktemp -d)
+  edge="$root/edge-worker"
+  core="$root/core"
+  mkdir -p "$edge/supabase/migrations" "$edge/scripts" "$core/migrations"
+  printf 'project_id = "edge-selftest"\n' >"$edge/supabase/config.toml"
+  cat >"$edge/scripts/prepare-supabase.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+pkg=$(cd "$(dirname "$0")/.." && pwd)
+cp "$pkg/../core/migrations/current.sql" "$pkg/supabase/migrations/current.sql"
+EOF
+  chmod +x "$edge/scripts/prepare-supabase.sh"
+
+  printf '99\n' >"$root/health-probe-count"
+  node() { printf 'db\nauth\n'; }
+  docker() {
+    local health_probe_count
+    case "$1" in
+      ps) printf 'supabase_db_edge-selftest\nsupabase_auth_edge-selftest\n' ;;
+      inspect)
+        health_probe_count=$(<"$root/health-probe-count")
+        health_probe_count=$((health_probe_count + 1))
+        printf '%s\n' "$health_probe_count" >"$root/health-probe-count"
+        if ((health_probe_count == 1)); then printf 'starting\n'; else printf 'healthy\n'; fi
+        ;;
+    esac
+  }
+  pnpm() {
+    echo "FAIL fast path unexpectedly ran pnpm $*" >&2
+    return 1
+  }
+
+  printf 'A\n' >"$core/migrations/current.sql"
+  run_supabase_start "$edge" >/dev/null
+  if [[ "$(<"$edge/supabase/migrations/current.sql")" == A ]]; then
+    echo "ok   fast path prepares the initial migration mirror"
+  else
+    echo "FAIL fast path did not prepare the initial migration mirror"
+    failures=$((failures + 1))
+  fi
+
+  printf 'B\n' >"$core/migrations/current.sql"
+  run_supabase_start "$edge" >/dev/null
+  if [[ "$(<"$edge/supabase/migrations/current.sql")" == B ]]; then
+    echo "ok   running-stack fast path refreshes A-to-B migration content"
+  else
+    echo "FAIL running-stack fast path retained stale A migration content"
+    failures=$((failures + 1))
+  fi
+
+  printf '0\n' >"$root/health-probe-count"
+  run_supabase_start "$edge" >/dev/null
+  if (( $(<"$root/health-probe-count") >= 3 )); then
+    echo "ok   fast path waits for required service health"
+  else
+    echo "FAIL fast path skipped required service health"
+    failures=$((failures + 1))
+  fi
+
+  rm -rf "$root"
+  if [[ "$failures" -eq 0 ]]; then
+    echo "supabase-start self-test passed."
+    return 0
+  fi
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  if [[ "${1:-}" == "--self-test" ]]; then
+    supabase_start_self_test
+  else
+    run_supabase_start "$@"
+  fi
+fi

--- a/scripts/test-env-fresh.sh
+++ b/scripts/test-env-fresh.sh
@@ -1,90 +1,81 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOCK_FILE=/tmp/pgflow-test-environment.lock
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script_dir="$root/scripts"
+lock_dir=$("$script_dir/lock-dir.sh")
+environment_lock_file="$lock_dir/environment.lock"
+integration_lock_file="$lock_dir/integration-db.lock"
+canonical_root=$(cd "$root" && pwd -P)
 
-has_test_path() {
-  local arg prefix=$1
-  shift
+declare -a stop_project_dirs=()
+declare -a stack_lock_fds=()
 
-  for arg; do
-    case "$arg" in
-      "$prefix"|"$prefix/"|"$prefix/"*) return 0 ;;
-    esac
-  done
-  return 1
-}
-
-is_same_path() {
-  local cwd=$1 actual=$2 expected=$3 actual_path expected_path
-
-  [[ "$actual" == /* ]] || actual="$cwd/$actual"
-  actual_path=$(readlink -f -- "$actual" 2>/dev/null) || return 1
-  expected_path=$(readlink -f -- "$expected" 2>/dev/null) || return 1
-  [[ "$actual_path" == "$expected_path" ]]
-}
-
-is_vitest_entrypoint() {
-  local cwd=$1 package=$2 entrypoint=$3
-
-  is_same_path "$cwd" "$entrypoint" "$ROOT/node_modules/vitest/vitest.mjs" \
-    || is_same_path "$cwd" "$entrypoint" "$ROOT/pkgs/$package/node_modules/vitest/vitest.mjs"
-}
-
-is_owned_test_command() {
-  local cwd=$1 executable=${2##*/}
-  shift 2
-  local -a argv=("$@")
-
-  case "$cwd:$executable" in
-    "$ROOT/pkgs/edge-worker:supabase"|"$ROOT/pkgs/cli:supabase")
-      [[ "${argv[1]:-}" == "functions" && "${argv[2]:-}" == "serve" ]]
-      ;;
-    "$ROOT/pkgs/edge-worker:deno")
-      [[ "${argv[1]:-}" == "test" ]] || return 1
-      has_test_path tests/integration "${argv[@]:2}" \
-        || has_test_path tests/e2e "${argv[@]:2}" \
-        || has_test_path tests/e2e-portable-runtimes "${argv[@]:2}"
-      ;;
-    "$ROOT/pkgs/cli:vitest"|"$ROOT/pkgs/client:vitest")
-      [[ "${argv[1]:-}" == "run" ]] \
-        && has_test_path __tests__/e2e "${argv[@]:2}"
-      ;;
-    "$ROOT/pkgs/cli:node"|"$ROOT/pkgs/cli:nodejs")
-      is_vitest_entrypoint "$cwd" cli "${argv[1]:-}" \
-        && [[ "${argv[2]:-}" == "run" ]] \
-        && has_test_path __tests__/e2e "${argv[@]:3}"
-      ;;
-    "$ROOT/pkgs/client:node"|"$ROOT/pkgs/client:nodejs")
-      is_vitest_entrypoint "$cwd" client "${argv[1]:-}" \
-        && [[ "${argv[2]:-}" == "run" ]] \
-        && has_test_path __tests__/e2e "${argv[@]:3}"
-      ;;
-    "$ROOT/pkgs/edge-worker:node"|"$ROOT/pkgs/edge-worker:nodejs"|"$ROOT/pkgs/edge-worker:bun")
-      ((${#argv[@]} == 2)) \
-        && is_same_path "$cwd" "${argv[1]:-}" "$ROOT/pkgs/edge-worker/tests/e2e-portable-runtimes/portable-process-worker.mjs"
-      ;;
+# Nx-owned lifecycle targets this cleanup may stop. The exact workspace,
+# project, and target come from Nx task environment variables, not argv.
+owned_target() {
+  case "$1" in
+    edge-worker:test:integration|edge-worker:test:integration:file| \
+    edge-worker:e2e|edge-worker:e2e:portable-runtimes|edge-worker:db:ensure| \
+    edge-worker:test:lifecycle|edge-worker:supabase:start| \
+    edge-worker:supabase:ensure-started|edge-worker:supabase:restart| \
+    edge-worker:supabase:reset|edge-worker:supabase:stop| \
+    core:test:pgtap|core:test:pgtap:file|core:verify-migrations| \
+    core:verify-schemas-synced|core:gen-types|core:verify-gen-types| \
+    core:supabase:start|core:supabase:ensure-started|core:supabase:restart| \
+    core:supabase:reset|core:supabase:stop| \
+    client:e2e|client:benchmark|client:supabase:prepare|client:supabase:start| \
+    client:supabase:ensure-started|client:supabase:restart| \
+    client:supabase:reset|client:supabase:stop| \
+    website:dev:full|website:supabase:studio|website:supabase:start| \
+    website:supabase:stop|cli:supabase:stop) return 0 ;;
     *) return 1 ;;
   esac
 }
 
-is_owned_test_process() {
-  local pid=$1 process="/proc/$1" cwd executable
-  local -a argv=()
+is_own_tree_process() {
+  local pid=$1 reference=${PGFLOW_CLEANUP_PID:-$$} parent
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$pid" == "$reference" ]] && return 0
 
-  [[ "$pid" =~ ^[0-9]+$ && "$pid" != "$$" && -r "$process/cmdline" ]] || return 1
-  mapfile -d '' -t argv 2>/dev/null < "$process/cmdline" || return 1
-  ((${#argv[@]} > 0)) || return 1
+  parent=$pid
+  while [[ "$parent" =~ ^[0-9]+$ && "$parent" != 1 ]]; do
+    [[ "$parent" == "$reference" ]] && return 0
+    parent=$(awk '/^PPid:/{print $2}' "/proc/$parent/status" 2>/dev/null) || return 1
+  done
 
-  cwd=$(readlink "$process/cwd" 2>/dev/null) || return 1
-  executable=$(readlink "$process/exe" 2>/dev/null) || return 1
-  is_owned_test_command "$cwd" "$executable" "${argv[@]}"
+  parent=$reference
+  while [[ "$parent" =~ ^[0-9]+$ && "$parent" != 1 ]]; do
+    [[ "$parent" == "$pid" ]] && return 0
+    parent=$(awk '/^PPid:/{print $2}' "/proc/$parent/status" 2>/dev/null) || return 1
+  done
+  return 1
 }
 
-# Keep one pidfd across both signals, but recheck the command before each one.
+is_owned_test_process() {
+  local pid=$1 process="/proc/$1" line uid workspace_root= project= target=
+  local -a environ=()
+
+  [[ "$pid" =~ ^[0-9]+$ && -r "$process/environ" ]] || return 1
+  uid=$(awk '/^Uid:/{print $2; exit}' "$process/status" 2>/dev/null) || return 1
+  [[ "$uid" == "$(id -u)" ]] || return 1
+
+  mapfile -t environ < <(tr '\0' '\n' < "$process/environ" 2>/dev/null) || return 1
+  for line in "${environ[@]}"; do
+    case "$line" in
+      NX_WORKSPACE_ROOT=*) workspace_root=${line#*=} ;;
+      NX_TASK_TARGET_PROJECT=*) project=${line#*=} ;;
+      NX_TASK_TARGET_TARGET=*) target=${line#*=} ;;
+    esac
+  done
+
+  [[ "$workspace_root" == "$canonical_root" && -n "$project" && -n "$target" ]] || return 1
+  owned_target "$project:$target" || return 1
+  ! is_own_tree_process "$pid"
+}
+
 signal_owned_test_process() {
-  /usr/bin/python3 - "$1" "$ROOT/scripts/test-env-fresh.sh" <<'PY'
+  /usr/bin/python3 - "$1" "$root/scripts/test-env-fresh.sh" <<'PY'
 import os
 import select
 import signal
@@ -93,7 +84,6 @@ import sys
 
 pid = int(sys.argv[1])
 script = sys.argv[2]
-
 try:
     pidfd = os.pidfd_open(pid)
 except ProcessLookupError:
@@ -111,7 +101,6 @@ def is_owned():
 
 if not is_owned():
     sys.exit()
-
 try:
     signal.pidfd_send_signal(pidfd, signal.SIGTERM)
 except ProcessLookupError:
@@ -121,7 +110,6 @@ poller = select.poll()
 poller.register(pidfd, select.POLLIN)
 if poller.poll(5000) or not is_owned():
     sys.exit()
-
 try:
     signal.pidfd_send_signal(pidfd, signal.SIGKILL)
 except ProcessLookupError:
@@ -132,7 +120,6 @@ PY
 stop_owned_test_processes() {
   local pid process signaler found=false failed=false
   local -a signalers=()
-
   for process in /proc/[0-9]*; do
     pid=${process##*/}
     is_owned_test_process "$pid" || continue
@@ -141,7 +128,6 @@ stop_owned_test_processes() {
     signalers+=("$!")
     found=true
   done
-
   [[ "$found" == true ]] || return 0
   for signaler in "${signalers[@]}"; do
     wait "$signaler" || failed=true
@@ -149,9 +135,49 @@ stop_owned_test_processes() {
   [[ "$failed" == false ]]
 }
 
+project_id_for() { # project_id_for <project-dir>
+  sed -nE 's/^[[:space:]]*project_id[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+    "$1/supabase/config.toml" | head -1
+}
+
+acquire_stack_locks() {
+  local project project_dir project_id fd
+  local -a projects=()
+  local -A seen_project_ids=()
+
+  mapfile -t projects < <(pnpm nx show projects --withTarget=supabase:stop --json | jq -r '.[]' | LC_ALL=C sort)
+  for project in "${projects[@]}"; do
+    project_dir=$(pnpm nx show project "$project" --json | jq -r '.root')
+    project_dir="$root/$project_dir"
+    project_id=$(project_id_for "$project_dir")
+    [[ "$project_id" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]] || {
+      echo "Could not read a safe project_id for $project." >&2
+      return 1
+    }
+    [[ -z "${seen_project_ids[$project_id]:-}" ]] || continue
+    seen_project_ids[$project_id]=1
+
+    exec {fd}>"$lock_dir/stack-${project_id}.lock"
+    if ! flock -w 30 "$fd"; then
+      echo "The '$project_id' stack lock is still held after 30s." >&2
+      echo "Another worktree may be using it; fresh recovery will not stop it." >&2
+      return 1
+    fi
+    stack_lock_fds+=("$fd")
+    stop_project_dirs+=("$project_dir")
+  done
+}
+
+stop_pgflow_stacks() {
+  local project_dir
+  for project_dir in "${stop_project_dirs[@]}"; do
+    echo "Stopping Supabase stack in $project_dir"
+    (cd "$project_dir" && pnpm exec supabase stop --no-backup)
+  done
+}
+
 remove_legacy_integration_db() {
   local config container removed=false
-
   while read -r container; do
     [[ -n "$container" ]] || continue
     config=$(docker inspect "$container" --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' 2>/dev/null || true)
@@ -166,21 +192,41 @@ remove_legacy_integration_db() {
 
   if [[ "$removed" == true ]] \
     && docker network inspect db_default >/dev/null 2>&1 \
-    && [[ "$(docker network inspect db_default --format '{{len .Containers}}')" == "0" ]]; then
+    && [[ "$(docker network inspect db_default --format '{{len .Containers}}')" == 0 ]]; then
     docker network rm db_default >/dev/null
   fi
 }
 
 main() {
-  exec 9>"$LOCK_FILE"
-  flock 9
+  export PGFLOW_CLEANUP_PID=$$
+
+  # Take environment first. A bounded retry stops only current-worktree Nx
+  # holders; foreign resource locks remain a hard stop before destruction.
+  exec 9>"$environment_lock_file"
+  if ! flock -w 30 9; then
+    stop_owned_test_processes
+    flock -w 30 9 || {
+      echo "Could not acquire the pgflow test-environment lock within 60s." >&2
+      exit 1
+    }
+  fi
 
   stop_owned_test_processes
+  acquire_stack_locks
 
-  pnpm nx run-many --target=supabase:stop --parallel=false --outputStyle=static
+  exec 8>"$integration_lock_file"
+  if ! flock -w 30 8; then
+    echo "The integration database lock is still held after 30s." >&2
+    echo "Another worktree's suite may be using it; fresh recovery will not destroy it." >&2
+    exit 1
+  fi
 
-  docker compose -f "$ROOT/pkgs/edge-worker/tests/db/compose.yaml" down --volumes --remove-orphans
+  # All physical-resource locks are now held before any stop/remove command.
+  stop_pgflow_stacks
+  docker compose -f "$root/pkgs/edge-worker/tests/db/compose.yaml" down --volumes --remove-orphans
   remove_legacy_integration_db
+  # core:test:pgtap holds stack-core.lock, acquired above, around this global
+  # fixture. Do not remove it until that resource is demonstrably free.
   docker rm -f pgflow-upgrade-fixture >/dev/null 2>&1 || true
 
   echo "pgflow test environment is stopped and fresh. Test targets will start what they need."

--- a/scripts/test-env-fresh.sh
+++ b/scripts/test-env-fresh.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK_FILE=/tmp/pgflow-test-environment.lock
+
+has_test_path() {
+  local arg prefix=$1
+  shift
+
+  for arg; do
+    case "$arg" in
+      "$prefix"|"$prefix/"|"$prefix/"*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+is_same_path() {
+  local cwd=$1 actual=$2 expected=$3 actual_path expected_path
+
+  [[ "$actual" == /* ]] || actual="$cwd/$actual"
+  actual_path=$(readlink -f -- "$actual" 2>/dev/null) || return 1
+  expected_path=$(readlink -f -- "$expected" 2>/dev/null) || return 1
+  [[ "$actual_path" == "$expected_path" ]]
+}
+
+is_vitest_entrypoint() {
+  local cwd=$1 package=$2 entrypoint=$3
+
+  is_same_path "$cwd" "$entrypoint" "$ROOT/node_modules/vitest/vitest.mjs" \
+    || is_same_path "$cwd" "$entrypoint" "$ROOT/pkgs/$package/node_modules/vitest/vitest.mjs"
+}
+
+is_owned_test_command() {
+  local cwd=$1 executable=${2##*/}
+  shift 2
+  local -a argv=("$@")
+
+  case "$cwd:$executable" in
+    "$ROOT/pkgs/edge-worker:supabase"|"$ROOT/pkgs/cli:supabase")
+      [[ "${argv[1]:-}" == "functions" && "${argv[2]:-}" == "serve" ]]
+      ;;
+    "$ROOT/pkgs/edge-worker:deno")
+      [[ "${argv[1]:-}" == "test" ]] || return 1
+      has_test_path tests/integration "${argv[@]:2}" \
+        || has_test_path tests/e2e "${argv[@]:2}" \
+        || has_test_path tests/e2e-portable-runtimes "${argv[@]:2}"
+      ;;
+    "$ROOT/pkgs/cli:vitest"|"$ROOT/pkgs/client:vitest")
+      [[ "${argv[1]:-}" == "run" ]] \
+        && has_test_path __tests__/e2e "${argv[@]:2}"
+      ;;
+    "$ROOT/pkgs/cli:node"|"$ROOT/pkgs/cli:nodejs")
+      is_vitest_entrypoint "$cwd" cli "${argv[1]:-}" \
+        && [[ "${argv[2]:-}" == "run" ]] \
+        && has_test_path __tests__/e2e "${argv[@]:3}"
+      ;;
+    "$ROOT/pkgs/client:node"|"$ROOT/pkgs/client:nodejs")
+      is_vitest_entrypoint "$cwd" client "${argv[1]:-}" \
+        && [[ "${argv[2]:-}" == "run" ]] \
+        && has_test_path __tests__/e2e "${argv[@]:3}"
+      ;;
+    "$ROOT/pkgs/edge-worker:node"|"$ROOT/pkgs/edge-worker:nodejs"|"$ROOT/pkgs/edge-worker:bun")
+      ((${#argv[@]} == 2)) \
+        && is_same_path "$cwd" "${argv[1]:-}" "$ROOT/pkgs/edge-worker/tests/e2e-portable-runtimes/portable-process-worker.mjs"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+is_owned_test_process() {
+  local pid=$1 process="/proc/$1" cwd executable
+  local -a argv=()
+
+  [[ "$pid" =~ ^[0-9]+$ && "$pid" != "$$" && -r "$process/cmdline" ]] || return 1
+  mapfile -d '' -t argv 2>/dev/null < "$process/cmdline" || return 1
+  ((${#argv[@]} > 0)) || return 1
+
+  cwd=$(readlink "$process/cwd" 2>/dev/null) || return 1
+  executable=$(readlink "$process/exe" 2>/dev/null) || return 1
+  is_owned_test_command "$cwd" "$executable" "${argv[@]}"
+}
+
+# Keep one pidfd across both signals, but recheck the command before each one.
+signal_owned_test_process() {
+  /usr/bin/python3 - "$1" "$ROOT/scripts/test-env-fresh.sh" <<'PY'
+import os
+import select
+import signal
+import subprocess
+import sys
+
+pid = int(sys.argv[1])
+script = sys.argv[2]
+
+try:
+    pidfd = os.pidfd_open(pid)
+except ProcessLookupError:
+    sys.exit()
+
+
+def is_owned():
+    return subprocess.run(
+        [script, "--is-owned-test-process", str(pid)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+if not is_owned():
+    sys.exit()
+
+try:
+    signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+except ProcessLookupError:
+    sys.exit()
+
+poller = select.poll()
+poller.register(pidfd, select.POLLIN)
+if poller.poll(5000) or not is_owned():
+    sys.exit()
+
+try:
+    signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+except ProcessLookupError:
+    pass
+PY
+}
+
+stop_owned_test_processes() {
+  local pid process signaler found=false failed=false
+  local -a signalers=()
+
+  for process in /proc/[0-9]*; do
+    pid=${process##*/}
+    is_owned_test_process "$pid" || continue
+    echo "Stopping pgflow test process: $pid"
+    signal_owned_test_process "$pid" &
+    signalers+=("$!")
+    found=true
+  done
+
+  [[ "$found" == true ]] || return 0
+  for signaler in "${signalers[@]}"; do
+    wait "$signaler" || failed=true
+  done
+  [[ "$failed" == false ]]
+}
+
+remove_legacy_integration_db() {
+  local config container removed=false
+
+  while read -r container; do
+    [[ -n "$container" ]] || continue
+    config=$(docker inspect "$container" --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' 2>/dev/null || true)
+    case "$config" in
+      */pgflow/worktrees/*/pkgs/edge-worker/tests/db/compose.yaml|*/pgflow/pkgs/edge-worker/tests/db/compose.yaml)
+        echo "Removing legacy pgflow edge-worker integration container $container"
+        docker rm -fv "$container" >/dev/null
+        removed=true
+        ;;
+    esac
+  done < <(docker ps -aq --filter label=com.docker.compose.project=db)
+
+  if [[ "$removed" == true ]] \
+    && docker network inspect db_default >/dev/null 2>&1 \
+    && [[ "$(docker network inspect db_default --format '{{len .Containers}}')" == "0" ]]; then
+    docker network rm db_default >/dev/null
+  fi
+}
+
+main() {
+  exec 9>"$LOCK_FILE"
+  flock 9
+
+  stop_owned_test_processes
+
+  pnpm nx run-many --target=supabase:stop --parallel=false --outputStyle=static
+
+  docker compose -f "$ROOT/pkgs/edge-worker/tests/db/compose.yaml" down --volumes --remove-orphans
+  remove_legacy_integration_db
+  docker rm -f pgflow-upgrade-fixture >/dev/null 2>&1 || true
+
+  echo "pgflow test environment is stopped and fresh. Test targets will start what they need."
+}
+
+if [[ "${1:-}" == "--is-owned-test-process" ]]; then
+  (($# == 2)) || exit 2
+  is_owned_test_process "$2"
+elif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/test-lifecycle.sh
+++ b/scripts/test-lifecycle.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Deterministic lifecycle regression checks. They touch no live database or
+# shared stack: temporary files, lock contention, selector validation, and
+# process ownership only.
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+scripts="$root/scripts"
+tmp=$(mktemp -d)
+repo_visible="$root/pkgs/core/supabase/tests/nx-visible-lifecycle.test.sql"
+repo_ignored="$root/pkgs/edge-worker/tests/integration/.env-nx-ignored-lifecycle.test.ts"
+trap 'rm -rf "$tmp" "$repo_visible" "$repo_ignored"' EXIT
+failures=0
+
+check() { # check <name> <expected-status> <command...>
+  local name=$1 expected=$2 status
+  shift 2
+  if "$@" >/dev/null 2>&1; then status=0; else status=$?; fi
+  if [[ "$status" -eq "$expected" ]]; then
+    echo "ok   $name"
+  else
+    echo "FAIL $name (expected exit $expected, got $status)"
+    failures=$((failures + 1))
+  fi
+}
+
+common_dir=$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)
+from_root=$("$scripts/lock-dir.sh")
+from_pkg=$(cd "$root/pkgs/edge-worker" && "$scripts/lock-dir.sh")
+if [[ "$from_root" == "$common_dir/pgflow-locks" && "$from_root" == "$from_pkg" ]]; then
+  echo "ok   lock-dir resolves to the shared git common dir from any cwd"
+else
+  echo "FAIL lock-dir: root='$from_root' pkg='$from_pkg' expected='$common_dir/pgflow-locks'"
+  failures=$((failures + 1))
+fi
+
+# Two worktree paths with one project_id must contend on one stack lock.
+mkdir -p "$tmp/stack-a/supabase" "$tmp/stack-b/supabase"
+printf 'project_id = "shared-stack"\n' >"$tmp/stack-a/supabase/config.toml"
+printf 'project_id = "shared-stack"\n' >"$tmp/stack-b/supabase/config.toml"
+"$scripts/with-supabase-lock.sh" "$tmp/stack-a" sleep 3 &
+stack_holder=$!
+sleep 0.3
+check "same project_id stack lock spans worktree paths" 124 \
+  timeout 2 "$scripts/with-supabase-lock.sh" "$tmp/stack-b" true
+wait "$stack_holder"
+check "stack lock releases after its consumer exits" 0 \
+  "$scripts/with-supabase-lock.sh" "$tmp/stack-b" true
+
+client_prepare_command=$(jq -r '.targets["supabase:prepare"].options.command // empty' "$root/pkgs/client/project.json")
+if [[ "$client_prepare_command" == "../../scripts/with-supabase-lock.sh ."* ]]; then
+  echo "ok   client migration preparation invokes the stack lock wrapper"
+else
+  echo "FAIL client migration preparation does not invoke the stack lock wrapper"
+  failures=$((failures + 1))
+fi
+"$scripts/with-supabase-lock.sh" "$root/pkgs/client" sleep 3 &
+client_prepare_holder=$!
+sleep 0.3
+check "client preparation stack lock blocks a concurrent mutator" 124 \
+  timeout 2 "$scripts/with-supabase-lock.sh" "$root/pkgs/client" true
+wait "$client_prepare_holder"
+check "client preparation stack lock releases after its consumer exits" 0 \
+  "$scripts/with-supabase-lock.sh" "$root/pkgs/client" true
+
+integration_lock="$from_root/integration-db.lock"
+flock "$integration_lock" -c 'sleep 3' &
+integration_holder=$!
+sleep 0.3
+check "integration resource lock blocks a second holder" 124 \
+  timeout 2 "$scripts/with-integration-lock.sh" true
+wait "$integration_holder"
+check "integration lock releases after its consumer exits" 0 \
+  "$scripts/with-integration-lock.sh" true
+
+mkdir -p "$tmp/sub"
+echo test >"$tmp/sub/real.test.ts"
+ln -s /etc/hostname "$tmp/sub/escape.test.ts"
+check "valid file accepted" 0 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub sub/real.test.ts"
+check "./-prefixed valid file accepted" 0 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub ./sub/real.test.ts"
+check "empty selector rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub ''"
+check "missing file rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub sub/absent.test.ts"
+check "absolute path rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub '$tmp/sub/real.test.ts'"
+check "quote selector rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub 'sub/real.test.ts;touch-x'"
+check "external file rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub ../etc/hostname"
+check "traversal outside subtree rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub sub/../../etc/hostname"
+check "symlink escape rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub sub/escape.test.ts"
+check "directory rejected" 1 sh -c "cd '$tmp' && '$scripts/require-test-file.sh' sub sub"
+
+# Nx hashes nonignored files before Git tracks them. It can also reinclude an
+# otherwise Git-ignored path through .nxignore, so this check uses Nx's own
+# file map instead of Git's tracked/ignored status.
+printf '%s\n' '-- lifecycle visibility probe' >"$repo_visible"
+printf '%s\n' 'Deno.test("ignored", () => {});' >"$repo_ignored"
+check "new nonignored in-tree test is visible to Nx" 0 \
+  sh -c "cd '$root/pkgs/core' && '$scripts/require-test-file.sh' supabase/tests supabase/tests/nx-visible-lifecycle.test.sql"
+check "Nx re-included edge .env is visible" 0 \
+  node "$scripts/nx-file-visible.cjs" "$root" pkgs/edge-worker/supabase/functions/.env
+check "actual Nx-ignored test is rejected" 1 \
+  sh -c "cd '$root/pkgs/edge-worker' && '$scripts/require-test-file.sh' tests/integration tests/integration/.env-nx-ignored-lifecycle.test.ts"
+
+start_test_proc() { # start_test_proc <pidfile> <env assignments...>
+  local pidfile=$1
+  shift
+  env -i "PATH=$PATH" "$@" \
+    bash -c "echo \$BASHPID >'$pidfile'; exec 1>&- 2>&-; exec sleep 5" &
+  test_proc_bg=$!
+}
+
+stop_test_proc() {
+  kill "$(cat "$1")" 2>/dev/null || true
+  wait "$test_proc_bg" 2>/dev/null || true
+}
+
+start_focused_cancellation_proc() { # start_focused_cancellation_proc <pidfile>
+  local pidfile=$1
+  env -i "PATH=$PATH" "NX_WORKSPACE_ROOT=$root" \
+    NX_TASK_TARGET_PROJECT=edge-worker \
+    NX_TASK_TARGET_TARGET=test:integration:file \
+    bash -c 'trap "exit 0" TERM; sleep 30 & child=$!; printf "%s %s\n" "$BASHPID" "$child" >"$1"; wait "$child"' \
+    _ "$pidfile" &
+  focused_cancellation_bg=$!
+}
+
+start_test_proc "$tmp/owned.pid" \
+  "NX_WORKSPACE_ROOT=$root" \
+  NX_TASK_TARGET_PROJECT=edge-worker \
+  NX_TASK_TARGET_TARGET=test:integration
+sleep 0.3
+pid=$(cat "$tmp/owned.pid")
+check "owned target process matches" 0 "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+check "own-tree exclusion matches cleanup pid" 1 env "PGFLOW_CLEANUP_PID=$pid" \
+  "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+stop_test_proc "$tmp/owned.pid"
+
+start_focused_cancellation_proc "$tmp/focused-cancellation.pid"
+for _ in $(seq 1 50); do
+  [[ -f "$tmp/focused-cancellation.pid" ]] && break
+  sleep 0.1
+done
+if [[ -f "$tmp/focused-cancellation.pid" ]]; then
+  read -r focused_pid focused_child <"$tmp/focused-cancellation.pid"
+  check "focused Nx task process matches recovery ownership" 0 \
+    "$scripts/test-env-fresh.sh" --is-owned-test-process "$focused_pid"
+  check "focused Nx cancellation stops the owned process tree" 0 \
+    bash -ceu 'source "$1"; stop_owned_test_processes' _ "$scripts/test-env-fresh.sh"
+  wait "$focused_cancellation_bg" 2>/dev/null || true
+  if ! kill -0 "$focused_pid" 2>/dev/null && ! kill -0 "$focused_child" 2>/dev/null; then
+    echo "ok   focused Nx cancellation leaves no owned child"
+  else
+    echo "FAIL focused Nx cancellation left an owned child"
+    failures=$((failures + 1))
+  fi
+else
+  echo "FAIL focused Nx cancellation test did not start"
+  failures=$((failures + 1))
+  kill "$focused_cancellation_bg" 2>/dev/null || true
+  wait "$focused_cancellation_bg" 2>/dev/null || true
+fi
+
+start_test_proc "$tmp/client-prepare.pid" \
+  "NX_WORKSPACE_ROOT=$root" \
+  NX_TASK_TARGET_PROJECT=client \
+  NX_TASK_TARGET_TARGET=supabase:prepare
+sleep 0.3
+pid=$(cat "$tmp/client-prepare.pid")
+check "client migration preparation lifecycle consumer matches" 0 \
+  "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+stop_test_proc "$tmp/client-prepare.pid"
+
+start_test_proc "$tmp/benchmark.pid" \
+  "NX_WORKSPACE_ROOT=$root" \
+  NX_TASK_TARGET_PROJECT=client \
+  NX_TASK_TARGET_TARGET=benchmark
+sleep 0.3
+pid=$(cat "$tmp/benchmark.pid")
+check "client benchmark lifecycle consumer matches" 0 \
+  "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+stop_test_proc "$tmp/benchmark.pid"
+
+start_test_proc "$tmp/noenv.pid"
+sleep 0.3
+pid=$(cat "$tmp/noenv.pid")
+check "process without Nx task environment does not match" 1 \
+  "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+stop_test_proc "$tmp/noenv.pid"
+
+start_test_proc "$tmp/nontarget.pid" \
+  "NX_WORKSPACE_ROOT=$root" \
+  NX_TASK_TARGET_PROJECT=edge-worker \
+  NX_TASK_TARGET_TARGET=build
+sleep 0.3
+pid=$(cat "$tmp/nontarget.pid")
+check "non-lifecycle target does not match" 1 \
+  "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+stop_test_proc "$tmp/nontarget.pid"
+
+start_test_proc "$tmp/foreign.pid" \
+  "NX_WORKSPACE_ROOT=$tmp" \
+  NX_TASK_TARGET_PROJECT=edge-worker \
+  NX_TASK_TARGET_TARGET=test:integration
+sleep 0.3
+pid=$(cat "$tmp/foreign.pid")
+check "foreign workspace root does not match" 1 \
+  "$scripts/test-env-fresh.sh" --is-owned-test-process "$pid"
+stop_test_proc "$tmp/foreign.pid"
+
+"$scripts/supabase-start.sh" --self-test || failures=$((failures + 1))
+"$scripts/functions-server.sh" --self-test || failures=$((failures + 1))
+"$scripts/ensure-migrations.sh" --self-test || failures=$((failures + 1))
+"$root/pkgs/edge-worker/scripts/ensure-db-core" --self-test || failures=$((failures + 1))
+
+if [[ "$failures" -eq 0 ]]; then
+  echo "All lifecycle regression checks passed."
+else
+  echo "$failures lifecycle regression check(s) failed." >&2
+  exit 1
+fi

--- a/scripts/wait-for-function.sh
+++ b/scripts/wait-for-function.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL=${1:?"Usage: $0 <function-url> <expected-status> <expected-body>"}
+EXPECTED_STATUS=${2:?"Usage: $0 <function-url> <expected-status> <expected-body>"}
+EXPECTED_BODY=${3:?"Usage: $0 <function-url> <expected-status> <expected-body>"}
+DEADLINE=$((SECONDS + 120))
+BODY=$(mktemp)
+trap 'rm -f "$BODY"' EXIT
+
+echo "Waiting for the expected function response at $URL..."
+while ((SECONDS < DEADLINE)); do
+  timeout=$((DEADLINE - SECONDS))
+  if ((timeout > 15)); then timeout=15; fi
+  status=$(curl --silent --show-error --max-time "$timeout" --output "$BODY" --write-out '%{http_code}' "$URL" 2>/dev/null || true)
+  if [[ "$status" == "$EXPECTED_STATUS" ]] && grep -Fq -- "$EXPECTED_BODY" "$BODY"; then
+    echo "Function server is ready (HTTP $status with the expected response)."
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "TIMEOUT: Function server did not return HTTP $EXPECTED_STATUS with the expected response at $URL after 120s" >&2
+echo "Last response: HTTP ${status:-none}" >&2
+cat "$BODY" >&2
+exit 1

--- a/scripts/with-integration-lock.sh
+++ b/scripts/with-integration-lock.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Runs a command while holding the exclusive pgflow integration resource
+# lock, spanning migration preparation, live database setup, and the whole
+# integration suite (the caller's command). Locks are released only when the
+# command (and its children, which inherit the lock file descriptors) exit.
+#
+# Lock order, shared with scripts/test-env-fresh.sh and
+# scripts/supabase-start-locked.sh - keep it stable:
+#   1. environment lock, shared (excludes test-env:fresh teardown)
+#   2. integration resource lock, exclusive
+# test-env:fresh takes the environment lock exclusively FIRST and then tries
+# the resource lock with a bounded wait, so neither side can wait forever.
+set -euo pipefail
+
+[[ $# -gt 0 ]] || { echo "Usage: $0 <command> [args...]" >&2; exit 2; }
+
+LOCK_DIR=$(cd "$(dirname "$0")" && ./lock-dir.sh)
+
+exec 9>"$LOCK_DIR/environment.lock"
+flock --shared 9
+exec 8>"$LOCK_DIR/integration-db.lock"
+flock 8
+
+exec "$@"

--- a/scripts/with-supabase-lock.sh
+++ b/scripts/with-supabase-lock.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Runs a command while holding the pgflow lock for one physical Supabase stack.
+# Lock order is fixed: shared environment first, then the project_id resource.
+set -euo pipefail
+
+[[ $# -ge 2 ]] || {
+  echo "Usage: $0 <project-dir> <command> [args...]" >&2
+  exit 2
+}
+
+project_dir=$1
+shift
+[[ -d "$project_dir" ]] || {
+  echo "Project directory not found: $project_dir" >&2
+  exit 1
+}
+project_dir=$(realpath "$project_dir")
+config="$project_dir/supabase/config.toml"
+[[ -f "$config" ]] || {
+  echo "Supabase config not found: $config" >&2
+  exit 1
+}
+project_id=$(sed -nE 's/^[[:space:]]*project_id[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$config" | head -1)
+[[ "$project_id" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]] || {
+  echo "Could not read a safe project_id from $config." >&2
+  exit 1
+}
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+lock_dir=$("$script_dir/lock-dir.sh")
+
+exec 9>"$lock_dir/environment.lock"
+flock --shared 9
+exec 8>"$lock_dir/stack-${project_id}.lock"
+flock 8
+
+cd "$project_dir"
+exec "$@"

--- a/tools/nx-executors/executors.json
+++ b/tools/nx-executors/executors.json
@@ -1,0 +1,8 @@
+{
+  "executors": {
+    "focused-file": {
+      "implementation": "./focused-file.cjs",
+      "schema": "./schema.json"
+    }
+  }
+}

--- a/tools/nx-executors/focused-file.cjs
+++ b/tools/nx-executors/focused-file.cjs
@@ -1,0 +1,57 @@
+const { spawnSync } = require('node:child_process');
+const { join } = require('node:path');
+
+function selectedFile(args) {
+  const prefix = '--file=';
+  if (typeof args !== 'string' || !args.startsWith(prefix)) {
+    throw new Error('Use --args=--file=<relative-test-file>.');
+  }
+
+  const file = args.slice(prefix.length);
+  if (!file || /[\0\r\n]/.test(file)) {
+    throw new Error('Use --args=--file=<relative-test-file>.');
+  }
+  return file;
+}
+
+module.exports = async function focusedFile(options, context) {
+  let file;
+  try {
+    file = selectedFile(options.args);
+  } catch (error) {
+    console.error(error.message);
+    return { success: false };
+  }
+
+  const root = context.root;
+  const scripts = join(root, 'scripts');
+  const pgtap = context.projectName === 'core'
+    && context.targetName === 'test:pgtap:file';
+  const integration = context.projectName === 'edge-worker'
+    && context.targetName === 'test:integration:file';
+  if (!pgtap && !integration) {
+    console.error('focused-file only supports the configured focused test targets.');
+    return { success: false };
+  }
+
+  const project = pgtap ? 'pkgs/core' : 'pkgs/edge-worker';
+  const runner = pgtap
+    ? join(root, 'pkgs/core/scripts/run-pgtap-file')
+    : join(root, 'pkgs/edge-worker/scripts/run-integration.sh');
+  const command = pgtap
+    ? join(scripts, 'with-supabase-lock.sh')
+    : join(scripts, 'with-integration-lock.sh');
+  const commandArgs = pgtap
+    ? [join(root, project), runner, file]
+    : [runner, file];
+  const result = spawnSync(command, commandArgs, {
+    cwd: join(root, project),
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+  }
+  return { success: result.status === 0 && !result.error };
+};

--- a/tools/nx-executors/package.json
+++ b/tools/nx-executors/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@pgflow/nx-executors",
+  "private": true,
+  "version": "0.0.0",
+  "type": "commonjs",
+  "main": "./focused-file.cjs",
+  "executors": "./executors.json"
+}

--- a/tools/nx-executors/project.json
+++ b/tools/nx-executors/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "nx-executors",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "tools/nx-executors",
+  "projectType": "library",
+  "targets": {}
+}

--- a/tools/nx-executors/schema.json
+++ b/tools/nx-executors/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Focused test file",
+  "type": "object",
+  "properties": {
+    "args": {
+      "type": "string"
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- make Nx own fresh test-environment setup, focused slow tests, and interruption recovery
- serialize each shared Supabase stack and integration database across worktrees
- validate focused selectors before test execution through a direct-argv Nx executor
- fingerprint live database and stack state, including post-reset service readiness
- own E2E server processes and exact runtime containers through readiness, tests, and cleanup

## Why

Direct test-runner commands bypassed Nx setup and caching, while interrupted runs could leave stale processes or shared infrastructure. The prior lifecycle also allowed stale migrations, shell-expanded selectors, false readiness, and cross-worktree resource races.

The updated lifecycle keeps setup, recovery, cache validity, and live-resource ownership inside Nx. Full E2E suites remain intact because their workers and database state are shared.

## Local checks

Passed on commit `3d5d5f01`:

- affected lint, build, unit, type, and export checks
- Core pgTAP and lifecycle regression suite
- edge-worker E2E and portable-runtime E2E: 12 tests each
- client E2E: 12 files, 47 tests
- CLI E2E install checks and the full pre-push hook

Local edge-worker integration did not complete successfully. The full target timed out, and its focused reproduction failed one unchanged `performanceMapFlow.test.ts` 15-second completion bound while two tests passed. The change does not touch worker, schema, migration, integration-helper, or performance-test behavior. CI's isolated integration job will add evidence about whether this is local load or a reproducible regression.

Closes #673
